### PR TITLE
dockerModeParser parameter for ClusterInput tail

### DIFF
--- a/apis/fluentbit/v1alpha2/clusterinput_types_test.go
+++ b/apis/fluentbit/v1alpha2/clusterinput_types_test.go
@@ -1,8 +1,9 @@
 package v1alpha2
 
 import (
-	"github.com/go-logr/logr"
 	"testing"
+
+	"github.com/go-logr/logr"
 
 	"github.com/fluent/fluent-operator/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/apis/fluentbit/v1alpha2/plugins/input"
@@ -20,7 +21,11 @@ var inputExpected = `[Input]
     Skip_Long_Lines    true
     DB    /fluent-bit/tail/pos.db
     Mem_Buf_Limit    5MB
+    Parser    docker
     Tag    logs.foo.bar
+    Docker_Mode    true
+    Docker_Mode_Flush    4
+    Docker_Mode_Parser    docker-mode-parser
     Inotify_Watcher    false
 [Input]
     Name    dummy
@@ -73,6 +78,10 @@ func TestClusterInputList_Load(t *testing.T) {
 				MemBufLimit:            "5MB",
 				RefreshIntervalSeconds: ptrInt64(10),
 				DB:                     "/fluent-bit/tail/pos.db",
+				Parser:                 "docker",
+				DockerMode:             ptrBool(true),
+				DockerModeFlushSeconds: ptrInt64(4),
+				DockerModeParser:       "docker-mode-parser",
 			},
 		},
 	}

--- a/apis/fluentbit/v1alpha2/plugins/input/tail_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/input/tail_types.go
@@ -85,6 +85,8 @@ type Tail struct {
 	DockerMode *bool `json:"dockerMode,omitempty"`
 	// Wait period time in seconds to flush queued unfinished split lines.
 	DockerModeFlushSeconds *int64 `json:"dockerModeFlushSeconds,omitempty"`
+	// Specify an optional parser for the first line of the docker multiline mode. The parser name to be specified must be registered in the parsers.conf file.
+	DockerModeParser string `json:"dockerModeParser,omitempty"`
 	// DisableInotifyWatcher will disable inotify and use the file stat watcher instead.
 	DisableInotifyWatcher *bool `json:"disableInotifyWatcher,omitempty"`
 	// This will help to reassembly multiline messages originally split by Docker or CRI
@@ -166,6 +168,9 @@ func (t *Tail) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if t.DockerModeFlushSeconds != nil {
 		kvs.Insert("Docker_Mode_Flush", fmt.Sprint(*t.DockerModeFlushSeconds))
+	}
+	if t.DockerModeParser != "" {
+		kvs.Insert("Docker_Mode_Parser", fmt.Sprint(t.DockerModeParser))
 	}
 	if t.DisableInotifyWatcher != nil {
 		kvs.Insert("Inotify_Watcher", fmt.Sprint(!*t.DisableInotifyWatcher))

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusterinputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusterinputs.yaml
@@ -252,6 +252,11 @@ spec:
                       split lines.
                     format: int64
                     type: integer
+                  dockerModeParser:
+                    description: Specify an optional parser for the first line of
+                      the docker multiline mode. The parser name to be specified must
+                      be registered in the parsers.conf file.
+                    type: string
                   excludePath:
                     description: 'Set one or multiple shell patterns separated by
                       commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'

--- a/config/crd/bases/fluentbit.fluent.io_clusterinputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterinputs.yaml
@@ -252,6 +252,11 @@ spec:
                       split lines.
                     format: int64
                     type: integer
+                  dockerModeParser:
+                    description: Specify an optional parser for the first line of
+                      the docker multiline mode. The parser name to be specified must
+                      be registered in the parsers.conf file.
+                    type: string
                   excludePath:
                     description: 'Set one or multiple shell patterns separated by
                       commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'

--- a/docs/plugins/fluentbit/clusterinput/tail.md
+++ b/docs/plugins/fluentbit/clusterinput/tail.md
@@ -28,5 +28,6 @@ The Tail input plugin allows to monitor one or several text files. It has a simi
 | parserN | Optional-extra parser to interpret and structure multiline entries. This option can be used to define multiple parsers. | []string |
 | dockerMode | If enabled, the plugin will recombine split Docker log lines before passing them to any parser as configured above. This mode cannot be used at the same time as Multiline. | *bool |
 | dockerModeFlushSeconds | Wait period time in seconds to flush queued unfinished split lines. | *int64 |
+| dockerModeParser | Specify an optional parser for the first line of the docker multiline mode. The parser name to be specified must be registered in the parsers.conf file. | string |
 | disableInotifyWatcher | DisableInotifyWatcher will disable inotify and use the file stat watcher instead. | *bool |
 | multilineParser | This will help to reassembly multiline messages originally split by Docker or CRI Specify one or Multiline Parser definition to apply to the content. | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -1813,6 +1813,11 @@ spec:
                       split lines.
                     format: int64
                     type: integer
+                  dockerModeParser:
+                    description: Specify an optional parser for the first line of
+                      the docker multiline mode. The parser name to be specified must
+                      be registered in the parsers.conf file.
+                    type: string
                   excludePath:
                     description: 'Set one or multiple shell patterns separated by
                       commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -1813,6 +1813,11 @@ spec:
                       split lines.
                     format: int64
                     type: integer
+                  dockerModeParser:
+                    description: Specify an optional parser for the first line of
+                      the docker multiline mode. The parser name to be specified must
+                      be registered in the parsers.conf file.
+                    type: string
                   excludePath:
                     description: 'Set one or multiple shell patterns separated by
                       commas to exclude files matching a certain criteria, e.g: exclude_path=*.gz,*.zip'


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Implements an optional "dockerModeParser" parameter for FluentBit input tail
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Users can now specify an optional parser for parsing multiline logs with docker mode
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Same usage as described in https://docs.fluentbit.io/manual/pipeline/inputs/tail#docker_mode
```