### PR TITLE
Update definition of flushThreadCount

### DIFF
--- a/docs/plugins/fluentd/common/buffer.md
+++ b/docs/plugins/fluentd/common/buffer.md
@@ -28,7 +28,7 @@ Buffer defines various parameters for the buffer Plugin
 | flushAtShutdown | Flush parameters This specifies whether to flush/write all buffer chunks on shutdown or not. | *bool |
 | flushMode | FlushMode defines the flush mode: lazy: flushes/writes chunks once per timekey interval: flushes/writes chunks per specified time via flush_interval immediate: flushes/writes chunks immediately after events are appended into chunks default: equals to lazy if time is specified as chunk key, interval otherwise | *string |
 | flushInterval | FlushInterval defines the flush interval | *string |
-| flushThreadCount | The sleep interval (seconds) for threads to wait for the next flush try(when no chunks are waiting) | *string |
+| flushThreadCount | The number of threads to flush/write chunks in parallel | *integer |
 | delayedCommitTimeout | The timeout (seconds) until output plugin decides if the async write operation has failed. Default is 60s | *string |
 | overflowAction | OverflowAtction defines the output plugin behave when its buffer queue is full. Default: throw_exception | *string |
 | retryTimeout | Retry parameters The maximum time (seconds) to retry to flush again the failed chunks, until the plugin discards the buffer chunks | *string |


### PR DESCRIPTION
Signed-off-by: Samantha Castille <54690345+samanthacastille@users.noreply.github.com>

### What this PR does / why we need it:
Fixes a discrepancy between definitions of `flushThreadCount` between this file and online fluent documentation. According to the issue I submitted, online docs prevail.

### Which issue(s) this PR fixes:
Fixes #489 

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs
https://docs.fluentd.org/configuration/buffer-section#buffering-parameters
```