### PR TITLE
dependabot: Update schedule and fix typo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,15 +7,15 @@ updates:
   - package-ecosystem: "docker"
     directory: "/cmd/fluent-manager"
     schedule:
-      interval: "monthly"
+      interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/cmd/fluent-watcher/fluent-bit"
+    directory: "/cmd/fluent-watcher/fluentbit"
     schedule:
-      interval: "monthly"
+      interval: "daily"
   - package-ecosystem: "docker"
     directory: "/cmd/fluent-watcher/fluentd/base"
     schedule:
-      interval: "monthly"
+      interval: "daily"
   - package-ecosystem: "docker"
     directory: "/docs/best-practice/forwarding-logs-via-http"
     schedule:
@@ -23,5 +23,5 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
There was a typo in the path to the fluent-bit watcher Dockerfile, causing Dependabot to ignore it. In addition, the update schedule was changed, to consume new versions of fluent-bit, etc. faster.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```