### PR TITLE
feat: Enable fluentbit healthcheck

### DIFF
--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
@@ -58,13 +58,12 @@ type Service struct {
 	HcErrorsCount *int64 `json:"hcErrorsCount,omitempty"`
 	// the retry failure count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for retry failure: [2022/02/16 20:11:36] [ warn] [engine] chunk '1-1645042288.260516436.flb' cannot be retried: task_id=0, input=tcp.3 > output=cloudwatch_logs.1
 	// +kubebuilder:validation:Minimum:=1
-    HcRetryFailureCount *int64 `json:"hcRetryFailureCount,omitempty"`
+	HcRetryFailureCount *int64 `json:"hcRetryFailureCount,omitempty"`
 	// The time period by second to count the error and retry failure data point
 	// +kubebuilder:validation:Minimum:=1
-    HcPeriod *int64 `json:"hcPeriod,omitempty"`
-	// enable Health check feature
+	HcPeriod *int64 `json:"hcPeriod,omitempty"`
+	// enable Health check feature at http://127.0.0.1:2020/api/v1/health Note: Enabling this will not automatically configure kubernetes to use fluentbit's healthcheck endpoint
 	HealthCheck *bool `json:"healthCheck,omitempty"`
-	
 	// Address to listen
 	// +kubebuilder:validation:Pattern:="^\\d{1,3}.\\d{1,3}.\\d{1,3}.\\d{1,3}$"
 	HttpListen string `json:"httpListen,omitempty"`
@@ -121,16 +120,16 @@ func (s *Service) Params() *params.KVs {
 		m.Insert("Grace", fmt.Sprint(*s.GraceSeconds))
 	}
 	if s.HcErrorsCount != nil {
-		m.Insert("HC_Errors_Count",fmt.Sprint(*s.HcErrorsCount))
+		m.Insert("HC_Errors_Count", fmt.Sprint(*s.HcErrorsCount))
 	}
 	if s.HcRetryFailureCount != nil {
-		m.Insert("HC_Retry_Failure_Count",fmt.Sprint(*s.HcRetryFailureCount))
+		m.Insert("HC_Retry_Failure_Count", fmt.Sprint(*s.HcRetryFailureCount))
 	}
 	if s.HcPeriod != nil {
-		m.Insert("HC_Period",fmt.Sprint(*s.HcPeriod))
+		m.Insert("HC_Period", fmt.Sprint(*s.HcPeriod))
 	}
 	if s.HealthCheck != nil {
-		m.Insert("Health_Check",fmt.Sprint(*s.HealthCheck))
+		m.Insert("Health_Check", fmt.Sprint(*s.HealthCheck))
 	}
 	if s.HttpListen != "" {
 		m.Insert("Http_Listen", s.HttpListen)

--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
@@ -53,6 +53,18 @@ type Service struct {
 	FlushSeconds *int64 `json:"flushSeconds,omitempty"`
 	// Wait time on exit
 	GraceSeconds *int64 `json:"graceSeconds,omitempty"`
+	// the error count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for output error: [2022/02/16 10:44:10] [ warn] [engine] failed to flush chunk '1-1645008245.491540684.flb', retry in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3 (out_id=3)
+	// +kubebuilder:validation:Minimum:=1
+	HcErrorsCount *int64 `json:"hcErrorsCount,omitempty"`
+	// the retry failure count to meet the unhealthy requirement, this is a sum for all output plugins in a defined HC_Period, example for retry failure: [2022/02/16 20:11:36] [ warn] [engine] chunk '1-1645042288.260516436.flb' cannot be retried: task_id=0, input=tcp.3 > output=cloudwatch_logs.1
+	// +kubebuilder:validation:Minimum:=1
+    HcRetryFailureCount *int64 `json:"hcRetryFailureCount,omitempty"`
+	// The time period by second to count the error and retry failure data point
+	// +kubebuilder:validation:Minimum:=1
+    HcPeriod *int64 `json:"hcPeriod,omitempty"`
+	// enable Health check feature
+	HealthCheck *bool `json:"healthCheck,omitempty"`
+	
 	// Address to listen
 	// +kubebuilder:validation:Pattern:="^\\d{1,3}.\\d{1,3}.\\d{1,3}.\\d{1,3}$"
 	HttpListen string `json:"httpListen,omitempty"`
@@ -107,6 +119,18 @@ func (s *Service) Params() *params.KVs {
 	}
 	if s.GraceSeconds != nil {
 		m.Insert("Grace", fmt.Sprint(*s.GraceSeconds))
+	}
+	if s.HcErrorsCount != nil {
+		m.Insert("HC_Errors_Count",fmt.Sprint(*s.HcErrorsCount))
+	}
+	if s.HcRetryFailureCount != nil {
+		m.Insert("HC_Retry_Failure_Count",fmt.Sprint(*s.HcRetryFailureCount))
+	}
+	if s.HcPeriod != nil {
+		m.Insert("HC_Period",fmt.Sprint(*s.HcPeriod))
+	}
+	if s.HealthCheck != nil {
+		m.Insert("Health_Check",fmt.Sprint(*s.HealthCheck))
 	}
 	if s.HttpListen != "" {
 		m.Insert("Http_Listen", s.HttpListen)

--- a/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
@@ -1052,6 +1052,26 @@ func (in *Service) DeepCopyInto(out *Service) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.HcErrorsCount != nil {
+		in, out := &in.HcErrorsCount, &out.HcErrorsCount
+		*out = new(int64)
+		**out = **in
+	}
+	if in.HcRetryFailureCount != nil {
+		in, out := &in.HcRetryFailureCount, &out.HcRetryFailureCount
+		*out = new(int64)
+		**out = **in
+	}
+	if in.HcPeriod != nil {
+		in, out := &in.HcPeriod, &out.HcPeriod
+		*out = new(int64)
+		**out = **in
+	}
+	if in.HealthCheck != nil {
+		in, out := &in.HealthCheck, &out.HealthCheck
+		*out = new(bool)
+		**out = **in
+	}
 	if in.HttpPort != nil {
 		in, out := &in.HttpPort, &out.HttpPort
 		*out = new(int32)

--- a/apis/generated/clientset/versioned/clientset.go
+++ b/apis/generated/clientset/versioned/clientset.go
@@ -34,8 +34,7 @@ type Interface interface {
 	FluentdV1alpha1() fluentdv1alpha1.FluentdV1alpha1Interface
 }
 
-// Clientset contains the clients for groups. Each group has exactly one
-// version included in a Clientset.
+// Clientset contains the clients for groups.
 type Clientset struct {
 	*discovery.DiscoveryClient
 	fluentbitV1alpha2 *fluentbitv1alpha2.FluentbitV1alpha2Client

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -235,6 +235,34 @@ spec:
                     description: Wait time on exit
                     format: int64
                     type: integer
+                  hcErrorsCount:
+                    description: 'the error count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for output error: [2022/02/16 10:44:10] [ warn] [engine]
+                      failed to flush chunk ''1-1645008245.491540684.flb'', retry
+                      in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3
+                      (out_id=3)'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcPeriod:
+                    description: The time period by second to count the error and
+                      retry failure data point
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcRetryFailureCount:
+                    description: 'the retry failure count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for retry failure: [2022/02/16 20:11:36] [ warn] [engine]
+                      chunk ''1-1645042288.260516436.flb'' cannot be retried: task_id=0,
+                      input=tcp.3 > output=cloudwatch_logs.1'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  healthCheck:
+                    description: enable Health check feature
+                    type: boolean
                   httpListen:
                     description: Address to listen
                     pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -261,7 +261,9 @@ spec:
                     minimum: 1
                     type: integer
                   healthCheck:
-                    description: enable Health check feature
+                    description: 'enable Health check feature at http://127.0.0.1:2020/api/v1/health
+                      Note: Enabling this will not automatically configure kubernetes
+                      to use fluentbit''s healthcheck endpoint'
                     type: boolean
                   httpListen:
                     description: Address to listen

--- a/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -235,6 +235,34 @@ spec:
                     description: Wait time on exit
                     format: int64
                     type: integer
+                  hcErrorsCount:
+                    description: 'the error count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for output error: [2022/02/16 10:44:10] [ warn] [engine]
+                      failed to flush chunk ''1-1645008245.491540684.flb'', retry
+                      in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3
+                      (out_id=3)'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcPeriod:
+                    description: The time period by second to count the error and
+                      retry failure data point
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcRetryFailureCount:
+                    description: 'the retry failure count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for retry failure: [2022/02/16 20:11:36] [ warn] [engine]
+                      chunk ''1-1645042288.260516436.flb'' cannot be retried: task_id=0,
+                      input=tcp.3 > output=cloudwatch_logs.1'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  healthCheck:
+                    description: enable Health check feature
+                    type: boolean
                   httpListen:
                     description: Address to listen
                     pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$

--- a/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -261,7 +261,9 @@ spec:
                     minimum: 1
                     type: integer
                   healthCheck:
-                    description: enable Health check feature
+                    description: 'enable Health check feature at http://127.0.0.1:2020/api/v1/health
+                      Note: Enabling this will not automatically configure kubernetes
+                      to use fluentbit''s healthcheck endpoint'
                     type: boolean
                   httpListen:
                     description: Address to listen

--- a/go.mod
+++ b/go.mod
@@ -57,12 +57,14 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.4.0 // indirect
 	golang.org/x/term v0.4.0 // indirect
 	golang.org/x/text v0.6.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.2.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
@@ -71,7 +73,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
+	k8s.io/code-generator v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
+	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -342,6 +343,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0 h1:b9gGHsz9/HhJ3HF5DHQytPpuwocVTChQJK3AvoLRD5I=
+golang.org/x/mod v0.6.0/go.mod h1:4mET923SAdbXp2ki8ey+zGs1SLqsuM2Y0uvdZR/fUNI=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -496,6 +499,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -505,6 +509,8 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.2.0 h1:G6AHpWxTMGY1KyEYoAQ5WTtIekUUvDNjan3ugu60JvE=
+golang.org/x/tools v0.2.0/go.mod h1:y4OqIKeOV/fWJetJ8bXPU1sEVniLMIyDAZWeHdV+NTA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -631,8 +637,13 @@ k8s.io/apimachinery v0.26.1 h1:8EZ/eGJL+hY/MYCNwhmDzVqq2lPl3N3Bo8rvweJwXUQ=
 k8s.io/apimachinery v0.26.1/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
 k8s.io/client-go v0.26.1 h1:87CXzYJnAMGaa/IDDfRdhTzxk/wzGZ+/HUQpqgVSZXU=
 k8s.io/client-go v0.26.1/go.mod h1:IWNSglg+rQ3OcvDkhY6+QLeasV4OYHDjdqeWkDQZwGE=
+k8s.io/code-generator v0.26.1 h1:dusFDsnNSKlMFYhzIM0jAO1OlnTN5WYwQQ+Ai12IIlo=
+k8s.io/code-generator v0.26.1/go.mod h1:OMoJ5Dqx1wgaQzKgc+ZWaZPfGjdRq/Y3WubFrZmeI3I=
 k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
 k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d h1:U9tB195lKdzwqicbJvyJeOXV7Klv+wNAWENRnXEGi08=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.90.0 h1:VkTxIV/FjRXn1fgNNcKGM8cfmL1Z33ZjXRTVxKCoF5M=
 k8s.io/klog/v2 v2.90.0/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+OGxg8HsuBr/5f6tVAjDu6E=
@@ -648,5 +659,6 @@ sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -1413,7 +1413,9 @@ spec:
                     minimum: 1
                     type: integer
                   healthCheck:
-                    description: enable Health check feature
+                    description: 'enable Health check feature at http://127.0.0.1:2020/api/v1/health
+                      Note: Enabling this will not automatically configure kubernetes
+                      to use fluentbit''s healthcheck endpoint'
                     type: boolean
                   httpListen:
                     description: Address to listen

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -1387,6 +1387,34 @@ spec:
                     description: Wait time on exit
                     format: int64
                     type: integer
+                  hcErrorsCount:
+                    description: 'the error count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for output error: [2022/02/16 10:44:10] [ warn] [engine]
+                      failed to flush chunk ''1-1645008245.491540684.flb'', retry
+                      in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3
+                      (out_id=3)'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcPeriod:
+                    description: The time period by second to count the error and
+                      retry failure data point
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcRetryFailureCount:
+                    description: 'the retry failure count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for retry failure: [2022/02/16 20:11:36] [ warn] [engine]
+                      chunk ''1-1645042288.260516436.flb'' cannot be retried: task_id=0,
+                      input=tcp.3 > output=cloudwatch_logs.1'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  healthCheck:
+                    description: enable Health check feature
+                    type: boolean
                   httpListen:
                     description: Address to listen
                     pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -1413,7 +1413,9 @@ spec:
                     minimum: 1
                     type: integer
                   healthCheck:
-                    description: enable Health check feature
+                    description: 'enable Health check feature at http://127.0.0.1:2020/api/v1/health
+                      Note: Enabling this will not automatically configure kubernetes
+                      to use fluentbit''s healthcheck endpoint'
                     type: boolean
                   httpListen:
                     description: Address to listen

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -1387,6 +1387,34 @@ spec:
                     description: Wait time on exit
                     format: int64
                     type: integer
+                  hcErrorsCount:
+                    description: 'the error count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for output error: [2022/02/16 10:44:10] [ warn] [engine]
+                      failed to flush chunk ''1-1645008245.491540684.flb'', retry
+                      in 7 seconds: task_id=0, input=forward.1 > output=cloudwatch_logs.3
+                      (out_id=3)'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcPeriod:
+                    description: The time period by second to count the error and
+                      retry failure data point
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  hcRetryFailureCount:
+                    description: 'the retry failure count to meet the unhealthy requirement,
+                      this is a sum for all output plugins in a defined HC_Period,
+                      example for retry failure: [2022/02/16 20:11:36] [ warn] [engine]
+                      chunk ''1-1645042288.260516436.flb'' cannot be retried: task_id=0,
+                      input=tcp.3 > output=cloudwatch_logs.1'
+                    format: int64
+                    minimum: 1
+                    type: integer
+                  healthCheck:
+                    description: enable Health check feature
+                    type: boolean
                   httpListen:
                     description: Address to listen
                     pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR allows to enable the http Healthcheck that is already implemented in fluentbit and described here: https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit . Since the functionality to add liveness probes already exists it would allow users to setup the liveness probes of fluentbit pods in a way that they query the integrated healthcheck.
Users of the fluent-operator could use this to increase the observability and reliability of their fluentbit instances. 
Therefore I believe that this PR is loosely related to #321 . In my eyes it is related in the sense that it allows to enable the healthcheck and theoretically also to expose the healtcheck which could be queried by external tools or setup as kubernetes livenessProbe. 


**I did not test this in action yet.**

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
RelatesTo #321 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
With this update fluentbit can be configured to run a HealthCheck. Please be aware: Enabling the healthcheck here does not configure kubernetes to query it. To use the healthcheck as a liveness probe it needs to be enabled with the steps below AND a liveness probe that does http requests to the address below need to be set up separately.
The healthcheck is a simple Http endpoint on port 2020. From inside the pod it is available by querying http://127.0.0.1:2020/api/v1/health . It will return 200 in case all is good and 500 if not. This healthcheck is a standard fluentbit feature and configurable through the fluent operator. To enable and configure the Healthcheck adapt the values hcErrorsCount, hcRetryFailureCount, hcPeriod and set healthCheck to true. 

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
For details on the fluentbit HealthCheck please check the official documentation here: https://docs.fluentbit.io/manual/administration/monitoring#health-check-for-fluent-bit
```