### PR TITLE
Add external plugin flag in the Fluent-Bit watcher

### DIFF
--- a/cmd/fluent-watcher/fluentbit/main.go
+++ b/cmd/fluent-watcher/fluentbit/main.go
@@ -38,6 +38,7 @@ var (
 )
 
 var configPath string
+var externalPluginPath string
 var binPath string
 var watchPath string
 var poll bool
@@ -48,6 +49,7 @@ func main() {
 
 	flag.StringVar(&binPath, "b", defaultBinPath, "The fluent bit binary path.")
 	flag.StringVar(&configPath, "c", defaultCfgPath, "The config file path.")
+	flag.StringVar(&externalPluginPath, "e", "", "Path to external plugin (shared lib)")
 	flag.BoolVar(&exitOnFailure, "exit-on-failure", false, "If fluentbit exits with failure, also exit the watcher.")
 	flag.StringVar(&watchPath, "watch-path", defaultWatchDir, "The path to watch.")
 	flag.BoolVar(&poll, "poll", false, "Use poll watcher instead of ionotify.")
@@ -186,7 +188,11 @@ func start() {
 		return
 	}
 
-	cmd = exec.Command(binPath, "-c", configPath)
+	if externalPluginPath != "" {
+		cmd = exec.Command(binPath, "-c", configPath, "-e", externalPluginPath)
+	} else {
+		cmd = exec.Command(binPath, "-c", configPath)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Add an external plugin flag in the Fluent-Bit watcher which allows providing custom plugins to the FB binary.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fluent-bit-watcher binary now supports `-e` flag which accepts an external plugin path
```