### PR TITLE
fix segfault with DisableBuferVollume, rename to disableBufferVolume

### DIFF
--- a/apis/fluentd/v1alpha1/fluentd_types.go
+++ b/apis/fluentd/v1alpha1/fluentd_types.go
@@ -82,7 +82,7 @@ type FluentdSpec struct {
 
 type BufferVolume struct {
 	// Enabled buffer pvc by default.
-	DisableBufferVolume bool `json:"DisableBufferVolume,omitempty"`
+	DisableBufferVolume bool `json:"disableBufferVolume,omitempty"`
 
 	// Volume definition.
 	HostPath *corev1.HostPathVolumeSource `json:"hostPath,omitempty"`

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -872,7 +872,7 @@ spec:
                   gelfLevelKey:
                     description: Specify the key to use for the level in gelf format
                     type: string
-                  gelfShortMessgeKey:
+                  gelfShortMessageKey:
                     description: Specify the key to use as the short message in gelf
                       format
                     type: string

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -873,7 +873,7 @@ spec:
               buffer:
                 description: Buffer definition
                 properties:
-                  DisableBufferVolume:
+                  disableBufferVolume:
                     description: Enabled buffer pvc by default.
                     type: boolean
                   emptyDir:

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -872,7 +872,7 @@ spec:
                   gelfLevelKey:
                     description: Specify the key to use for the level in gelf format
                     type: string
-                  gelfShortMessgeKey:
+                  gelfShortMessageKey:
                     description: Specify the key to use as the short message in gelf
                       format
                     type: string

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -873,7 +873,7 @@ spec:
               buffer:
                 description: Buffer definition
                 properties:
-                  DisableBufferVolume:
+                  disableBufferVolume:
                     description: Enabled buffer pvc by default.
                     type: boolean
                   emptyDir:

--- a/docs/fluentd.md
+++ b/docs/fluentd.md
@@ -34,7 +34,7 @@ This Document documents the types introduced by the fluentd Operator.
 
 | Field | Description | Scheme |
 | ----- | ----------- | ------ |
-| DisableBufferVolume | Enabled buffer pvc by default. | bool |
+| disableBufferVolume | Enabled buffer pvc by default. | bool |
 | hostPath | Volume definition. | *corev1.HostPathVolumeSource |
 | emptyDir |  | *corev1.EmptyDirVolumeSource |
 | pvc | PVC definition | *corev1.PersistentVolumeClaim |

--- a/go.mod
+++ b/go.mod
@@ -57,12 +57,14 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
@@ -71,7 +73,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
+	k8s.io/code-generator v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
+	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -345,6 +346,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -499,6 +502,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -509,6 +513,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -635,8 +640,13 @@ k8s.io/apimachinery v0.26.3 h1:dQx6PNETJ7nODU3XPtrwkfuubs6w7sX0M8n61zHIV/k=
 k8s.io/apimachinery v0.26.3/go.mod h1:ats7nN1LExKHvJ9TmwootT00Yz05MuYqPXEXaVeOy5I=
 k8s.io/client-go v0.26.3 h1:k1UY+KXfkxV2ScEL3gilKcF7761xkYsSD6BC9szIu8s=
 k8s.io/client-go v0.26.3/go.mod h1:ZPNu9lm8/dbRIPAgteN30RSXea6vrCpFvq+MateTUuQ=
+k8s.io/code-generator v0.26.1 h1:dusFDsnNSKlMFYhzIM0jAO1OlnTN5WYwQQ+Ai12IIlo=
+k8s.io/code-generator v0.26.1/go.mod h1:OMoJ5Dqx1wgaQzKgc+ZWaZPfGjdRq/Y3WubFrZmeI3I=
 k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
 k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d h1:U9tB195lKdzwqicbJvyJeOXV7Klv+wNAWENRnXEGi08=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.90.1 h1:m4bYOKall2MmOiRaR1J+We67Do7vm9KiQVlT96lnHUw=
 k8s.io/klog/v2 v2.90.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+OGxg8HsuBr/5f6tVAjDu6E=
@@ -652,5 +662,6 @@ sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -18134,7 +18134,7 @@ spec:
               buffer:
                 description: Buffer definition
                 properties:
-                  DisableBufferVolume:
+                  disableBufferVolume:
                     description: Enabled buffer pvc by default.
                     type: boolean
                   emptyDir:
@@ -22036,7 +22036,7 @@ spec:
                   gelfLevelKey:
                     description: Specify the key to use for the level in gelf format
                     type: string
-                  gelfShortMessgeKey:
+                  gelfShortMessageKey:
                     description: Specify the key to use as the short message in gelf
                       format
                     type: string

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -18134,7 +18134,7 @@ spec:
               buffer:
                 description: Buffer definition
                 properties:
-                  DisableBufferVolume:
+                  disableBufferVolume:
                     description: Enabled buffer pvc by default.
                     type: boolean
                   emptyDir:
@@ -22036,7 +22036,7 @@ spec:
                   gelfLevelKey:
                     description: Specify the key to use for the level in gelf format
                     type: string
-                  gelfShortMessgeKey:
+                  gelfShortMessageKey:
                     description: Specify the key to use as the short message in gelf
                       format
                     type: string

--- a/pkg/operator/pvc.go
+++ b/pkg/operator/pvc.go
@@ -12,7 +12,7 @@ import (
 
 func MakeFluentdPVC(fd fluentdv1alpha1.Fluentd) corev1.PersistentVolumeClaim {
 	bufferStorage := fd.Spec.BufferVolume
-	if bufferStorage == nil {
+	if bufferStorage == nil || bufferStorage.PersistentVolumeClaim == nil {
 		return makeDefaultFluentdPVC(fd)
 	}
 	bufferPvc := bufferStorage.PersistentVolumeClaim.Spec

--- a/pkg/operator/sts.go
+++ b/pkg/operator/sts.go
@@ -169,14 +169,14 @@ func MakeStatefulset(fd fluentdv1alpha1.Fluentd) appsv1.StatefulSet {
 		}
 	}
 
-	// Bind pvc
-	sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, MakeFluentdPVC(fd))
+    if fd.Spec.BufferVolume == nil || !fd.Spec.BufferVolume.DisableBufferVolume {
+        sts.Spec.VolumeClaimTemplates = append(sts.Spec.VolumeClaimTemplates, MakeFluentdPVC(fd))
 
-	sts.Spec.Template.Spec.Containers[0].VolumeMounts = append(sts.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-		Name:      fmt.Sprintf("%s-buffer-pvc", fd.Name),
-		MountPath: BufferMountPath,
-	})
-
+        sts.Spec.Template.Spec.Containers[0].VolumeMounts = append(sts.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+            Name:      fmt.Sprintf("%s-buffer-pvc", fd.Name),
+            MountPath: BufferMountPath,
+        })
+    }
 	return sts
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Fixes SIGSEGV when setting Fluentd.spec.buffer.DisableBufferVolume to true/false without setting any other options.
**Renames DisableBufferVolume to disableBufferVolume to follow the camelCase pattern for field names. While this is technically a breaking change, the fact that this option was bugged and worked only under some specific conditions leads me to believe it shouldn't affect many (if anyone at all). Either way, if you think we should avoid such changes, I will revert it.**
This PR also includes some updates that were missed in previous PRs
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #620 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
This PR renames Fluentd.spec.buffer.DisableBufferVolume to disableBufferVolume, setups might have to be adjusted.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```