### PR TITLE
feat: adding support for labels for fluent-operator and fluent-bit pods

### DIFF
--- a/apis/fluentbit/v1alpha2/fluentbit_types.go
+++ b/apis/fluentbit/v1alpha2/fluentbit_types.go
@@ -67,6 +67,8 @@ type FluentBitSpec struct {
 	VolumesMounts []corev1.VolumeMount `json:"volumesMounts,omitempty"`
 	// Annotations to add to each Fluentbit pod.
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Labels to add to each FluentBit pod
+	Labels map[string]string `json:"labels,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	// Host networking is requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.

--- a/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
@@ -587,6 +587,13 @@ func (in *FluentBitSpec) DeepCopyInto(out *FluentBitSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.PodSecurityContext)

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -2226,6 +2226,11 @@ spec:
                   - name
                   type: object
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels to add to each FluentBit pod
+                type: object
               livenessProbe:
                 description: LivenessProbe represents the pod's liveness probe.
                 properties:

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -20,10 +20,10 @@ spec:
         {{- if .Values.operator.labels }}
         {{- toYaml .Values.operator.labels | nindent 8 }}
         {{- end }}
+      {{- if .Values.operator.annotations }} 
       annotations:
-        {{- if .Values.operator.annotations }}      
         {{- toYaml .Values.operator.annotations| nindent 8 }}
-        {{- end }}
+      {{- end }}
     spec:
       {{- if eq .Values.containerRuntime "docker" }}
       volumes:

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: fluent-operator
+        {{- if .Values.operator.labels }}
+        {{- toYaml .Values.operator.labels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if eq .Values.containerRuntime "docker" }}
       volumes:
@@ -85,5 +88,5 @@ spec:
       serviceAccountName: fluent-operator
       {{- if .Values.operator.imagePullSecrets }}
       imagePullSecrets:
-      {{ toYaml .Values.operator.imagePullSecrets | indent 8 }}
+      {{- toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -42,4 +42,8 @@ spec:
   annotations:
 {{ toYaml .Values.fluentbit.annotations | indent 4 }}
   {{- end }}
+  {{- if .Values.fluentbit.labels }}
+  labels:
+{{ toYaml .Values.fluentbit.labels | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -25,6 +25,9 @@ operator:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   imagePullSecrets: []
   # - name: "image-pull-secret"
+  # Reference one more key-value pairs of labels that should be attached to fluent-operator
+  labels: {}
+#  myExampleLabel: someValue  
   logPath:
     crio: /var/log
     containerd: /var/log
@@ -45,6 +48,10 @@ fluentbit:
   # Specify custom annotations to be added to each FluentBit pod.
   annotations: {}
     # prometheus.io/scrape: "true"
+  # Specify additional custom labels for fluentbit-pods
+  labels: {}
+
+
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##

--- a/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
@@ -2226,6 +2226,11 @@ spec:
                   - name
                   type: object
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels to add to each FluentBit pod
+                type: object
               livenessProbe:
                 description: LivenessProbe represents the pod's liveness probe.
                 properties:

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -8350,6 +8350,11 @@ spec:
                   - name
                   type: object
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels to add to each FluentBit pod
+                type: object
               livenessProbe:
                 description: LivenessProbe represents the pod's liveness probe.
                 properties:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -8350,6 +8350,11 @@ spec:
                   - name
                   type: object
                 type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels to add to each FluentBit pod
+                type: object
               livenessProbe:
                 description: LivenessProbe represents the pod's liveness probe.
                 properties:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR adds the functionality to add labels to to fluent-bit and fluent-operator.

I tested it with `helm template` a few times and it looks good. So at least no obvious helm errors However, I did not deploy it anywhere so far. Please test carefully before merging.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
partially addresses: https://github.com/fluent/fluent-operator/issues/456

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
With this updated version you can now add custom labels to fluent-bit and fluent-operator pods. For example refer to the values file.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```