### PR TITLE
fix: intendation corrected in fluentbit-fluentBit.yaml

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -9,7 +9,7 @@ spec:
   image: {{ .Values.fluentbit.image.repository }}:{{ .Values.fluentbit.image.tag }}
   {{- if .Values.fluentbit.imagePullSecrets }}
   imagePullSecrets:
-  {{ toYaml .Values.fluentbit.imagePullSecrets | indent 4 }}
+{{ toYaml .Values.fluentbit.imagePullSecrets | indent 4 }}
   {{- end }}
   positionDB:
     hostPath:
@@ -28,18 +28,18 @@ spec:
                 operator: DoesNotExist
   {{- if .Values.fluentbit.secrets }}
   secrets:
-  {{ toYaml .Values.fluentbit.secrets | indent 4 }}
+{{ toYaml .Values.fluentbit.secrets | indent 4 }}
   {{- end }}
   {{- if .Values.fluentbit.volumes }}
   volumes:
-  {{ toYaml .Values.fluentbit.volumes | indent 4 }}
+{{ toYaml .Values.fluentbit.volumes | indent 4 }}
   {{- end }}
   {{- if .Values.fluentbit.volumesMounts }}
   volumesMounts:
-  {{ toYaml .Values.fluentbit.volumesMounts | indent 4 }}
+{{ toYaml .Values.fluentbit.volumesMounts | indent 4 }}
   {{- end }}
   {{- if .Values.fluentbit.annotations }}
   annotations:
-  {{ toYaml .Values.fluentbit.annotations | indent 4 }}
+{{ toYaml .Values.fluentbit.annotations | indent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
I created this PR because I was struggling to add (multiple) annotations to my fluent-bits. I noticed that this code ( https://github.com/fluent/fluent-operator/blob/0ca8da204eb4dd249f90b39201aebdc3e97923fb/charts/fluent-operator/templates/fluentbit-fluentBit.yaml#L43 ) is the problem. To my understanding if multiple annotations are supplied through the values, it will generate output such as this:
```
  annotations:
      key0: value0
    key1: value1
    key2: value2
```
Note that there are 6 spaces before key0 and only 4 spaces before key1 and key2.

The above issue only manifests if multiple annotations are supplied. If one only key0 and value0 are supplied it will work just fine as all keys and values and are intended the same way but as soon as there is more than one key/value pair. key-pair one will be intended two more spaces to the right than all the others as the statement that generates this output itself has two spaces before it.

The above error-pattern seems to be repeated several times in the code. I tried to fix all occurrences in this file.

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This fixes an issue where annotations and VolumeMounts do not work if more than one is supplied.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```