### PR TITLE
fix fluentbit operator not support Time_Key_Nanos field bug

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/elasticsearch_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/elasticsearch_types.go
@@ -70,6 +70,8 @@ type Elasticsearch struct {
 	TimeKey string `json:"timeKey,omitempty"`
 	// When Logstash_Format is enabled, this property defines the format of the timestamp.
 	TimeKeyFormat string `json:"timeKeyFormat,omitempty"`
+	// When Logstash_Format is enabled, enabling this property sends nanosecond precision timestamps.
+	TimeKeyNanos *bool `json:"timeKeyNanos,omitempty"`
 	// When enabled, it append the Tag name to the record.
 	IncludeTagKey *bool `json:"includeTagKey,omitempty"`
 	// When Include_Tag_Key is enabled, this property defines the key name for the tag.
@@ -172,6 +174,9 @@ func (es *Elasticsearch) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if es.TimeKeyFormat != "" {
 		kvs.Insert("Time_Key_Format", es.TimeKeyFormat)
+	}
+	if es.TimeKeyNanos != nil {
+		kvs.Insert("Time_Key_Nanos", fmt.Sprint(*es.TimeKeyNanos))
 	}
 	if es.IncludeTagKey != nil {
 		kvs.Insert("Include_Tag_Key", fmt.Sprint(*es.IncludeTagKey))

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -268,6 +268,10 @@ spec:
                     description: When Logstash_Format is enabled, this property defines
                       the format of the timestamp.
                     type: string
+                  timeKeyNanos:
+                    description: When Logstash_Format is enabled, enabling this property
+                      sends nanosecond precision timestamps.
+                    type: boolean
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -268,6 +268,10 @@ spec:
                     description: When Logstash_Format is enabled, this property defines
                       the format of the timestamp.
                     type: string
+                  timeKeyNanos:
+                    description: When Logstash_Format is enabled, enabling this property
+                      sends nanosecond precision timestamps.
+                    type: boolean
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -1958,6 +1958,10 @@ spec:
                     description: When Logstash_Format is enabled, this property defines
                       the format of the timestamp.
                     type: string
+                  timeKeyNanos:
+                    description: When Logstash_Format is enabled, enabling this property
+                      sends nanosecond precision timestamps.
+                    type: boolean
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -1958,6 +1958,10 @@ spec:
                     description: When Logstash_Format is enabled, this property defines
                       the format of the timestamp.
                     type: string
+                  timeKeyNanos:
+                    description: When Logstash_Format is enabled, enabling this property
+                      sends nanosecond precision timestamps.
+                    type: boolean
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```