### PR TITLE
feat: add ability to customize metrics port

### DIFF
--- a/apis/fluentbit/v1alpha2/fluentbit_types.go
+++ b/apis/fluentbit/v1alpha2/fluentbit_types.go
@@ -88,7 +88,7 @@ type FluentBitSpec struct {
 	// Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are
 	// 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
 	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
-	// Set the port used by the metrics server
+	// MetricsPort is the port used by the metrics server. If this option is set, HttpPort from ClusterFluentBitConfig needs to match this value. Default is 2020.
 	MetricsPort int32 `json:"metricsPort,omitempty"`
 }
 

--- a/apis/fluentbit/v1alpha2/fluentbit_types.go
+++ b/apis/fluentbit/v1alpha2/fluentbit_types.go
@@ -88,6 +88,8 @@ type FluentBitSpec struct {
 	// Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are
 	// 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
 	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+	// Set the port used by the metrics server
+	MetricsPort int32 `json:"metricsPort,omitempty"`
 }
 
 // FluentBitStatus defines the observed state of FluentBit

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -2399,6 +2399,10 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              metricsPort:
+                description: Set the port used by the metrics server
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
@@ -2399,6 +2399,10 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              metricsPort:
+                description: Set the port used by the metrics server
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -309,7 +309,7 @@ FluentBitSpec defines the desired state of FluentBit
 | ports | Ports represents the pod's ports. | []corev1.ContainerPort |
 | rbacRules | RBACRules represents additional rbac rules which will be applied to the fluent-bit clusterrole. | []rbacv1.PolicyRule |
 | dnsPolicy | Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. | corev1.DNSPolicy |
-| metricsPort | Set the port used by the metrics server | int32 |
+| metricsPort | MetricsPort is the port used by the metrics server. If this option is set, HttpPort from ClusterFluentBitConfig needs to match this value. Default is 2020. | int32 |
 
 [Back to TOC](#table-of-contents)
 # InputSpec

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -309,6 +309,7 @@ FluentBitSpec defines the desired state of FluentBit
 | ports | Ports represents the pod's ports. | []corev1.ContainerPort |
 | rbacRules | RBACRules represents additional rbac rules which will be applied to the fluent-bit clusterrole. | []rbacv1.PolicyRule |
 | dnsPolicy | Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. | corev1.DNSPolicy |
+| metricsPort | Set the port used by the metrics server | int32 |
 
 [Back to TOC](#table-of-contents)
 # InputSpec

--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -17,6 +17,14 @@ func MakeDaemonSet(fb fluentbitv1alpha2.FluentBit, logPath string) appsv1.Daemon
 	} else {
 		labels = fb.Labels
 	}
+
+	var metricsPort int32
+	if fb.Spec.MetricsPort != 0 {
+		metricsPort = fb.Spec.MetricsPort
+	} else {
+		metricsPort = 2020
+	}
+
 	ds := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fb.Name,
@@ -81,7 +89,7 @@ func MakeDaemonSet(fb fluentbitv1alpha2.FluentBit, logPath string) appsv1.Daemon
 							Ports: []corev1.ContainerPort{
 								{
 									Name:          "metrics",
-									ContainerPort: 2020,
+									ContainerPort: metricsPort,
 									Protocol:      "TCP",
 								},
 							},

--- a/pkg/operator/fluent-bit-service.go
+++ b/pkg/operator/fluent-bit-service.go
@@ -10,11 +10,18 @@ import (
 
 const (
 	FluentBitMetricsPortName = "metrics"
-	FluentBitMetricsPort     = 2020
 	FluentBitTCPProtocolName = "TCP"
 )
 
 func MakeFluentbitService(fb fluentbitv1alpha2.FluentBit) corev1.Service {
+
+	var FluentBitMetricsPort int32
+	if fb.Spec.MetricsPort != 0 {
+		FluentBitMetricsPort = fb.Spec.MetricsPort
+	} else {
+		FluentBitMetricsPort = 2020
+	}
+
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fb.Name,
@@ -29,7 +36,7 @@ func MakeFluentbitService(fb fluentbitv1alpha2.FluentBit) corev1.Service {
 					Name:       FluentBitMetricsPortName,
 					Port:       FluentBitMetricsPort,
 					Protocol:   FluentBitTCPProtocolName,
-					TargetPort: intstr.FromInt(FluentBitMetricsPort),
+					TargetPort: intstr.FromInt(int(FluentBitMetricsPort)),
 				},
 			},
 		},


### PR DESCRIPTION
### What this PR does / why we need it:
This change allows a user to specify a metrics port as part of their `FluentBit` custom resource.  This is useful for those who need to use a port other than 2020.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added the optional `metricsPort` property in the `FluentBit` custom resource allowing users to specify a port.  Port 2020 will be used by default if this property is not set.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
An example of a partial FluentBit resource with this new property might look like this:

apiVersion: fluentbit.fluent.io/v1alpha2
kind: FluentBit
metadata:
  name: fluent-bit
  namespace: fluent
  labels:
    app.kubernetes.io/name: fluent-bit
spec:
  image: kubesphere/fluent-bit:v2.0.9
  metricsPort: 32020

```