### PR TITLE
fix: the issue of request help closed by mistake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -16,7 +16,7 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Describe the bug
+      label: Describe the issue
       description: A clear and concise description of what the bug is
     validations:
       required: true
@@ -53,7 +53,7 @@ body:
       render: markdown
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: how-to-install
     attributes:
       label: How did you install fluent operator?

--- a/.github/ISSUE_TEMPLATE/request_help.yaml
+++ b/.github/ISSUE_TEMPLATE/request_help.yaml
@@ -15,12 +15,12 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: Describe the issue
       description: Describe the issue you are facing and what you need help with.
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: how-to-install
     attributes:
       label: How did you install fluent operator?

--- a/.github/workflows/issue-auto-closer.yaml
+++ b/.github/workflows/issue-auto-closer.yaml
@@ -9,4 +9,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-close-message: "@${issue.user.login} this issue was automatically closed because it did not follow the issue template"
-          issue-pattern: "(.*Describe the bug.*)|(.*Is your feature request related to a problem.*)"
+          issue-pattern: "(.*Describe the issue.*)|(.*Is your feature request related to a problem.*)"


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Fix the bug of feature help issue will be closed by mistake.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```