### PR TITLE
add /finalizers to fluent-operator-clusterRole.yaml to fix openshift …

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -47,11 +47,17 @@ rules:
     resources:
       - collectors
       - fluentbits
+      - fluentbits/finalizers
       - clusterfluentbitconfigs
+      - clusterfluentbitconfigs/finalizers
       - clusterfilters
+      - clusterfilters/finalizers
       - clusterinputs
+      - clusterinputs/finalizers
       - clusteroutputs
+      - clusteroutputs/finalizers
       - clusterparsers
+      - clusterparsers/finalizers
     verbs:
       - create
       - delete


### PR DESCRIPTION
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #425

### Does this PR introduced a user-facing change?
None

### Additional documentation, usage docs, etc.:
This PR fixes the openshift issue #425.
Adding /finalizers to the resources in the cluster-role fluent-operator solved the issue for us.