### PR TITLE
fix: Helm Chart for Fluentd resources settings (#271)

### DIFF
--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -14,7 +14,7 @@ spec:
   replicas: {{ .Values.fluentd.replicas }}
   image: {{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}
   resources:
-  {{- toYaml .Values.fluentbit.resources | nindent 4  }}
+  {{- toYaml .Values.fluentd.resources | nindent 4  }}
   fluentdCfgSelector:
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"


### PR DESCRIPTION
Signed-off-by: hostalp [hostalp@post.cz](mailto:hostalp@post.cz)

### What this PR does / why we need it:
Fixes the Helm chart for Fluentd resources settings, where Fluentbit resource settings were incorrectly used instead.

### Which issue(s) this PR fixes:
Fixes #271

### Does this PR introduced a user-facing change?
None

### Additional documentation, usage docs, etc.: