### PR TITLE
Add fluent-bit service and option to extend the RBAC configurations

### DIFF
--- a/apis/fluentbit/v1alpha2/fluentbit_types.go
+++ b/apis/fluentbit/v1alpha2/fluentbit_types.go
@@ -18,6 +18,7 @@ package v1alpha2
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fluent/fluent-operator/pkg/utils"
@@ -28,6 +29,8 @@ import (
 
 // FluentBitSpec defines the desired state of FluentBit
 type FluentBitSpec struct {
+	// DisableService tells if the fluentbit service should be deployed.
+	DisableService bool `json:"disableService,omitempty"`
 	// Fluent Bit image.
 	Image string `json:"image,omitempty"`
 	// Fluent Bit Watcher command line arguments.
@@ -78,6 +81,8 @@ type FluentBitSpec struct {
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 	// Ports represents the pod's ports.
 	Ports []corev1.ContainerPort `json:"ports,omitempty"`
+	// RBACRules represents additional rbac rules which will be applied to the fluent-bit clusterrole.
+	RBACRules []rbacv1.PolicyRule `json:"rbacRules,omitempty"`
 }
 
 // FluentBitStatus defines the observed state of FluentBit

--- a/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fluent/fluent-operator/apis/fluentbit/v1alpha2/plugins/output"
 	"github.com/fluent/fluent-operator/apis/fluentbit/v1alpha2/plugins/parser"
 	"k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -619,6 +620,13 @@ func (in *FluentBitSpec) DeepCopyInto(out *FluentBitSpec) {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]v1.ContainerPort, len(*in))
 		copy(*out, *in)
+	}
+	if in.RBACRules != nil {
+		in, out := &in.RBACRules, &out.RBACRules
+		*out = make([]rbacv1.PolicyRule, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/apis/fluentd/v1alpha1/fluentd_types.go
+++ b/apis/fluentd/v1alpha1/fluentd_types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins/input"
 	"github.com/fluent/fluent-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -65,6 +66,8 @@ type FluentdSpec struct {
 	RuntimeClassName string `json:"runtimeClassName,omitempty"`
 	// PriorityClassName represents the pod's priority class.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+	// RBACRules represents additional rbac rules which will be applied to the fluentd clusterrole.
+	RBACRules []rbacv1.PolicyRule `json:"rbacRules,omitempty"`
 }
 
 type BufferVolume struct {

--- a/apis/fluentd/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/fluentd/v1alpha1/zz_generated.deepcopy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins/input"
 	"github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins/output"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -706,6 +707,13 @@ func (in *FluentdSpec) DeepCopyInto(out *FluentdSpec) {
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.RBACRules != nil {
+		in, out := &in.RBACRules, &out.RBACRules
+		*out = make([]rbacv1.PolicyRule, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -873,6 +873,10 @@ spec:
               containerLogRealPath:
                 description: Container log path
                 type: string
+              disableService:
+                description: DisableService tells if the fluentbit service should
+                  be deployed.
+                type: boolean
               envVars:
                 description: EnvVars represent environment variables that can be passed
                   to fluentbit pods.
@@ -3872,6 +3876,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluent-bit clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               readinessProbe:
                 description: ReadinessProbe represents the pod's readiness probe.
                 properties:

--- a/charts/fluent-operator/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_fluentds.yaml
@@ -1694,6 +1694,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluentd clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               replicas:
                 description: Numbers of the Fluentd instance
                 format: int32

--- a/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
@@ -873,6 +873,10 @@ spec:
               containerLogRealPath:
                 description: Container log path
                 type: string
+              disableService:
+                description: DisableService tells if the fluentbit service should
+                  be deployed.
+                type: boolean
               envVars:
                 description: EnvVars represent environment variables that can be passed
                   to fluentbit pods.
@@ -3872,6 +3876,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluent-bit clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               readinessProbe:
                 description: ReadinessProbe represents the pod's readiness probe.
                 properties:

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -1694,6 +1694,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluentd clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               replicas:
                 description: Numbers of the Fluentd instance
                 format: int32

--- a/controllers/fluentd_controller.go
+++ b/controllers/fluentd_controller.go
@@ -91,7 +91,7 @@ func (r *FluentdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Install RBAC resources for the filter plugin kubernetes
-	var rbacObj, saObj, bindingObj = operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd")
+	var rbacObj, saObj, bindingObj = operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd", fd.Spec.RBACRules)
 
 	// Set ServiceAccount's owner to this Fluentd
 	if err := ctrl.SetControllerReference(&fd, saObj, r.Scheme); err != nil {

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -6997,6 +6997,10 @@ spec:
               containerLogRealPath:
                 description: Container log path
                 type: string
+              disableService:
+                description: DisableService tells if the fluentbit service should
+                  be deployed.
+                type: boolean
               envVars:
                 description: EnvVars represent environment variables that can be passed
                   to fluentbit pods.
@@ -9996,6 +10000,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluent-bit clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               readinessProbe:
                 description: ReadinessProbe represents the pod's readiness probe.
                 properties:
@@ -13885,6 +13940,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluentd clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               replicas:
                 description: Numbers of the Fluentd instance
                 format: int32

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -6997,6 +6997,10 @@ spec:
               containerLogRealPath:
                 description: Container log path
                 type: string
+              disableService:
+                description: DisableService tells if the fluentbit service should
+                  be deployed.
+                type: boolean
               envVars:
                 description: EnvVars represent environment variables that can be passed
                   to fluentbit pods.
@@ -9996,6 +10000,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluent-bit clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               readinessProbe:
                 description: ReadinessProbe represents the pod's readiness probe.
                 properties:
@@ -13885,6 +13940,57 @@ spec:
               priorityClassName:
                 description: PriorityClassName represents the pod's priority class.
                 type: string
+              rbacRules:
+                description: RBACRules represents additional rbac rules which will
+                  be applied to the fluentd clusterrole.
+                items:
+                  description: PolicyRule holds information that describes a policy
+                    rule, but does not contain information about who the rule applies
+                    to or which namespace the rule applies to.
+                  properties:
+                    apiGroups:
+                      description: APIGroups is the name of the APIGroup that contains
+                        the resources.  If multiple API groups are specified, any
+                        action requested against one of the enumerated resources in
+                        any API group will be allowed. "" represents the core API
+                        group and "*" represents all API groups.
+                      items:
+                        type: string
+                      type: array
+                    nonResourceURLs:
+                      description: NonResourceURLs is a set of partial urls that a
+                        user should have access to.  *s are allowed, but only as the
+                        full, final step in the path Since non-resource URLs are not
+                        namespaced, this field is only applicable for ClusterRoles
+                        referenced from a ClusterRoleBinding. Rules can either apply
+                        to API resources (such as "pods" or "secrets") or non-resource
+                        URL paths (such as "/api"),  but not both.
+                      items:
+                        type: string
+                      type: array
+                    resourceNames:
+                      description: ResourceNames is an optional white list of names
+                        that the rule applies to.  An empty set means that everything
+                        is allowed.
+                      items:
+                        type: string
+                      type: array
+                    resources:
+                      description: Resources is a list of resources this rule applies
+                        to. '*' represents all resources.
+                      items:
+                        type: string
+                      type: array
+                    verbs:
+                      description: Verbs is a list of Verbs that apply to ALL the
+                        ResourceKinds contained in this rule. '*' represents all verbs.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - verbs
+                  type: object
+                type: array
               replicas:
                 description: Numbers of the Fluentd instance
                 format: int32

--- a/pkg/operator/fluent-bit-service.go
+++ b/pkg/operator/fluent-bit-service.go
@@ -1,0 +1,50 @@
+package operator
+
+import (
+	fluentbitv1alpha2 "github.com/fluent/fluent-operator/apis/fluentbit/v1alpha2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	FluentBitMetricsPortName = "metrics"
+	FluentBitMetricsPort     = 2020
+	FluentBitTCPProtocolName = "TCP"
+)
+
+func MakeFluentbitService(fb fluentbitv1alpha2.FluentBit) corev1.Service {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fb.Name,
+			Namespace: fb.Namespace,
+			Labels:    fb.Labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: fb.Labels,
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       FluentBitMetricsPortName,
+					Port:       FluentBitMetricsPort,
+					Protocol:   FluentBitTCPProtocolName,
+					TargetPort: intstr.FromInt(FluentBitMetricsPort),
+				},
+			},
+		},
+	}
+
+	if fb.Spec.Ports != nil {
+		for _, port := range fb.Spec.Ports {
+			svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+				Name:       port.Name,
+				Port:       port.ContainerPort,
+				Protocol:   port.Protocol,
+				TargetPort: intstr.FromInt(int(port.ContainerPort)),
+			})
+		}
+	}
+
+	return svc
+}

--- a/pkg/operator/fluentd-service.go
+++ b/pkg/operator/fluentd-service.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	ForwardPortName = "forward"
-	HttpPortName    = "http"
+	FluentdForwardPortName = "forward"
+	FluentdHttpPortName    = "http"
 )
 
 func MakeFluentdService(fd fluentdv1alpha1.Fluentd) corev1.Service {
@@ -45,7 +45,7 @@ func MakeFluentdService(fd fluentdv1alpha1.Fluentd) corev1.Service {
 			forwardContainerPort := corev1.ServicePort{
 				Name:       DefaultForwardName,
 				Port:       forwardPort,
-				TargetPort: intstr.FromString(ForwardPortName),
+				TargetPort: intstr.FromString(FluentdForwardPortName),
 				Protocol:   corev1.ProtocolTCP,
 			}
 			svc.Spec.Ports = append(svc.Spec.Ports, forwardContainerPort)
@@ -60,7 +60,7 @@ func MakeFluentdService(fd fluentdv1alpha1.Fluentd) corev1.Service {
 			httpContainerPort := corev1.ServicePort{
 				Name:       DefaultHttpName,
 				Port:       httpPort,
-				TargetPort: intstr.FromString(HttpPortName),
+				TargetPort: intstr.FromString(FluentdHttpPortName),
 				Protocol:   corev1.ProtocolTCP,
 			}
 			svc.Spec.Ports = append(svc.Spec.Ports, httpContainerPort)

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func MakeRBACObjects(name, namespace, component string) (*rbacv1.ClusterRole, *corev1.ServiceAccount, *rbacv1.ClusterRoleBinding) {
+func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1.PolicyRule) (*rbacv1.ClusterRole, *corev1.ServiceAccount, *rbacv1.ClusterRoleBinding) {
 	rbacName := fmt.Sprintf("kubesphere-%s", component)
 	cr := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -21,6 +21,10 @@ func MakeRBACObjects(name, namespace, component string) (*rbacv1.ClusterRole, *c
 				Resources: []string{"pods"},
 			},
 		},
+	}
+
+	if additionalRules != nil {
+		cr.Rules = append(cr.Rules, additionalRules...)
 	}
 
 	sa := corev1.ServiceAccount{


### PR DESCRIPTION
Signed-off-by: Kristian-ZH <k.zhelyazkov@sap.com>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
The PR adds fluent-bit service that can be disabled with the configuration `DisableService`. It also adds an option to extend the RBAC configurations through the FB/Fluentd Spec config file.

Motivation:
The Service is needed in case you want to easily scrape metrics from the fluent-bit from Prometheus for example.
The RBAC extension is needed in case you deploy your custom output plugin (As the operator and the FB itself already support this option) and this custom plugin works with additional resources.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
The RBAC extension is also added in fluentd because I think that it is also valid scenario there.

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
The operator now deploys fluent-bit service which can be disabled with `DisableService` configuration in the FluentBit
```
```release-note
FluentBit and FluentD resources now support `rbacRules` configuration which allows to extend their RBACs
```