### PR TITLE
properly exclude fluentbit output when stdout output is enabled

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/templates/fluentbit-clusterfilter-kubernetes.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterfilter-kubernetes.yaml
@@ -14,8 +14,13 @@ spec:
       kubeURL: https://kubernetes.default.svc:443
       kubeCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       kubeTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      labels: {{ .Values.fluentbit.filter.kubernetes.labels }}
-      annotations: {{ .Values.fluentbit.filter.kubernetes.annotations }}
+      {{- $params := omit .Values.fluentbit.filter.kubernetes "enable" }}
+      {{- if .Values.fluentbit.output.stdout.enable }}
+      {{- $_ := set $params "k8sLoggingExclude" true -}}
+      {{- end }}
+      {{- with $params }}
+      {{- . | toYaml | nindent 6 }}
+      {{- end }}
   - nest:
       operation: lift
       nestedUnder: kubernetes

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -38,10 +38,12 @@ spec:
   volumesMounts:
 {{ toYaml .Values.fluentbit.additionalVolumesMounts | indent 4 }}
   {{- end }}
-  {{- if .Values.fluentbit.annotations }}
+  {{- if or .Values.fluentbit.annotations .Values.fluentbit.output.stdout.enable }}
   annotations:
-{{ toYaml .Values.fluentbit.annotations | indent 4 }}
-  {{- if .Values.fluentbit.output.stdout }}
+  {{- with .Values.fluentbit.annotations }}
+{{ toYaml . | indent 4 }}
+  {{- end -}}
+  {{- if .Values.fluentbit.output.stdout.enable }}
     fluentbit.io/exclude: "true"
   {{- end }}
   {{- end }}


### PR DESCRIPTION
### What this PR does / why we need it:

when fluentbit stdout output is enabled:
* `fluentbit.io/exclude` is added to fluentbit. the current check only added the annotation if another annotations was defined
* `k8sLoggingExclude` parameter is added to the kubernetes filter to activate usage of the `fluentbit.io/exclude` annotation


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


### Does this PR introduced a user-facing change?

None


### Additional documentation, usage docs, etc.:
