### PR TITLE
fix: handling optional bool parameters for Splunk ClusterOutput

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
@@ -105,13 +105,20 @@ func (o *Splunk) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	if o.Channel != "" {
 		kvs.Insert("channel", o.Channel)
 	}
-	if *o.HTTPDebugBadRequest {
-		kvs.Insert("http_debug_bad_request", "On")
+	if o.HTTPDebugBadRequest != nil {
+		if *o.HTTPDebugBadRequest {
+			kvs.Insert("http_debug_bad_request", "On")
+		} else {
+			kvs.Insert("http_debug_bad_request", "Off")
+		}
 	}
-	if *o.SplunkSendRaw {
-		kvs.Insert("splunk_send_raw", "On")
+	if o.SplunkSendRaw != nil {
+		if *o.SplunkSendRaw {
+			kvs.Insert("splunk_send_raw", "On")
+		} else {
+			kvs.Insert("splunk_send_raw", "Off")
+		}
 	}
-
 	if o.EventKey != "" {
 		kvs.Insert("event_key", o.EventKey)
 	}

--- a/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
@@ -106,18 +106,10 @@ func (o *Splunk) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		kvs.Insert("channel", o.Channel)
 	}
 	if o.HTTPDebugBadRequest != nil {
-		if *o.HTTPDebugBadRequest {
-			kvs.Insert("http_debug_bad_request", "On")
-		} else {
-			kvs.Insert("http_debug_bad_request", "Off")
-		}
+		kvs.Insert("http_debug_bad_request", fmt.Sprint(*o.HTTPDebugBadRequest))
 	}
 	if o.SplunkSendRaw != nil {
-		if *o.SplunkSendRaw {
-			kvs.Insert("splunk_send_raw", "On")
-		} else {
-			kvs.Insert("splunk_send_raw", "Off")
-		}
+		kvs.Insert("splunk_send_raw", fmt.Sprint(*o.SplunkSendRaw))
 	}
 	if o.EventKey != "" {
 		kvs.Insert("event_key", o.EventKey)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR fixes `nil` pointer exceptions while rendering fluentbit config, when Splunk `ClusterOutput` does not define boolean attributes.
It was fixed by intention in a way to explicitly show `Off` values when the respective boolean attributes are explicitly defined in the `ClusterOutput` definition, despite the fact that `Off` might be the default value when not provided.

It is confirmed working, locally, now.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
no issue raised, yet, as the Splunk output was contributed by 'us' and there was no fluent-operator release for that, yet.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```