### PR TITLE
fix: fluentbit template render error - fixes #457

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -9,13 +9,13 @@ spec:
   image: {{ .Values.fluentbit.image.repository }}:{{ .Values.fluentbit.image.tag }}
   {{- if .Values.fluentbit.imagePullSecrets }}
   imagePullSecrets:
-  {{ toYaml .Values.fluentbit.imagePullSecrets | indent 4 }}
+{{ toYaml .Values.fluentbit.imagePullSecrets | indent 4 }}
   {{- end }}
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/
   resources:
-    {{- toYaml .Values.fluentbit.resources | nindent 4  }}
+{{- toYaml .Values.fluentbit.resources | nindent 4  }}
   fluentBitConfigName: fluent-bit-config
   tolerations:
     - operator: Exists
@@ -28,18 +28,18 @@ spec:
                 operator: DoesNotExist
   {{- if .Values.fluentbit.secrets }}
   secrets:
-  {{ toYaml .Values.fluentbit.secrets | indent 4 }}
+{{ toYaml .Values.fluentbit.secrets | indent 4 }}
   {{- end }}
   {{- if .Values.fluentbit.volumes }}
   volumes:
-  {{ toYaml .Values.fluentbit.volumes | indent 4 }}
+{{ toYaml .Values.fluentbit.volumes | indent 4 }}
   {{- end }}
   {{- if .Values.fluentbit.volumesMounts }}
   volumesMounts:
-  {{ toYaml .Values.fluentbit.volumesMounts | indent 4 }}
+{{ toYaml .Values.fluentbit.volumesMounts | indent 4 }}
   {{- end }}
   {{- if .Values.fluentbit.annotations }}
   annotations:
-  {{ toYaml .Values.fluentbit.annotations | indent 4 }}
+{{ toYaml .Values.fluentbit.annotations | indent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Jeremiah Roth <jeremiah@sundeck.io>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Fixes template render error in fluentbit-fluentBit.yaml when adding more than one annotation, secret, volume, volumeMount.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #457

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```