### PR TITLE
fixing a typo 'Spklunk' to 'Splunk'

### DIFF
--- a/apis/fluentbit/v1alpha2/clusteroutput_types.go
+++ b/apis/fluentbit/v1alpha2/clusteroutput_types.go
@@ -69,7 +69,7 @@ type OutputSpec struct {
 	DataDog *output.DataDog `json:"datadog,omitempty"`
 	// Firehose defines Firehose Output configuration.
 	Fireose *output.Firehose `json:"firehose,omitempty"`
-	//Spklunk defines Splunk Output Configuration
+	//Splunk defines Splunk Output Configuration
 	Splunk *output.Splunk `json:"splunk,omitempty"`
 	// OpenSearch defines OpenSearch Output configuration.
 	OpenSearch *output.OpenSearch `json:"opensearch,omitempty"`

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1663,7 +1663,7 @@ spec:
                   discard the data after reaching that limit.
                 type: string
               splunk:
-                description: Spklunk defines Splunk Output Configuration
+                description: Splunk defines Splunk Output Configuration
                 properties:
                   Workers:
                     description: Enables dedicated thread(s) for this output. Default

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1663,7 +1663,7 @@ spec:
                   discard the data after reaching that limit.
                 type: string
               splunk:
-                description: Spklunk defines Splunk Output Configuration
+                description: Splunk defines Splunk Output Configuration
                 properties:
                   Workers:
                     description: Enables dedicated thread(s) for this output. Default

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -3457,7 +3457,7 @@ spec:
                   discard the data after reaching that limit.
                 type: string
               splunk:
-                description: Spklunk defines Splunk Output Configuration
+                description: Splunk defines Splunk Output Configuration
                 properties:
                   Workers:
                     description: Enables dedicated thread(s) for this output. Default

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3457,7 +3457,7 @@ spec:
                   discard the data after reaching that limit.
                 type: string
               splunk:
-                description: Spklunk defines Splunk Output Configuration
+                description: Splunk defines Splunk Output Configuration
                 properties:
                   Workers:
                     description: Enables dedicated thread(s) for this output. Default


### PR DESCRIPTION
This PR is in relation to the recently merged PR https://github.com/fluent/fluent-operator/pull/417 . This PR does nothing put fixing a simple typo.


<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR fixes a typo in the recent PR https://github.com/fluent/fluent-operator/pull/417 . 
Some comments used the term 'Spklunk' but it should have been 'Splunk'.

This PR should not, add remove or change any functionality. It is purely cosmetic.
 
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```