### PR TITLE
feat: Add annotations to fleuntbit daemonset

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -5,6 +5,8 @@ metadata:
   name: fluent-bit
   labels:
     app.kubernetes.io/name: fluent-bit
+  annotations:
+    {{- toYaml .Values.fluentbit.annotations| nindent 4 }}    
 spec:
   image: {{ .Values.fluentbit.image.repository }}:{{ .Values.fluentbit.image.tag }}
   {{- if .Values.fluentbit.imagePullSecrets }}

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
   annotations:
-    {{- toYaml .Values.fluentbit.annotations| nindent 4 }}    
+    {{- toYaml .Values.fluentbit.annotations| nindent 4 }}
 spec:
   image: {{ .Values.fluentbit.image.repository }}:{{ .Values.fluentbit.image.tag }}
   {{- if .Values.fluentbit.imagePullSecrets }}

--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -16,6 +16,7 @@ func MakeDaemonSet(fb fluentbitv1alpha2.FluentBit, logPath string) appsv1.Daemon
 			Name:      fb.Name,
 			Namespace: fb.Namespace,
 			Labels:    fb.Labels,
+			Annotations: fb.Annotations,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it: The PR will provide the functionality to add the custom annotations at the fluent-bit daemonset level.
Currently the annotations are added only at the fluent bit pods level.
