### PR TITLE
non-kubernetes format

### DIFF
--- a/controllers/fluentdconfig_controller.go
+++ b/controllers/fluentdconfig_controller.go
@@ -227,22 +227,6 @@ func (r *FluentdConfigReconciler) ClusterCfgsForFluentd(
 	globalCfgLabels map[string]bool) error {
 
 	for _, cfg := range clustercfgs.Items {
-		// If the field watchedNamespaces is empty, all namesapces will be watched.
-		watchedNamespaces := cfg.GetWatchedNamespaces()
-
-		if len(watchedNamespaces) == 0 {
-			var namespaceList corev1.NamespaceList
-			if err := r.List(ctx, &namespaceList); err != nil {
-				return err
-			}
-
-			for _, item := range namespaceList.Items {
-				watchedNamespaces = append(watchedNamespaces, item.Name)
-			}
-
-			// Don't patch the CR, or it would requeue.
-			cfg.Spec.WatchedNamespaces = watchedNamespaces
-		}
 
 		// Build the inner router for this cfg.
 		// Each cfg is a workflow.


### PR DESCRIPTION
Signed-off-by: chengdehao <dehaocheng@kubesphere.io>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/fluent/fluent-operator/issues/305

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

![ED9B8)SUHVR 0`@1%HKQF_Y](https://user-images.githubusercontent.com/39892300/191684969-973661a8-8f04-40b8-a4a2-b14171b3b778.png)

![SC KP0IZ DW{}YU_0Q4V 0J](https://user-images.githubusercontent.com/39892300/191687472-8d3f2b58-6453-45a3-aee2-6b88a826f855.png)



