### PR TITLE
Fixes #522 CRD and operator conform to fluentd-loki-output-plugin documentation

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/output/loki.go
+++ b/apis/fluentd/v1alpha1/plugins/output/loki.go
@@ -1,6 +1,8 @@
 package output
 
-import "github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins"
+import (
+	"github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins"
+)
 
 // The loki output plugin, allows to ingest your records into a Loki service.
 type Loki struct {
@@ -30,5 +32,16 @@ type Loki struct {
 	LineFormat string `json:"lineFormat,omitempty"`
 	// If set to true, it will add all Kubernetes labels to the Stream labels.
 	ExtractKubernetesLabels *bool `json:"extractKubernetesLabels,omitempty"`
-	*plugins.TLS            `json:"tls,omitempty"`
+	// If a record only has 1 key, then just set the log line to the value and discard the key.
+	DropSingleKey *bool `json:"dropSingleKey,omitempty"`
+	// Whether or not to include the fluentd_thread label when multiple threads are used for flushing
+	IncludeThreadLabel *bool `json:"includeThreadLabel,omitempty"`
+	// Disable certificate validation
+	Insecure *bool `json:"insecure,omitempty"`
+	// TlsCaCert defines the CA certificate file for TLS.
+	TlsCaCertFile *string `json:"tlsCaCertFile,omitempty"`
+	// TlsClientCert defines the client certificate file for TLS.
+	TlsClientCertFile *string `json:"tlsClientCertFile,omitempty"`
+	// TlsPrivateKey defines the client private key file for TLS.
+	TlsPrivateKeyFile *string `json:"tlsPrivateKeyFile,omitempty"`
 }

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -569,20 +569,23 @@ func (o *Output) lokiPlugin(parent *params.PluginStore, loader plugins.SecretLoa
 	if o.Loki.ExtractKubernetesLabels != nil {
 		parent.InsertPairs("extract_kubernetes_labels", fmt.Sprint(*o.Loki.ExtractKubernetesLabels))
 	}
-	if o.Loki.TLS != nil {
-		t := o.Loki.TLS
-		if t.Insecure != nil {
-			parent.InsertPairs("insecure_tls", fmt.Sprint(*t.Insecure))
-		}
-		if t.CAFile != "" {
-			parent.InsertPairs("ca_cert", t.CAFile)
-		}
-		if t.CRTFile != "" {
-			parent.InsertPairs("cert", t.CRTFile)
-		}
-		if t.KeyFile != "" {
-			parent.InsertPairs("key", t.KeyFile)
-		}
+	if o.Loki.DropSingleKey != nil {
+		parent.InsertPairs("drop_single_key", fmt.Sprint(*o.Loki.DropSingleKey))
+	}
+	if o.Loki.IncludeThreadLabel != nil {
+		parent.InsertPairs("include_thread_label", fmt.Sprint(*o.Loki.IncludeThreadLabel))
+	}
+	if o.Loki.Insecure != nil {
+		parent.InsertPairs("insecure_tls", fmt.Sprint(*o.Loki.Insecure))
+	}
+	if o.Loki.TlsCaCertFile != nil {
+		parent.InsertPairs("ca_cert", fmt.Sprint(*o.Loki.TlsCaCertFile))
+	}
+	if o.Loki.TlsClientCertFile != nil {
+		parent.InsertPairs("cert", fmt.Sprint(*o.Loki.TlsClientCertFile))
+	}
+	if o.Loki.TlsPrivateKeyFile != nil {
+		parent.InsertPairs("key", fmt.Sprint(*o.Loki.TlsPrivateKeyFile))
 	}
 	return parent
 }

--- a/apis/fluentd/v1alpha1/plugins/tls_types.go
+++ b/apis/fluentd/v1alpha1/plugins/tls_types.go
@@ -6,14 +6,24 @@ import (
 
 // Fluentd provides integrated support for Transport Layer Security (TLS) and it predecessor Secure Sockets Layer (SSL) respectively.
 type TLS struct {
-	// Disable certificate validation
-	Insecure *bool `json:"insecure,omitempty"`
+	// Force certificate validation
+	Verify *bool `json:"verify,omitempty"`
+	// Set TLS debug verbosity level.
+	// It accept the following values: 0 (No debug), 1 (Error), 2 (State change), 3 (Informational) and 4 Verbose
+	// +kubebuilder:validation:Enum:=0;1;2;3;4
+	Debug *int32 `json:"debug,omitempty"`
 	// Absolute path to CA certificate file
 	CAFile string `json:"caFile,omitempty"`
+	// Absolute path to scan for certificate files
+	CAPath string `json:"caPath,omitempty"`
 	// Absolute path to Certificate file
 	CRTFile string `json:"crtFile,omitempty"`
 	// Absolute path to private Key file
 	KeyFile string `json:"keyFile,omitempty"`
+	// Optional password for tls.key_file file
+	KeyPassword *Secret `json:"keyPassword,omitempty"`
+	// Hostname to be used for TLS SNI extension
+	Vhost string `json:"vhost,omitempty"`
 }
 
 type TLSLoader struct {

--- a/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-loki.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-loki.cfg
@@ -25,8 +25,10 @@
   <match **>
     @id  ClusterFluentdConfig-cluster-fluentd-config::cluster::clusteroutput::fluentd-output-loki-0
     @type  loki
+    drop_single_key  true
     extra_labels  {"key11":"value11","key12":"value12"}
     extract_kubernetes_labels  true
+    include_thread_label  true
     insecure_tls  true
     remove_keys  key31,key32
     url  http://loki-logging-data.kubesphere-logging-system.svc:3100

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -235,11 +235,12 @@ spec:
       removeKeys:
         - key31
         - key32
-      tls:
-#        caFile: /path/to/ca.pem
-#        crtFile: /path/to/certificate.pem
-#        keyFile: /path/to/key.key
-        insecure: true
+      dropSingleKey: true
+      includeThreadLabel: true
+#      tlsCaCertFile: /path/to/ca.pem
+#      tlsClientCertFile: /path/to/certificate.pem
+#      tlsPrivateKeyFile: /path/to/key.key
+      insecure: true
 `
 	FluentdClusterOutputLogOperator    fluentdv1alpha1.ClusterOutput
 	FluentdClusterOutputLogOperatorRaw = `

--- a/charts/fluent-operator/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -1137,6 +1137,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -1202,6 +1206,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -1267,24 +1278,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string

--- a/charts/fluent-operator/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/crds/fluentd.fluent.io_outputs.yaml
@@ -1137,6 +1137,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -1202,6 +1206,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -1267,24 +1278,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -1137,6 +1137,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -1202,6 +1206,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -1267,24 +1278,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -1137,6 +1137,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -1202,6 +1206,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -1267,24 +1278,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5210,6 +5210,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -5275,6 +5279,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -5340,24 +5351,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string
@@ -15188,6 +15193,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -15253,6 +15262,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -15318,24 +15334,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5210,6 +5210,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -5275,6 +5279,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -5340,24 +5351,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string
@@ -15188,6 +15193,10 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        dropSingleKey:
+                          description: If a record only has 1 key, then just set the
+                            log line to the value and discard the key.
+                          type: boolean
                         extractKubernetesLabels:
                           description: If set to true, it will add all Kubernetes
                             labels to the Stream labels.
@@ -15253,6 +15262,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        includeThreadLabel:
+                          description: Whether or not to include the fluentd_thread
+                            label when multiple threads are used for flushing
+                          type: boolean
+                        insecure:
+                          description: Disable certificate validation
+                          type: boolean
                         labelKeys:
                           description: Optional list of record keys that will be placed
                             as stream labels. This configuration property is for records
@@ -15318,24 +15334,18 @@ spec:
                                   type: object
                               type: object
                           type: object
-                        tls:
-                          description: Fluentd provides integrated support for Transport
-                            Layer Security (TLS) and it predecessor Secure Sockets
-                            Layer (SSL) respectively.
-                          properties:
-                            caFile:
-                              description: Absolute path to CA certificate file
-                              type: string
-                            crtFile:
-                              description: Absolute path to Certificate file
-                              type: string
-                            insecure:
-                              description: Disable certificate validation
-                              type: boolean
-                            keyFile:
-                              description: Absolute path to private Key file
-                              type: string
-                          type: object
+                        tlsCaCertFile:
+                          description: TlsCaCert defines the CA certificate file for
+                            TLS.
+                          type: string
+                        tlsClientCertFile:
+                          description: TlsClientCert defines the client certificate
+                            file for TLS.
+                          type: string
+                        tlsPrivateKeyFile:
+                          description: TlsPrivateKey defines the client private key
+                            file for TLS.
+                          type: string
                         url:
                           description: Loki URL.
                           type: string


### PR DESCRIPTION
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #522 Made CRD and operator conform to fluentd-loki-output-plugin documentation

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```