### PR TITLE
fluent-bit-watcher: timeout parameter, log timestamps, new/changed logs, additional nil/err checks

### DIFF
--- a/cmd/fluent-watcher/fluentbit/main.go
+++ b/cmd/fluent-watcher/fluentbit/main.go
@@ -185,7 +185,6 @@ func isValidEvent(event fsnotify.Event) bool {
 }
 
 func start() {
-
 	mutex.Lock()
 	defer mutex.Unlock()
 
@@ -200,6 +199,7 @@ func start() {
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	flbTerminated = make(chan bool, 1)
 	if err := cmd.Start(); err != nil {
 		_ = level.Error(logger).Log("msg", "start Fluent bit error", "error", err)
 		cmd = nil
@@ -219,7 +219,6 @@ func wait() error {
 
 	startTime := time.Now()
 
-	flbTerminated = make(chan bool, 1)
 	err := cmd.Wait()
 	if err != nil {
 		_ = level.Error(logger).Log("msg", "Fluent bit exited", "error", err)


### PR DESCRIPTION

### What this PR does / why we need it:
Implements a timeout parameter in fluent-bit-watcher for killing fluent-bit in case it fails to terminate
In addition the commit also contains following changes:
- additional err/nil check for some actions,
- adds timestamps to fluent-bit-watcher logs as well as additional logs and some changed,
- changes deprecated imports: "github.com/go-kit/kit/log" to "github.com/go-kit/log" and "github.com/go-kit/kit/log/level" to "github.com/go-kit/log/level"

Please let me know if you spot any issues or something that would be worth improving. I've tested it at work with the default timeout of 30s and it seems to be working whenever the issue appears. For local testing "-flb-timeout 20ms" can be used to force kill fluent-bit before it manages to terminate. If needed I can post some logs.
### Which issue(s) this PR fixes:
<!--

-->
Fixes #510 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
No
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
-flb-timeout <time> (default 30s) can be specified as an argument in FluentBit yaml as a paremeter for fluent-bit-watcher
```