### PR TITLE
fix: add missing config attributes for splunk output

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
@@ -120,7 +120,21 @@ func (o *Splunk) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	if o.EventSource != "" {
 		kvs.Insert("event_source", o.EventSource)
 	}
-
+	if o.EventSourcetype != "" {
+		kvs.Insert("event_sourcetype", o.EventSourcetype)
+	}
+	if o.EventSourcetypeKey != "" {
+		kvs.Insert("event_sourcetype_key", o.EventSourcetypeKey)
+	}
+	if o.EventIndex != "" {
+		kvs.Insert("event_index", o.EventIndex)
+	}
+	if o.EventIndexKey != "" {
+		kvs.Insert("event_index_key", o.EventIndexKey)
+	}
+	if o.EventField != "" {
+		kvs.Insert("event_field", o.EventField)
+	}
 	if o.Workers != nil {
 		kvs.Insert("workers", fmt.Sprint(*o.Workers))
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR adds missing config attributes for splunk output to be rendered to the configuration. We just missed it in previous PRs

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes - no issue raised for this.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```