### PR TITLE
Enable annotations for service account in fluentbit/fluentd

### DIFF
--- a/apis/fluentbit/v1alpha2/collector_types.go
+++ b/apis/fluentbit/v1alpha2/collector_types.go
@@ -59,6 +59,8 @@ type CollectorSpec struct {
 	VolumesMounts []corev1.VolumeMount `json:"volumesMounts,omitempty"`
 	// Annotations to add to each Fluentbit pod.
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Annotations to add to the Fluentbit service account
+	ServiceAccountAnnotations map[string]string `json:"serviceAccountAnnotations,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 	// Host networking is requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.

--- a/apis/fluentbit/v1alpha2/fluentbit_types.go
+++ b/apis/fluentbit/v1alpha2/fluentbit_types.go
@@ -67,6 +67,8 @@ type FluentBitSpec struct {
 	VolumesMounts []corev1.VolumeMount `json:"volumesMounts,omitempty"`
 	// Annotations to add to each Fluentbit pod.
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Annotations to add to the Fluentbit service account
+	ServiceAccountAnnotations map[string]string `json:"serviceAccountAnnotations,omitempty"`
 	// Labels to add to each FluentBit pod
 	Labels map[string]string `json:"labels,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.

--- a/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
@@ -440,6 +440,13 @@ func (in *CollectorSpec) DeepCopyInto(out *CollectorSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ServiceAccountAnnotations != nil {
+		in, out := &in.ServiceAccountAnnotations, &out.ServiceAccountAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
 		*out = new(v1.PodSecurityContext)
@@ -754,6 +761,13 @@ func (in *FluentBitSpec) DeepCopyInto(out *FluentBitSpec) {
 	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ServiceAccountAnnotations != nil {
+		in, out := &in.ServiceAccountAnnotations, &out.ServiceAccountAnnotations
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/apis/fluentd/v1alpha1/fluentd_types.go
+++ b/apis/fluentd/v1alpha1/fluentd_types.go
@@ -58,6 +58,8 @@ type FluentdSpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// NodeSelector
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// Annotations to add to the Fluentd service account
+	ServiceAccountAnnotations map[string]string `json:"serviceAccountAnnotations,omitempty"`
 	// Pod's scheduling constraints.
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 	// Tolerations

--- a/apis/fluentd/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/fluentd/v1alpha1/zz_generated.deepcopy.go
@@ -699,6 +699,13 @@ func (in *FluentdSpec) DeepCopyInto(out *FluentdSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ServiceAccountAnnotations != nil {
+		in, out := &in.ServiceAccountAnnotations, &out.ServiceAccountAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
 		*out = new(corev1.Affinity)

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_collectors.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_collectors.yaml
@@ -1563,6 +1563,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -4427,6 +4427,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -1876,6 +1876,11 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentd service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/config/crd/bases/fluentbit.fluent.io_collectors.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_collectors.yaml
@@ -1563,6 +1563,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
@@ -4427,6 +4427,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -1876,6 +1876,11 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentd service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -93,7 +93,7 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Install RBAC resources for the filter plugin kubernetes
 	var rbacObj, saObj, bindingObj client.Object
-	rbacObj, saObj, bindingObj = operator.MakeRBACObjects(co.Name, co.Namespace, "collector", co.Spec.RBACRules)
+	rbacObj, saObj, bindingObj = operator.MakeRBACObjects(co.Name, co.Namespace, "collector", co.Spec.RBACRules, co.Spec.ServiceAccountAnnotations)
 	// Set ServiceAccount's owner to this fluentbit
 	if err := ctrl.SetControllerReference(&co, saObj, r.Scheme); err != nil {
 		return ctrl.Result{}, err

--- a/controllers/fluentd_controller.go
+++ b/controllers/fluentd_controller.go
@@ -91,7 +91,7 @@ func (r *FluentdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Install RBAC resources for the filter plugin kubernetes
-	var rbacObj, saObj, bindingObj = operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd", fd.Spec.RBACRules)
+	var rbacObj, saObj, bindingObj = operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd", fd.Spec.RBACRules, fd.Spec.ServiceAccountAnnotations)
 
 	// Set ServiceAccount's owner to this Fluentd
 	if err := ctrl.SetControllerReference(&fd, saObj, r.Scheme); err != nil {

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -182,6 +182,7 @@ CollectorSpec defines the desired state of FluentBit
 | volumes | List of volumes that can be mounted by containers belonging to the pod. | []corev1.Volume |
 | volumesMounts | Pod volumes to mount into the container's filesystem. | []corev1.VolumeMount |
 | annotations | Annotations to add to each Fluentbit pod. | map[string]string |
+| serviceAccountAnnotations | Annotations to add to the Fluentbit service account | map[string]string |
 | securityContext | SecurityContext holds pod-level security attributes and common container settings. | *corev1.PodSecurityContext |
 | hostNetwork | Host networking is requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false. | bool |
 | pvc | PVC definition | *corev1.PersistentVolumeClaim |
@@ -299,6 +300,7 @@ FluentBitSpec defines the desired state of FluentBit
 | volumes | List of volumes that can be mounted by containers belonging to the pod. | []corev1.Volume |
 | volumesMounts | Pod volumes to mount into the container's filesystem. | []corev1.VolumeMount |
 | annotations | Annotations to add to each Fluentbit pod. | map[string]string |
+| serviceAccountAnnotations | Annotations to add to the Fluentbit service account | map[string]string |
 | labels | Labels to add to each FluentBit pod | map[string]string |
 | securityContext | SecurityContext holds pod-level security attributes and common container settings. | *corev1.PodSecurityContext |
 | hostNetwork | Host networking is requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false. | bool |

--- a/docs/fluentd.md
+++ b/docs/fluentd.md
@@ -284,6 +284,7 @@ FluentdSpec defines the desired state of Fluentd
 | imagePullSecrets | Fluentd image pull secret | []corev1.LocalObjectReference |
 | resources | Compute Resources required by container. | corev1.ResourceRequirements |
 | nodeSelector | NodeSelector | map[string]string |
+| serviceAccountAnnotations | Annotations to add to the Fluentd service account | map[string]string |
 | affinity | Pod's scheduling constraints. | *corev1.Affinity |
 | tolerations | Tolerations | [][corev1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) |
 | runtimeClassName | RuntimeClassName represents the container runtime configuration. | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -7826,6 +7826,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:
@@ -14355,6 +14360,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:
@@ -18158,6 +18168,11 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentd service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -7826,6 +7826,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:
@@ -14355,6 +14360,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentbit service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:
@@ -18158,6 +18168,11 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              serviceAccountAnnotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to the Fluentd service account
+                type: object
               tolerations:
                 description: Tolerations
                 items:

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1.PolicyRule) (*rbacv1.ClusterRole, *corev1.ServiceAccount, *rbacv1.ClusterRoleBinding) {
+func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1.PolicyRule, fbAnnotations map[string]string) (*rbacv1.ClusterRole, *corev1.ServiceAccount, *rbacv1.ClusterRoleBinding) {
 	rbacName := fmt.Sprintf("kubesphere-%s", component)
 	cr := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -29,8 +29,9 @@ func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1
 
 	sa := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: fbAnnotations,
 		},
 	}
 
@@ -55,7 +56,7 @@ func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1
 	return &cr, &sa, &crb
 }
 
-func MakeScopedRBACObjects(fbName, fbNamespace string) (*rbacv1.Role, *corev1.ServiceAccount, *rbacv1.RoleBinding) {
+func MakeScopedRBACObjects(fbName, fbNamespace string, fbAnnotations map[string]string) (*rbacv1.Role, *corev1.ServiceAccount, *rbacv1.RoleBinding) {
 	r := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubesphere:fluent",
@@ -72,8 +73,9 @@ func MakeScopedRBACObjects(fbName, fbNamespace string) (*rbacv1.Role, *corev1.Se
 
 	sa := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fbName,
-			Namespace: fbNamespace,
+			Name:        fbName,
+			Namespace:   fbNamespace,
+			Annotations: fbAnnotations,
 		},
 	}
 

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1.PolicyRule, fbAnnotations map[string]string) (*rbacv1.ClusterRole, *corev1.ServiceAccount, *rbacv1.ClusterRoleBinding) {
+func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1.PolicyRule, saAnnotations map[string]string) (*rbacv1.ClusterRole, *corev1.ServiceAccount, *rbacv1.ClusterRoleBinding) {
 	rbacName := fmt.Sprintf("kubesphere-%s", component)
 	cr := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
@@ -31,7 +31,7 @@ func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
-			Annotations: fbAnnotations,
+			Annotations: saAnnotations,
 		},
 	}
 
@@ -56,7 +56,7 @@ func MakeRBACObjects(name, namespace, component string, additionalRules []rbacv1
 	return &cr, &sa, &crb
 }
 
-func MakeScopedRBACObjects(fbName, fbNamespace string, fbAnnotations map[string]string) (*rbacv1.Role, *corev1.ServiceAccount, *rbacv1.RoleBinding) {
+func MakeScopedRBACObjects(fbName, fbNamespace string, saAnnotations map[string]string) (*rbacv1.Role, *corev1.ServiceAccount, *rbacv1.RoleBinding) {
 	r := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubesphere:fluent",
@@ -75,7 +75,7 @@ func MakeScopedRBACObjects(fbName, fbNamespace string, fbAnnotations map[string]
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fbName,
 			Namespace:   fbNamespace,
-			Annotations: fbAnnotations,
+			Annotations: saAnnotations,
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Currently, if you wanted to use Workload Identity - you'd have to manually annotate the fluentbit/fluentd service account, and then restart the pods for authentication to occur. (Sometimes it worked without authentication). This PR allows for annotations to be added to the service account and a restart of fluentbit/fluentd to occur.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #562 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None (or not really, more an optional field than any action required)
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
See PR for docs.md
```