### PR TITLE
feature: support `logstashPrefix` to ClusterOutput

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
@@ -12,7 +12,9 @@ spec:
   es:
     host: {{ .Values.fluentbit.output.es.host }}
     port: {{ .Values.fluentbit.output.es.port }}
+{{- if .Values.fluentbit.output.es.path }}
     path: {{ .Values.fluentbit.output.es.path }}
+{{- end }}
     bufferSize: {{ .Values.fluentbit.output.es.bufferSize }}
     index: {{ .Values.fluentbit.output.es.index }}
 {{- if .Values.fluentbit.output.es.httpUser }}

--- a/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
@@ -12,9 +12,25 @@ spec:
   es:
     host: {{ .Values.fluentbit.output.es.host }}
     port: {{ .Values.fluentbit.output.es.port }}
+    path: {{ .Values.fluentbit.output.es.path }}
+    bufferSize: {{ .Values.fluentbit.output.es.bufferSize }}
+    index: {{ .Values.fluentbit.output.es.index }}
+{{- if .Values.fluentbit.output.es.httpUser }}
+    httpUser:
+{{ toYaml .Values.fluentbit.output.es.httpUser | indent 6 }}
+{{- end }}
+{{- if .Values.fluentbit.output.es.httpPassword }}
+    httpPassword:
+{{ toYaml .Values.fluentbit.output.es.httpPassword | indent 6 }}
+{{- end }}
+    logstashFormat: {{ .Values.fluentbit.output.es.logstashFormat }}
+    logstashPrefix: {{ .Values.fluentbit.output.es.logstashPrefix }}
+    replaceDots: {{ .Values.fluentbit.output.es.replaceDots }}
     generateID: true
-    logstashPrefix: ks-logstash-log
-    logstashFormat: true
     timeKey: "@timestamp"
