### PR TITLE
Make default ClusterInputs optional and configurable

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.input.systemd.enable -}}
 apiVersion: fluentbit.fluent.io/v1alpha2
 kind: ClusterInput
 metadata:
@@ -9,10 +10,13 @@ metadata:
 spec:
   systemd:
     tag: service.*
-    path: /var/log/journal
+    path: {{ .Values.fluentbit.input.systemd.path }}
     db: /fluent-bit/tail/systemd.db
     dbSync: Normal
     systemdFilter:
       - _SYSTEMD_UNIT={{ .Values.containerRuntime }}.service
+      {{- if .Values.fluentbit.input.systemd.includeKubelet }}
       - _SYSTEMD_UNIT=kubelet.service
+      {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.input.tail.enable -}}
 apiVersion: fluentbit.fluent.io/v1alpha2
 kind: ClusterInput
 metadata:
@@ -9,7 +10,7 @@ metadata:
 spec:
   tail:
     tag: kube.*
-    path: /var/log/containers/*.log
+    path: {{ .Values.fluentbit.input.tail.path }}
     {{- if eq .Values.containerRuntime "docker" }}
     parser: docker
     {{- else if eq .Values.containerRuntime "containerd" }}
@@ -17,9 +18,10 @@ spec:
     {{- else if eq .Values.containerRuntime "crio" }}
     parser: cri
     {{- end }}
-    refreshIntervalSeconds: 10
+    refreshIntervalSeconds: {{ .Values.fluentbit.input.tail.refreshIntervalSeconds }}
     memBufLimit: {{ .Values.fluentbit.input.tail.memBufLimit }}
-    skipLongLines: true
+    skipLongLines: {{ .Values.fluentbit.input.tail.skipLongLines }}
     db: /fluent-bit/tail/pos.db
     dbSync: Normal
+{{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -98,7 +98,15 @@ fluentbit:
   #if the inbound traffic is less than 13.64Mbps, setting memBufLimit to 50MB is enough
   input:
     tail:
+      enable: true
+      refreshIntervalSeconds: 10
       memBufLimit: 5MB
+      path: "/var/log/containers/*.log"
+      skipLongLines: true
+    systemd:
+      enable: true
+      path: "/var/log/journal"
+      includeKubelet: true
     nodeExporterMetrics: {}
     # uncomment below nodeExporterMetrics section if you want to collect node exporter metrics
 #   nodeExporterMetrics:


### PR DESCRIPTION
### What this PR does / why we need it:
Make default ClusterInputs optional and configurable as already done for ClusterFilter objects.

### Which issue(s) this PR fixes:
Fixes [#594](https://github.com/fluent/fluent-operator/issues/594)

### Does this PR introduced a user-facing change?
```release-note
Make default ClusterInputs optional and configurable
```

### Additional documentation, usage docs, etc.:
```docs

```