### PR TITLE
feat: adding annotations to Dameon Set of fluent-bit

### DIFF
--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -13,9 +13,10 @@ import (
 func MakeDaemonSet(fb fluentbitv1alpha2.FluentBit, logPath string) appsv1.DaemonSet {
 	ds := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fb.Name,
-			Namespace: fb.Namespace,
-			Labels:    fb.Labels,
+			Name:        fb.Name,
+			Namespace:   fb.Namespace,
+			Labels:      fb.Labels,
+			Annotations: fb.Annotations,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR will add annotations not only to fluent-bit pods, but also to the Daemon Set itself.
This is a slight detail I overlooked in my latest PR ( https://github.com/fluent/fluent-operator/pull/468 )


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
partially adresses https://github.com/fluent/fluent-operator/issues/456

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
With this release you get the ability to add annotations to fluent-bit pods and the fluent-bit Dameon-Set generated.

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```