### PR TITLE
fix: Fix the permissions in the cluster roles and bindings in helm

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -97,9 +97,17 @@ rules:
       - clusterrolebindings
     verbs:
       - create
+      - list
+      - get
+      - watch
+      - patch
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterroles
     verbs:
       - create
+      - list
+      - get
+      - watch
+      - patch

--- a/manifests/setup/fluent-operator-clusterRole.yaml
+++ b/manifests/setup/fluent-operator-clusterRole.yaml
@@ -91,9 +91,17 @@ rules:
       - clusterrolebindings
     verbs:
       - create
+      - list
+      - get
+      - watch
+      - patch
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterroles
     verbs:
       - create
+      - list
+      - get
+      - watch
+      - patch


### PR DESCRIPTION

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Fix the helm template permissions for clusterrole and clusterrole bindings
- Added list, get, watch, patch to the clusterrole resource
- Added list, get, watch, patch to the clusterrolebinding resource

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #646 

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```