### PR TITLE
Fluent-bit upgrade to v2.0.6

### DIFF
--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -13,7 +13,7 @@ on:
       - "pkg/filenotify/**"
 
 env:
-  FB_IMG: 'kubesphere/fluent-bit:v1.9.9'
+  FB_IMG: 'kubesphere/fluent-bit:v2.0.6'
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION?=$(shell cat VERSION | tr -d " \t\n\r")
 # Image URL to use all building/pushing image targets
-FB_IMG ?= kubesphere/fluent-bit:v1.9.9
+FB_IMG ?= kubesphere/fluent-bit:v2.0.6
 FD_IMG ?= kubesphere/fluentd:v1.14.6
 FO_IMG ?= kubesphere/fluent-operator:$(VERSION)
 FD_IMG_BASE ?= kubesphere/fluentd:v1.14.6-arm64-base

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -29,7 +29,7 @@ operator:
   # - name: "image-pull-secret"
   # Reference one more key-value pairs of labels that should be attached to fluent-operator
   labels: {}
-#  myExampleLabel: someValue  
+#  myExampleLabel: someValue
   logPath:
     crio: /var/log
     containerd: /var/log
@@ -37,7 +37,7 @@ operator:
 fluentbit:
   image:
     repository: "kubesphere/fluent-bit"
-    tag: "v1.9.9"
+    tag: "v2.0.6"
   # fluentbit resources. If you do want to specify resources, adjust them as necessary
   #You can adjust it based on the log volume.
   resources:
@@ -65,7 +65,7 @@ fluentbit:
   # Pod volumes to mount into the container's filesystem.
   volumesMounts: []
 
-  # Remove the above empty volumes and volumesMounts, and then set volumes and volumesMounts as below if you want to collect node exporter metrics 
+  # Remove the above empty volumes and volumesMounts, and then set volumes and volumesMounts as below if you want to collect node exporter metrics
 # volumes:
 #   - name: hostProc
 #     hostPath:
@@ -76,11 +76,11 @@ fluentbit:
 # volumesMounts:
 #   - mountPath: /host/sys
 #     mountPropagation: HostToContainer
-#     name: hostSys 
+#     name: hostSys
 #     readOnly: true
 #   - mountPath: /host/proc
 #     mountPropagation: HostToContainer
-#     name: hostProc 
+#     name: hostProc
 #     readOnly: true
 
   #Set a limit of memory that Tail plugin can use when appending data to the Engine.
@@ -91,7 +91,7 @@ fluentbit:
   input:
     tail:
       memBufLimit: 5MB
-    # uncomment below nodeExporterMetrics section if you want to collect node exporter metrics 
+    # uncomment below nodeExporterMetrics section if you want to collect node exporter metrics
 #   nodeExporterMetrics:
 #     tag: node_metrics
 #     scrapeInterval: 15s
@@ -128,7 +128,7 @@ fluentbit:
       enable: false
       brokers: "<kafka broker list like xxx.xxx.xxx.xxx:9092,yyy.yyy.yyy.yyy:9092>"
       topics: ks-log
-  
+
   #Configure the default filters in FluentBit.
   filter:
     kubernetes:
@@ -184,8 +184,3 @@ fluentd:
 nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
-
-
-
-
-

--- a/cmd/fluent-watcher/fluentbit/Dockerfile
+++ b/cmd/fluent-watcher/fluentbit/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /code
 RUN echo $(ls -al /code)
 RUN CGO_ENABLED=0 go build -i -ldflags '-w -s' -o /fluent-bit/fluent-bit /code/cmd/fluent-watcher/fluentbit/main.go
 
-FROM fluent/fluent-bit:1.9.9
+FROM fluent/fluent-bit:2.0.6
 LABEL Description="Fluent Bit docker image" Vendor="Fluent" Version="1.0"
 
 COPY conf/fluent-bit.conf conf/parsers.conf /fluent-bit/etc/

--- a/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
+++ b/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v1.9.9
+  image: kubesphere/fluent-bit:v2.0.6
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/
@@ -38,9 +38,9 @@ spec:
   volumesMounts:
     - mountPath: /host/sys
       mountPropagation: HostToContainer
-      name: host-sys 
+      name: host-sys
       readOnly: true
     - mountPath: /host/proc
       mountPropagation: HostToContainer
-      name: host-proc 
+      name: host-proc
       readOnly: true

--- a/manifests/logging-stack/fluentbit-fluentBit.yaml
+++ b/manifests/logging-stack/fluentbit-fluentBit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v1.9.9
+  image: kubesphere/fluent-bit:v2.0.6
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/quick-start/fluentbit.yaml
+++ b/manifests/quick-start/fluentbit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v1.9.9
+  image: kubesphere/fluent-bit:v2.0.6
   fluentBitConfigName: fluent-bit-config
 
 ---

--- a/manifests/regex-parser/fluentbit-fluentBit.yaml
+++ b/manifests/regex-parser/fluentbit-fluentBit.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v1.9.9
+  image: kubesphere/fluent-bit:v2.0.6
   fluentBitConfigName: fluent-bit-config


### PR DESCRIPTION
### What this PR does / why we need it:
This PR bumps fluent-bit to v2.0.6

### Which issue(s) this PR fixes:
This PR doesn't fix anything special, but sightly improves work with Grafana Loki output 

### Does this PR introduced a user-facing change?
```release-note
Upgrade fluent-bit to v2.0.6
```

### Additional documentation, usage docs, etc.:
```docs
This PR upgrades fluent-bit to v2.0.6 what can introduce breaking changes in certain situations for some plugins (like Loki output plugin, for example). Consult with fluent-bit 2.0 release notes for details
```