### PR TITLE
Adding Azure Blob output plugin

### DIFF
--- a/apis/fluentbit/v1alpha2/clusteroutput_types.go
+++ b/apis/fluentbit/v1alpha2/clusteroutput_types.go
@@ -44,7 +44,7 @@ type OutputSpec struct {
 	// Used in metrics for distinction of each configured output.
 	Alias string `json:"alias,omitempty"`
 	// AzureBlob defines AzureBlob Output Configuration
-	AzureBlob *output.AzureBlob `json:"azureblob,omitempty"`
+	AzureBlob *output.AzureBlob `json:"azureBlob,omitempty"`
 	// RetryLimit represents configuration for the scheduler which can be set independently on each output section.
 	// This option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit.
 	RetryLimit string `json:"retry_limit,omitempty"`

--- a/apis/fluentbit/v1alpha2/clusteroutput_types.go
+++ b/apis/fluentbit/v1alpha2/clusteroutput_types.go
@@ -43,6 +43,8 @@ type OutputSpec struct {
 	// A user friendly alias name for this output plugin.
 	// Used in metrics for distinction of each configured output.
 	Alias string `json:"alias,omitempty"`
+	// AzureBlob defines AzureBlob Output Configuration
+	AzureBlob *output.AzureBlob `json:"azureblob,omitempty"`
 	// RetryLimit represents configuration for the scheduler which can be set independently on each output section.
 	// This option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit.
 	RetryLimit string `json:"retry_limit,omitempty"`

--- a/apis/fluentbit/v1alpha2/plugins/output/azure_blob_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/azure_blob_types.go
@@ -1,0 +1,74 @@
+package output
+
+import (
+	"fmt"
+
+	"github.com/fluent/fluent-operator/apis/fluentbit/v1alpha2/plugins"
+	"github.com/fluent/fluent-operator/apis/fluentbit/v1alpha2/plugins/params"
+)
+
+// +kubebuilder:object:generate:=true
+
+// Azure Blob is the Azure Blob output plugin, allows to ingest your records into Azure Blob Storage.
+type AzureBlob struct {
+	// Azure Storage account name
+	AccountName string `json:"account_name,omitempty"`
+	// Specify the Azure Storage Shared Key to authenticate against the storage account
+	SharedKey *plugins.Secret `json:"shared_key,omitempty"`
+	// Name of the container that will contain the blobs
+	ContainerName string `json:"container_name,omitempty"`
+	// Specify the desired blob type. Must be `appendblob` or `blockblob`
+	BlobType string `json:"blob_type,omitempty"`
+	// Creates container if ContainerName is not set.
+	AutoCreateContainer *bool `json:"auto_create_container,omitempty"`
+	// Optional path to store the blobs.
+	Path string `json:"path,omitempty"`
+	// Optional toggle to use an Azure emulator
+	EmulatorMode *bool `json:"emulator_mode,omitempty"`
+	// HTTP Service of the endpoint (if using EmulatorMode)
+	Endpoint string `json:"endpoint,omitempty"`
+	// Enable/Disable TLS Encryption. Azure services require TLS to be enabled.
+	TLS *bool `json:"tls,omitempty"`
+}
+
+// Name implement Section() method
+func (_ *AzureBlob) Name() string {
+	return "azureblob"
+}
+
+// Params implement Section() method
+func (o *AzureBlob) Params(sl plugins.SecretLoader) (*params.KVs, error) {
+	kvs := params.NewKVs()
+	if o.AccountName != "" {
+		kvs.Insert("account_name", o.AccountName)
+	}
+	if o.SharedKey != nil {
+		u, err := sl.LoadSecret(*o.SharedKey)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Insert("shared_key", u)
+	}
+	if o.ContainerName != "" {
+		kvs.Insert("container_name", o.ContainerName)
+	}
+	if o.BlobType != "" {
+		kvs.Insert("blob_type", o.BlobType)
+	}
+	if o.AutoCreateContainer != nil {
+		kvs.Insert("auto_create_container", fmt.Sprint(*o.AutoCreateContainer))
+	}
+	if o.Path != "" {
+		kvs.Insert("path", o.Path)
+	}
+	if o.EmulatorMode != nil {
+		kvs.Insert("emulator_mode", fmt.Sprint(*o.EmulatorMode))
+	}
+	if o.Endpoint != "" {
+		kvs.Insert("endpoint", o.Endpoint)
+	}
+	if o.TLS != nil {
+		kvs.Insert("tls", fmt.Sprint(*o.TLS))
+	}
+	return kvs, nil
+}

--- a/apis/fluentbit/v1alpha2/plugins/output/azure_blob_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/azure_blob_types.go
@@ -12,19 +12,19 @@ import (
 // Azure Blob is the Azure Blob output plugin, allows to ingest your records into Azure Blob Storage.
 type AzureBlob struct {
 	// Azure Storage account name
-	AccountName string `json:"account_name,omitempty"`
+	AccountName string `json:"accountName"`
 	// Specify the Azure Storage Shared Key to authenticate against the storage account
-	SharedKey *plugins.Secret `json:"shared_key,omitempty"`
+	SharedKey *plugins.Secret `json:"sharedKey"`
 	// Name of the container that will contain the blobs
-	ContainerName string `json:"container_name,omitempty"`
+	ContainerName string `json:"containerName"`
 	// Specify the desired blob type. Must be `appendblob` or `blockblob`
-	BlobType string `json:"blob_type,omitempty"`
+	BlobType string `json:"blobType,omitempty"`
 	// Creates container if ContainerName is not set.
-	AutoCreateContainer *bool `json:"auto_create_container,omitempty"`
+	AutoCreateContainer *bool `json:"autoCreateContainer,omitempty"`
 	// Optional path to store the blobs.
 	Path string `json:"path,omitempty"`
 	// Optional toggle to use an Azure emulator
-	EmulatorMode *bool `json:"emulator_mode,omitempty"`
+	EmulatorMode *bool `json:"emulatorMode,omitempty"`
 	// HTTP Service of the endpoint (if using EmulatorMode)
 	Endpoint string `json:"endpoint,omitempty"`
 	// Enable/Disable TLS Encryption. Azure services require TLS to be enabled.

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -45,20 +45,20 @@ spec:
               azureblob:
                 description: AzureBlob defines AzureBlob Output Configuration
                 properties:
-                  account_name:
+                  accountName:
                     description: Azure Storage account name
                     type: string
-                  auto_create_container:
+                  autoCreateContainer:
                     description: Creates container if ContainerName is not set.
                     type: boolean
-                  blob_type:
+                  blobType:
                     description: Specify the desired blob type. Must be `appendblob`
                       or `blockblob`
                     type: string
-                  container_name:
+                  containerName:
                     description: Name of the container that will contain the blobs
                     type: string
-                  emulator_mode:
+                  emulatorMode:
                     description: Optional toggle to use an Azure emulator
                     type: boolean
                   endpoint:
@@ -67,7 +67,7 @@ spec:
                   path:
                     description: Optional path to store the blobs.
                     type: string
-                  shared_key:
+                  sharedKey:
                     description: Specify the Azure Storage Shared Key to authenticate
                       against the storage account
                     properties:
@@ -99,6 +99,10 @@ spec:
                     description: Enable/Disable TLS Encryption. Azure services require
                       TLS to be enabled.
                     type: boolean
+                required:
+                - accountName
+                - containerName
+                - sharedKey
                 type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -42,6 +42,64 @@ spec:
                 description: A user friendly alias name for this output plugin. Used
                   in metrics for distinction of each configured output.
                 type: string
+              azureblob:
+                description: AzureBlob defines AzureBlob Output Configuration
+                properties:
+                  account_name:
+                    description: Azure Storage account name
+                    type: string
+                  auto_create_container:
+                    description: Creates container if ContainerName is not set.
+                    type: boolean
+                  blob_type:
+                    description: Specify the desired blob type. Must be `appendblob`
+                      or `blockblob`
+                    type: string
+                  container_name:
+                    description: Name of the container that will contain the blobs
+                    type: string
+                  emulator_mode:
+                    description: Optional toggle to use an Azure emulator
+                    type: boolean
+                  endpoint:
+                    description: HTTP Service of the endpoint (if using EmulatorMode)
+                    type: string
+                  path:
+                    description: Optional path to store the blobs.
+                    type: string
+                  shared_key:
+                    description: Specify the Azure Storage Shared Key to authenticate
+                      against the storage account
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  tls:
+                    description: Enable/Disable TLS Encryption. Azure services require
+                      TLS to be enabled.
+                    type: boolean
+                type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.
                 properties:

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -45,20 +45,20 @@ spec:
               azureblob:
                 description: AzureBlob defines AzureBlob Output Configuration
                 properties:
-                  account_name:
+                  accountName:
                     description: Azure Storage account name
                     type: string
-                  auto_create_container:
+                  autoCreateContainer:
                     description: Creates container if ContainerName is not set.
                     type: boolean
-                  blob_type:
+                  blobType:
                     description: Specify the desired blob type. Must be `appendblob`
                       or `blockblob`
                     type: string
-                  container_name:
+                  containerName:
                     description: Name of the container that will contain the blobs
                     type: string
-                  emulator_mode:
+                  emulatorMode:
                     description: Optional toggle to use an Azure emulator
                     type: boolean
                   endpoint:
@@ -67,7 +67,7 @@ spec:
                   path:
                     description: Optional path to store the blobs.
                     type: string
-                  shared_key:
+                  sharedKey:
                     description: Specify the Azure Storage Shared Key to authenticate
                       against the storage account
                     properties:
@@ -99,6 +99,10 @@ spec:
                     description: Enable/Disable TLS Encryption. Azure services require
                       TLS to be enabled.
                     type: boolean
+                required:
+                - accountName
+                - containerName
+                - sharedKey
                 type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -42,6 +42,64 @@ spec:
                 description: A user friendly alias name for this output plugin. Used
                   in metrics for distinction of each configured output.
                 type: string
+              azureblob:
+                description: AzureBlob defines AzureBlob Output Configuration
+                properties:
+                  account_name:
+                    description: Azure Storage account name
+                    type: string
+                  auto_create_container:
+                    description: Creates container if ContainerName is not set.
+                    type: boolean
+                  blob_type:
+                    description: Specify the desired blob type. Must be `appendblob`
+                      or `blockblob`
+                    type: string
+                  container_name:
+                    description: Name of the container that will contain the blobs
+                    type: string
+                  emulator_mode:
+                    description: Optional toggle to use an Azure emulator
+                    type: boolean
+                  endpoint:
+                    description: HTTP Service of the endpoint (if using EmulatorMode)
+                    type: string
+                  path:
+                    description: Optional path to store the blobs.
+                    type: string
+                  shared_key:
+                    description: Specify the Azure Storage Shared Key to authenticate
+                      against the storage account
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  tls:
+                    description: Enable/Disable TLS Encryption. Azure services require
+                      TLS to be enabled.
+                    type: boolean
+                type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.
                 properties:

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -272,7 +272,7 @@ OutputSpec defines the desired state of ClusterOutput
 | match | A pattern to match against the tags of incoming records. It's case sensitive and support the star (*) character as a wildcard. | string |
 | matchRegex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax. | string |
 | alias | A user friendly alias name for this output plugin. Used in metrics for distinction of each configured output. | string |
-| azureblob | AzureBlob defines AzureBlob Output Configuration | *[output.AzureBlob](plugins/output/azureblob.md) |
+| azureBlob | AzureBlob defines AzureBlob Output Configuration | *[output.AzureBlob](plugins/output/azureblob.md) |
 | retry_limit | RetryLimit represents configuration for the scheduler which can be set independently on each output section. This option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit. | string |
 | es | Elasticsearch defines Elasticsearch Output configuration. | *[output.Elasticsearch](plugins/output/elasticsearch.md) |
 | file | File defines File Output configuration. | *[output.File](plugins/output/file.md) |

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -272,6 +272,7 @@ OutputSpec defines the desired state of ClusterOutput
 | match | A pattern to match against the tags of incoming records. It's case sensitive and support the star (*) character as a wildcard. | string |
 | matchRegex | A regular expression to match against the tags of incoming records. Use this option if you want to use the full regex syntax. | string |
 | alias | A user friendly alias name for this output plugin. Used in metrics for distinction of each configured output. | string |
+| azureblob | AzureBlob defines AzureBlob Output Configuration | *[output.AzureBlob](plugins/output/azureblob.md) |
 | retry_limit | RetryLimit represents configuration for the scheduler which can be set independently on each output section. This option allows to disable retries or impose a limit to try N times and then discard the data after reaching that limit. | string |
 | es | Elasticsearch defines Elasticsearch Output configuration. | *[output.Elasticsearch](plugins/output/elasticsearch.md) |
 | file | File defines File Output configuration. | *[output.File](plugins/output/file.md) |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -2009,20 +2009,20 @@ spec:
               azureblob:
                 description: AzureBlob defines AzureBlob Output Configuration
                 properties:
-                  account_name:
+                  accountName:
                     description: Azure Storage account name
                     type: string
-                  auto_create_container:
+                  autoCreateContainer:
                     description: Creates container if ContainerName is not set.
                     type: boolean
-                  blob_type:
+                  blobType:
                     description: Specify the desired blob type. Must be `appendblob`
                       or `blockblob`
                     type: string
-                  container_name:
+                  containerName:
                     description: Name of the container that will contain the blobs
                     type: string
-                  emulator_mode:
+                  emulatorMode:
                     description: Optional toggle to use an Azure emulator
                     type: boolean
                   endpoint:
@@ -2031,7 +2031,7 @@ spec:
                   path:
                     description: Optional path to store the blobs.
                     type: string
-                  shared_key:
+                  sharedKey:
                     description: Specify the Azure Storage Shared Key to authenticate
                       against the storage account
                     properties:
@@ -2063,6 +2063,10 @@ spec:
                     description: Enable/Disable TLS Encryption. Azure services require
                       TLS to be enabled.
                     type: boolean
+                required:
+                - accountName
+                - containerName
+                - sharedKey
                 type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -2006,6 +2006,64 @@ spec:
                 description: A user friendly alias name for this output plugin. Used
                   in metrics for distinction of each configured output.
                 type: string
+              azureblob:
+                description: AzureBlob defines AzureBlob Output Configuration
+                properties:
+                  account_name:
+                    description: Azure Storage account name
+                    type: string
+                  auto_create_container:
+                    description: Creates container if ContainerName is not set.
+                    type: boolean
+                  blob_type:
+                    description: Specify the desired blob type. Must be `appendblob`
+                      or `blockblob`
+                    type: string
+                  container_name:
+                    description: Name of the container that will contain the blobs
+                    type: string
+                  emulator_mode:
+                    description: Optional toggle to use an Azure emulator
+                    type: boolean
+                  endpoint:
+                    description: HTTP Service of the endpoint (if using EmulatorMode)
+                    type: string
+                  path:
+                    description: Optional path to store the blobs.
+                    type: string
+                  shared_key:
+                    description: Specify the Azure Storage Shared Key to authenticate
+                      against the storage account
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  tls:
+                    description: Enable/Disable TLS Encryption. Azure services require
+                      TLS to be enabled.
+                    type: boolean
+                type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.
                 properties:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -2009,20 +2009,20 @@ spec:
               azureblob:
                 description: AzureBlob defines AzureBlob Output Configuration
                 properties:
-                  account_name:
+                  accountName:
                     description: Azure Storage account name
                     type: string
-                  auto_create_container:
+                  autoCreateContainer:
                     description: Creates container if ContainerName is not set.
                     type: boolean
-                  blob_type:
+                  blobType:
                     description: Specify the desired blob type. Must be `appendblob`
                       or `blockblob`
                     type: string
-                  container_name:
+                  containerName:
                     description: Name of the container that will contain the blobs
                     type: string
-                  emulator_mode:
+                  emulatorMode:
                     description: Optional toggle to use an Azure emulator
                     type: boolean
                   endpoint:
@@ -2031,7 +2031,7 @@ spec:
                   path:
                     description: Optional path to store the blobs.
                     type: string
-                  shared_key:
+                  sharedKey:
                     description: Specify the Azure Storage Shared Key to authenticate
                       against the storage account
                     properties:
@@ -2063,6 +2063,10 @@ spec:
                     description: Enable/Disable TLS Encryption. Azure services require
                       TLS to be enabled.
                     type: boolean
+                required:
+                - accountName
+                - containerName
+                - sharedKey
                 type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -2006,6 +2006,64 @@ spec:
                 description: A user friendly alias name for this output plugin. Used
                   in metrics for distinction of each configured output.
                 type: string
+              azureblob:
+                description: AzureBlob defines AzureBlob Output Configuration
+                properties:
+                  account_name:
+                    description: Azure Storage account name
+                    type: string
+                  auto_create_container:
+                    description: Creates container if ContainerName is not set.
+                    type: boolean
+                  blob_type:
+                    description: Specify the desired blob type. Must be `appendblob`
+                      or `blockblob`
+                    type: string
+                  container_name:
+                    description: Name of the container that will contain the blobs
+                    type: string
+                  emulator_mode:
+                    description: Optional toggle to use an Azure emulator
+                    type: boolean
+                  endpoint:
+                    description: HTTP Service of the endpoint (if using EmulatorMode)
+                    type: string
+                  path:
+                    description: Optional path to store the blobs.
+                    type: string
+                  shared_key:
+                    description: Specify the Azure Storage Shared Key to authenticate
+                      against the storage account
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    type: object
+                  tls:
+                    description: Enable/Disable TLS Encryption. Azure services require
+                      TLS to be enabled.
+                    type: boolean
+                type: object
               customPlugin:
                 description: CustomPlugin defines Custom Output configuration.
                 properties:


### PR DESCRIPTION
### What this PR does / why we need it:

PR creates an Azure Blob Output plugin, needed as part of the fluent-operator roadmap to add more output plugins.

### Which issue(s) this PR fixes:
Fixes #547

Let me know what I've (likely) missed/done wrong and happy to fix 👍🏻 