### PR TITLE
Added support for Time_Offset parameter in regex parser

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/parser/regex_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/parser/regex_types.go
@@ -18,6 +18,8 @@ type Regex struct {
 	TimeFormat string `json:"timeFormat,omitempty"`
 	// Time_Keep
 	TimeKeep *bool  `json:"timeKeep,omitempty"`
+	// Time_Offset
+	TimeOffset *bool  `json:"timeOffset,omitempty"`
 	Types    string `json:"types,omitempty"`
 }
 
@@ -39,8 +41,11 @@ func (re *Regex) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	if re.TimeKeep != nil {
 		kvs.Insert("Time_Keep", fmt.Sprint(*re.TimeKeep))
 	}
+	if re.TimeKeep != nil {
+		kvs.Insert("Time_Keep", fmt.Sprint(*re.TimeKeep))
+	}
 	if re.Types != "" {
-		kvs.Insert("Types", re.Types)
+		kvs.Insert("Time_Offset", fmt.Sprint(*re.TimeOffset))
 	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/parser/regex_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/parser/regex_types.go
@@ -17,10 +17,10 @@ type Regex struct {
 	// Time_Format, eg. %Y-%m-%dT%H:%M:%S %z
 	TimeFormat string `json:"timeFormat,omitempty"`
 	// Time_Keep
-	TimeKeep *bool  `json:"timeKeep,omitempty"`
-	// Time_Offset
-	TimeOffset *bool  `json:"timeOffset,omitempty"`
-	Types    string `json:"types,omitempty"`
+	TimeKeep *bool `json:"timeKeep,omitempty"`
+	// Time_Offset, eg. +0200
+	TimeOffset string `json:"timeOffset,omitempty"`
+	Types      string `json:"types,omitempty"`
 }
 
 func (_ *Regex) Name() string {
@@ -41,11 +41,11 @@ func (re *Regex) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	if re.TimeKeep != nil {
 		kvs.Insert("Time_Keep", fmt.Sprint(*re.TimeKeep))
 	}
-	if re.TimeKeep != nil {
-		kvs.Insert("Time_Keep", fmt.Sprint(*re.TimeKeep))
+	if re.TimeOffset != "" {
+		kvs.Insert("Time_Offset", re.TimeOffset)
 	}
 	if re.Types != "" {
-		kvs.Insert("Time_Offset", fmt.Sprint(*re.TimeOffset))
+		kvs.Insert("Types", re.Types)
 	}
 	return kvs, nil
 }

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusterparsers.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusterparsers.yaml
@@ -102,6 +102,9 @@ spec:
                   timeKey:
                     description: Time_Key
                     type: string
+                  timeOffset:
+                    description: Time_Offset, eg. +0200
+                    type: string
                   types:
                     type: string
                 type: object

--- a/config/crd/bases/fluentbit.fluent.io_clusterparsers.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterparsers.yaml
@@ -102,6 +102,9 @@ spec:
                   timeKey:
                     description: Time_Key
                     type: string
+                  timeOffset:
+                    description: Time_Offset, eg. +0200
+                    type: string
                   types:
                     type: string
                 type: object

--- a/docs/plugins/fluentbit/clusterparser/regex.md
+++ b/docs/plugins/fluentbit/clusterparser/regex.md
@@ -9,4 +9,5 @@ The regex parser plugin
 | timeKey | Time_Key | string |
 | timeFormat | Time_Format, eg. %Y-%m-%dT%H:%M:%S %z | string |
 | timeKeep | Time_Keep | *bool |
+| timeOffset | Time_Offset eg. +0200 | string |
 | types |  | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5535,6 +5535,9 @@ spec:
                   timeKey:
                     description: Time_Key
                     type: string
+                  timeOffset:
+                    description: Time_Offset, eg. +0200
+                    type: string
                   types:
                     type: string
                 type: object

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5535,6 +5535,9 @@ spec:
                   timeKey:
                     description: Time_Key
                     type: string
+                  timeOffset:
+                    description: Time_Offset, eg. +0200
+                    type: string
                   types:
                     type: string
                 type: object


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Adds support to define Time_Offset parameter on regex parser

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```