### PR TITLE
create or patch rbac objects

### DIFF
--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -105,13 +106,13 @@ func (r *FluentBitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := ctrl.SetControllerReference(&fb, saObj, r.Scheme); err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.Create(ctx, rbacObj); err != nil && !errors.IsAlreadyExists(err) {
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, rbacObj, r.mutate(rbacObj, fb)); err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.Create(ctx, saObj); err != nil && !errors.IsAlreadyExists(err) {
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, saObj, r.mutate(saObj, fb)); err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.Create(ctx, bindingObj); err != nil && !errors.IsAlreadyExists(err) {
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, bindingObj, r.mutate(bindingObj, fb)); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -182,6 +183,49 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb fluentbitv1alpha2.Flu
 			}
 			return nil
 		}
+	case *rbacv1.Role:
+		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace)
+
+		return func() error {
+			o.Name = expected.Name
+			o.Rules = expected.Rules
+			return nil
+		}
+	case *rbacv1.ClusterRole:
+		expected, _, _ := operator.MakeRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules)
+		return func() error {
+			o.Name = expected.Name
+			o.Rules = expected.Rules
+			return nil
+		}
+
+	case *corev1.ServiceAccount:
+		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace)
+
+		return func() error {
+			o.Name = expected.Name
+			if err := ctrl.SetControllerReference(&fb, o, r.Scheme); err != nil {
+				return err
+			}
+			return nil
+		}
+	case *rbacv1.RoleBinding:
+		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace)
+		return func() error {
+			o.Name = expected.Name
+			o.Subjects = expected.Subjects
+			o.RoleRef = expected.RoleRef
+			return nil
+		}
+	case *rbacv1.ClusterRoleBinding:
+		_, _, expected := operator.MakeRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules)
+		return func() error {
+			o.Name = expected.Name
+			o.Subjects = expected.Subjects
+			o.RoleRef = expected.RoleRef
+			return nil
+		}
+
 	default:
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it:

In our monitoring stack, we've been noticing that each reconciliation from the fluentbit controller results in three 409 errors. See image below:

<img width="1314" alt="FluentOperatorErrors" src="https://user-images.githubusercontent.com/25295682/227573031-eaf3229a-68aa-4bfe-9e8f-6be1651fd09f.png">

I believe this change fixes that, though understand you might have different thoughts on implementation, so happy to hear them!

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```