### PR TITLE
Namespace level secret loader for namespaced FluentBit configs

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/secret_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/secret_types.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-logr/logr"
 	"github.com/go-openapi/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,20 +25,20 @@ type ValueSource struct {
 }
 
 type SecretLoader struct {
-	client    client.Client
+	Client    client.Client
 	namespace string
 }
 
-func NewSecretLoader(c client.Client, ns string, l logr.Logger) SecretLoader {
+func NewSecretLoader(c client.Client, ns string) SecretLoader {
 	return SecretLoader{
-		client:    c,
+		Client:    c,
 		namespace: ns,
 	}
 }
 
 func (sl SecretLoader) LoadSecret(s Secret) (string, error) {
 	var secret corev1.Secret
-	if err := sl.client.Get(context.Background(), client.ObjectKey{Name: s.ValueFrom.SecretKeyRef.Name, Namespace: sl.namespace}, &secret); err != nil {
+	if err := sl.Client.Get(context.Background(), client.ObjectKey{Name: s.ValueFrom.SecretKeyRef.Name, Namespace: sl.namespace}, &secret); err != nil {
 		return "", err
 	}
 

--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -141,7 +141,7 @@ func (r *FluentBitConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				ns = os.Getenv("NAMESPACE")
 			}
 			// Inject config data into Secret
-			sl := plugins.NewSecretLoader(r.Client, ns, r.Log)
+			sl := plugins.NewSecretLoader(r.Client, ns)
 			mainAppCfg, err := cfg.RenderMainConfig(sl, inputs, filters, outputs, nsFilterLists, nsOutputLists, rewriteTagConfigs)
 			if err != nil {
 				return ctrl.Result{}, err


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
For namespaced FluentBit configs, search for secrets in the same namespace as the configs.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #653 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```