### PR TITLE
Add Pod Annotations support to FluentD

### DIFF
--- a/apis/fluentd/v1alpha1/fluentd_types.go
+++ b/apis/fluentd/v1alpha1/fluentd_types.go
@@ -58,6 +58,8 @@ type FluentdSpec struct {
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// NodeSelector
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// Annotations to add to each Fluentd pod.
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// Annotations to add to the Fluentd service account
 	ServiceAccountAnnotations map[string]string `json:"serviceAccountAnnotations,omitempty"`
 	// Pod's scheduling constraints.

--- a/apis/fluentd/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/fluentd/v1alpha1/zz_generated.deepcopy.go
@@ -728,6 +728,13 @@ func (in *FluentdSpec) DeepCopyInto(out *FluentdSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ServiceAccountAnnotations != nil {
 		in, out := &in.ServiceAccountAnnotations, &out.ServiceAccountAnnotations
 		*out = make(map[string]string, len(*in))

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -865,6 +865,11 @@ spec:
                         type: array
                     type: object
                 type: object
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to each Fluentd pod.
+                type: objects
               args:
                 description: Fluentd Watcher command line arguments.
                 items:

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -865,6 +865,11 @@ spec:
                         type: array
                     type: object
                 type: object
+              annotations:
+                additionalProperties:
+                  type: string
+                description: Annotations to add to each Fluentd pod.
+                type: object
               args:
                 description: Fluentd Watcher command line arguments.
                 items:

--- a/docs/fluentd.md
+++ b/docs/fluentd.md
@@ -297,6 +297,7 @@ FluentdSpec defines the desired state of Fluentd
 | imagePullSecrets | Fluentd image pull secret | []corev1.LocalObjectReference |
 | resources | Compute Resources required by container. | corev1.ResourceRequirements |
 | nodeSelector | NodeSelector | map[string]string |
+| annotations | Annotations to add to each Fluentd pod. | map[string]string |
 | serviceAccountAnnotations | Annotations to add to the Fluentd service account | map[string]string |
 | affinity | Pod's scheduling constraints. | *corev1.Affinity |
 | tolerations | Tolerations | [][corev1.Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#toleration-v1-core) |

--- a/pkg/operator/sts.go
+++ b/pkg/operator/sts.go
@@ -53,9 +53,10 @@ func MakeStatefulset(fd fluentdv1alpha1.Fluentd) *appsv1.StatefulSet {
 
 	sts := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fd.Name,
-			Namespace: fd.Namespace,
-			Labels:    labels,
+			Name:        fd.Name,
+			Namespace:   fd.Namespace,
+			Labels:      labels,
+			Annotations: fd.Annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,
@@ -64,9 +65,10 @@ func MakeStatefulset(fd fluentdv1alpha1.Fluentd) *appsv1.StatefulSet {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fd.Name,
-					Namespace: fd.Namespace,
-					Labels:    labels,
+					Name:        fd.Name,
+					Namespace:   fd.Namespace,
+					Labels:      labels,
+					Annotations: fd.Spec.Annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: fd.Name,


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Hi, I would like to add the ability to set annotations to Fluentd.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
- Annotations can be now passed into Fluentd Pod.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```