### PR TITLE
config: run "make manifests" to generate metricsPort

### DIFF
--- a/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -2400,7 +2400,9 @@ spec:
                     type: integer
                 type: object
               metricsPort:
-                description: Set the port used by the metrics server
+                description: MetricsPort is the port used by the metrics server. If
+                  this option is set, HttpPort from ClusterFluentBitConfig needs to
+                  match this value. Default is 2020.
                 format: int32
                 type: integer
               nodeSelector:

--- a/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
@@ -2400,7 +2400,9 @@ spec:
                     type: integer
                 type: object
               metricsPort:
-                description: Set the port used by the metrics server
+                description: MetricsPort is the port used by the metrics server. If
+                  this option is set, HttpPort from ClusterFluentBitConfig needs to
+                  match this value. Default is 2020.
                 format: int32
                 type: integer
               nodeSelector:

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -11852,6 +11852,12 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              metricsPort:
+                description: MetricsPort is the port used by the metrics server. If
+                  this option is set, HttpPort from ClusterFluentBitConfig needs to
+                  match this value. Default is 2020.
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -11852,6 +11852,12 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              metricsPort:
+                description: MetricsPort is the port used by the metrics server. If
+                  this option is set, HttpPort from ClusterFluentBitConfig needs to
+                  match this value. Default is 2020.
+                format: int32
+                type: integer
               nodeSelector:
                 additionalProperties:
                   type: string


### PR DESCRIPTION
### What this PR does / why we need it:
Update the manifests that should have been updated with https://github.com/fluent/fluent-operator/pull/587 for the `metricsPort` addition.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```