### PR TITLE
feat: Add CI templates for fluent-operator

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,76 @@
+name: Bug Report
+description: Create a report with a procedure for reproducing the bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check [CONTRIBUTING guideline](https://github.com/fluent/fluent-operator/blob/master/CONTRIBUTING.md) first and here is the list to help us investigate the problem.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Your Environment
+      description: |
+        - Fluent Operator version: 
+        - Container Runtime: 
+        - Operating system: `cat /etc/os-release`
+        - Kernel version: `uname -r`
+
+        Tip: If you hit the problem with older fluent operator version, try latest version first.
+      value: |
+        - Fluent Operator version:
+        - Container Runtime:
+        - Operating system:
+        - Kernel version:
+      render: markdown
+    validations:
+      required: true
+  - type: input
+    id: how-to-install
+    attributes:
+      label: How did you install fluent operator?
+      description: In some cases, this is very important.
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Your Error Log
+      description: Write your ALL error log here
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: addtional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/fluent/fluent-operator/discussions
+    about: I have questions about Fluent Operator. Please ask and answer questions at https://github.com/fluent/fluent-operator/discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest an idea for this project
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check [CONTRIBUTING guideline](https://github.com/fluent/fluent-operator/blob/master/CONTRIBUTING.md) first and here is the list to help us investigate the problem.
+  - type: textarea
+    id: description
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: |
+        A clear and concise description of what the problem is.
+        Ex. I'm always frustrated when [...]
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: addtional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Thank you for contributing to Fluent Operator!
+Your commits need to follow DCO: https://probot.github.io/apps/dco/
+And please provide the following information to help us make the most of your pull request:
+-->
+
+### What this PR does / why we need it:
+
+### Which issue(s) this PR fixes:
+<!--
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes #
+
+### Does this PR introduced a user-facing change?
+<!--
+If no, just write "None" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+
+For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
+-->
+```release-note
+
+```
+
+### Additional documentation, usage docs, etc.:
+<!--
+This section can be blank if this pull request does not require a release note.
+Please use the following format for linking documentation or pass the
+section below:
+- [KEP]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+```docs
+
+```

--- a/.github/workflows/issue-auto-closer.yaml
+++ b/.github/workflows/issue-auto-closer.yaml
@@ -1,0 +1,12 @@
+name: Autocloser
+on: [issues]
+jobs:
+  autoclose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Autoclose issues that did not follow issue template
+        uses: roots/issue-closer-action@v1.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-close-message: "@${issue.user.login} this issue was automatically closed because it did not follow the issue template"
+          issue-pattern: "(.*Describe the bug.*)|(.*Is your feature request related to an issue.*)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Fluent Operator
+
+Firstly, thanks for your interest in contributing! I hope that this will be a pleasant first experience for you, and that you will return to continue contributing.
+
+### How to contribute?
+
+Most of the contributions that we receive are code contributions, but you can also contribute to the documentation or simply report solid bugs for us to fix.
+
+For new contributors, please take a look at issues with a tag called [Good first issue](https://github.com/fluent/fluent-operator/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [Help wanted](https://github.com/fluent/fluent-operator/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+
+## Found a bug?
+
+Ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/fluent/fluent-operator/issues).
+
+If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/fluent/fluent-operator/issues/new). Be sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
+
+Note: Before report the issue, check latest version first. Sometimes users report fixed bug with older version.
+
+### How to add a new feature or change an existing one
+
+Before making any significant changes, please [open an issue](https://github.com/fluent/fluent-operator/issues). Discussing your proposed changes ahead of time will make the contribution process smooth for everyone.
+
+Once we've discussed your changes and you've got your code ready, make sure that tests are passing and open your pull request. Your PR is most likely to be accepted if it:
+
+- Update the README.md with details of changes to the interface.
+- Includes tests for new functionality.
+- References the original issue in the description, e.g. "Fixes #123".
+- Has a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Fluent Operator repositories needs [DCO](https://github.com/apps/dco) on PR. Please add `Signed-off-by` to the commit(See DCO link for more detail).


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Add CI templates for fluentbit-operator.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #207

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Other doc]: https://github.com/fluent/fluent-operator/pull/242
```
