### PR TITLE
adding support for labels for fluent-bit pods 

### DIFF
--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -26,7 +26,7 @@ func MakeDaemonSet(fb fluentbitv1alpha2.FluentBit, logPath string) appsv1.Daemon
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        fb.Name,
 					Namespace:   fb.Namespace,
-					Labels:      fb.Labels,
+					Labels:      fb.Spec.Labels,
 					Annotations: fb.Spec.Annotations,
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
Signed-off-by: chengdehao <dehaocheng@kubesphere.io>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
In the pr https://github.com/fluent/fluent-operator/pull/468, we added the label field, but not to the generated deployment file, and this pr is to fix that error.