### PR TITLE
feat: control/configure default ClusterFilters (helm chart)

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.1
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/templates/fluentbit-clusterfilter-containerd.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterfilter-containerd.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.filter.containerd.enable -}}
 apiVersion: fluentbit.fluent.io/v1alpha2
 kind: ClusterFilter
 metadata:
@@ -15,4 +16,5 @@ spec:
         name: fluent-bit-containerd-config
       call: containerd
       timeAsTable: true
+{{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-clusterfilter-kubernetes.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterfilter-kubernetes.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.filter.kubernetes.enable -}}
 apiVersion: fluentbit.fluent.io/v1alpha2
 kind: ClusterFilter
 metadata:
@@ -13,8 +14,8 @@ spec:
       kubeURL: https://kubernetes.default.svc:443
       kubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      labels: false
-      annotations: false
+      labels: {{ .Values.fluentbit.filter.kubernetes.labels }}
+      annotations: {{ .Values.fluentbit.filter.kubernetes.annotations }}
   - nest:
       operation: lift
       nestedUnder: kubernetes
@@ -31,4 +32,5 @@ spec:
       - kubernetes_*
       nestUnder: kubernetes
       removePrefix: kubernetes_
+{{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-clusterfilter-systemd.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterfilter-systemd.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.filter.systemd.enable -}}
 apiVersion: fluentbit.fluent.io/v1alpha2
 kind: ClusterFilter
 metadata:
@@ -15,4 +16,5 @@ spec:
         name: fluent-bit-lua
       call: add_time
       timeAsTable: true
+{{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-containerd-config.yaml
+++ b/charts/fluent-operator/templates/fluentbit-containerd-config.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.filter.containerd.enable -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,4 +23,4 @@ data:
            end
     end
 {{- end }}
-
+{{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -119,6 +119,17 @@ fluentbit:
       enable: false
       brokers: "<kafka broker list like xxx.xxx.xxx.xxx:9092,yyy.yyy.yyy.yyy:9092>"
       topics: ks-log
+  
+  #Configure the default filters in FluentBit.
+  filter:
+    kubernetes:
+      enable: true
+      labels: false
+      annotations: false
+    containerd:
+      enable: true
+    systemd:
+      enable: true
 
 fluentd:
   enable: false


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Allows users to control and slightly configure the deployment of default ClusterFilters, this is useful for when users have their own ClusterFilter being deployed which overlaps with the defaults.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
New values defined to allow users to control the deployment of the default ClusterFilters.
The default values match the existing behaviour today.

fluentbit:
  filter:
    kubernetes:
      enable: true
      labels: false
      annotations: false
    containerd:
      enable: true
    systemd:
      enable: true
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```