### PR TITLE
exclude docs from github action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,18 @@ on:
     branches:
       - 'master'
       - 'release-*'
-
+    paths:
+      - ".github/workflows/build-op-image.yaml"
+      - "apis/**"
+      - "cmd/**"
+      - "controllers/**"
+      - "hack/**"
+      - "manifests/setup/setup.yaml"
+      - "tests/**"
+      - "pkg/**"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
 jobs:
   basic_tests:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Signed-off-by: Benjamin Huo <benjamin@kubesphere.io>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```