+{{- if .Values.fluentbit.output.es.enableTLS }}
+    tls:
+{{ toYaml .Values.fluentbit.output.es.tls | indent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
@@ -15,8 +15,12 @@ spec:
 {{- if .Values.fluentbit.output.es.path }}
     path: {{ .Values.fluentbit.output.es.path }}
 {{- end }}
+{{- if .Values.fluentbit.output.es.bufferSize }}
     bufferSize: {{ .Values.fluentbit.output.es.bufferSize }}
+{{- end }}
+{{- if .Values.fluentbit.output.es.index }}
     index: {{ .Values.fluentbit.output.es.index }}
+{{- end }}
 {{- if .Values.fluentbit.output.es.httpUser }}
     httpUser:
 {{ toYaml .Values.fluentbit.output.es.httpUser | indent 6 }}
@@ -25,9 +29,9 @@ spec:
     httpPassword:
 {{ toYaml .Values.fluentbit.output.es.httpPassword | indent 6 }}
 {{- end }}
-    logstashFormat: {{ .Values.fluentbit.output.es.logstashFormat }}
-    logstashPrefix: {{ .Values.fluentbit.output.es.logstashPrefix }}
-    replaceDots: {{ .Values.fluentbit.output.es.replaceDots }}
+    logstashFormat: {{ .Values.fluentbit.output.es.logstashFormat | default true }}
+    logstashPrefix: {{ .Values.fluentbit.output.es.logstashPrefix | default "ks-logstash-log" | quote }}
+    replaceDots: {{ .Values.fluentbit.output.es.replaceDots | default false }}
     generateID: true
     timeKey: "@timestamp"
 {{- if .Values.fluentbit.output.es.enableTLS }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -4,7 +4,7 @@
 
 #Set this to containerd or crio if you want to collect CRI format logs
 containerRuntime: docker
-Kubernetes: false
+Kubernetes: true
 
 operator:
   initcontainer:
@@ -60,27 +60,27 @@ fluentbit:
   #You can set enable to true to output logs to the specified location.
   output:
     es:
-      enable: false
+      enable: true
       host: "<Elasticsearch url like elasticsearch-logging-data.kubesphere-logging-system.svc>"
       port: 9200
-      path: ""
-      bufferSize: "4KB"
-      index: "fluent-bit"
-      httpUser:
-      httpPassword:
-      logstashFormat: true
-      logstashPrefix: ks-logstash-log
-      replaceDots: false
-      enableTLS: false
-      tls:
-        verify: On
-        debug: 1
-        caFile: "<Absolute path to CA certificate file>"
-        caPath: "<Absolute path to scan for certificate files>"
-        crtFile: "<Absolute path to private Key file>"
-        keyFile: "<Absolute path to private Key file>"
-        keyPassword:
-        vhost: "<Hostname to be used for TLS SNI extension>"
+#      path: ""
+#      bufferSize: "4KB"
+#      index: "fluent-bit"
+#      httpUser:
+#      httpPassword:
+#      logstashFormat: true
+#      logstashPrefix: ks-logstash-log
+#      replaceDots: false
+#      enableTLS: false
+#      tls:
+#        verify: On
+#        debug: 1
+#        caFile: "<Absolute path to CA certificate file>"
+#        caPath: "<Absolute path to scan for certificate files>"
+#        crtFile: "<Absolute path to private Key file>"
+#        keyFile: "<Absolute path to private Key file>"
+#        keyPassword:
+#        vhost: "<Hostname to be used for TLS SNI extension>"
     kafka:
       enable: false
       brokers: "<kafka broker list like xxx.xxx.xxx.xxx:9092,yyy.yyy.yyy.yyy:9092>"

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -63,13 +63,13 @@ fluentbit:
       enable: false
       host: "<Elasticsearch url like elasticsearch-logging-data.kubesphere-logging-system.svc>"
       port: 9200
+      logstashPrefix: ks-logstash-log
 #      path: ""
 #      bufferSize: "4KB"
 #      index: "fluent-bit"
 #      httpUser:
 #      httpPassword:
 #      logstashFormat: true
-#      logstashPrefix: ks-logstash-log
 #      replaceDots: false
 #      enableTLS: false
 #      tls:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -68,10 +68,10 @@ fluentbit:
       index: "fluent-bit"
       httpUser:
       httpPassword:
-      logstashFormat: false
+      logstashFormat: true
       logstashPrefix: ks-logstash-log
       replaceDots: false
-      enableTLS: true
+      enableTLS: false
       tls:
         verify: On
         debug: 1

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -4,7 +4,7 @@
 
 #Set this to containerd or crio if you want to collect CRI format logs
 containerRuntime: docker
-Kubernetes: true
+Kubernetes: false
 
 operator:
   initcontainer:
@@ -60,7 +60,7 @@ fluentbit:
   #You can set enable to true to output logs to the specified location.
   output:
     es:
-      enable: true
+      enable: false
       host: "<Elasticsearch url like elasticsearch-logging-data.kubesphere-logging-system.svc>"
       port: 9200
 #      path: ""

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -63,7 +63,24 @@ fluentbit:
       enable: false
       host: "<Elasticsearch url like elasticsearch-logging-data.kubesphere-logging-system.svc>"
       port: 9200
+      path: ""
+      bufferSize: "4KB"
+      index: "fluent-bit"
+      httpUser:
+      httpPassword:
+      logstashFormat: false
       logstashPrefix: ks-logstash-log
+      replaceDots: false
+      enableTLS: true
+      tls:
+        verify: On
+        debug: 1
+        caFile: "<Absolute path to CA certificate file>"
+        caPath: "<Absolute path to scan for certificate files>"
+        crtFile: "<Absolute path to private Key file>"
+        keyFile: "<Absolute path to private Key file>"
+        keyPassword:
+        vhost: "<Hostname to be used for TLS SNI extension>"
     kafka:
       enable: false
       brokers: "<kafka broker list like xxx.xxx.xxx.xxx:9092,yyy.yyy.yyy.yyy:9092>"


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Support `logstashPrefix`, `httpUser` and so on to ClusterOutput.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #265

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added logstashPrefix, httpUser, tls to ClusterOutput.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```