### PR TITLE
fluent operator & fluentbit: Added tolerations, nodeSelector + more

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -99,14 +99,18 @@ spec:
       priorityClassName: {{ .Values.operator.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.operator.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.operator.imagePullSecrets | nindent 8 }}
+      imagePullSecrets:
+        {{ toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- if .Values.operator.tolerations }}
-      tolerations: {{ toYaml .Values.operator.tolerations | nindent 8 }}
+      tolerations:
+        {{ toYaml .Values.operator.tolerations | nindent 8 }}
       {{- end }}
       {{- if .Values.operator.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.operator.nodeSelector | nindent 8 }}
+      nodeSelector:
+        {{ toYaml .Values.operator.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.operator.podSecurityContext }}
-      podSecurityContext: {{ toYaml .Values.operator.podSecurityContext | nindent 8 }}
+      podSecurityContext:
+        {{ toYaml .Values.operator.podSecurityContext | nindent 8 }}
       {{- end }}

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -95,7 +95,18 @@ spec:
         - name: env
           mountPath: /fluent-operator
       serviceAccountName: fluent-operator
+      {{- if .Values.operator.priorityClassName }}
+      priorityClassName: {{ .Values.operator.priorityClassName | quote }}
+      {{- end }}
       {{- if .Values.operator.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       {{- end }}
+{{- with .Values.operator.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -99,14 +99,14 @@ spec:
       priorityClassName: {{ .Values.operator.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.operator.imagePullSecrets }}
-      imagePullSecrets:
-      {{- toYaml .Values.operator.imagePullSecrets | nindent 8 }}
+      imagePullSecrets: {{ toYaml .Values.operator.imagePullSecrets | nindent 8 }}
       {{- end }}
-{{- with .Values.operator.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-{{- end }}
-{{- with .Values.operator.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-{{- end }}
+      {{- if .Values.operator.tolerations }}
+      tolerations: {{ toYaml .Values.operator.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.operator.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.podSecurityContext }}
+      podSecurityContext: {{ toYaml .Values.operator.podSecurityContext | nindent 8 }}
+      {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -18,8 +18,17 @@ spec:
   resources:
 {{- toYaml .Values.fluentbit.resources | nindent 4  }}
   fluentBitConfigName: fluent-bit-config
+{{- with .Values.fluentbit.tolerations }}
   tolerations:
-    - operator: Exists
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.fluentbit.nodeSelector }}
+  nodeSelector:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- if .Values.fluentbit.priorityClassName }}
+  priorityClassName: {{ .Values.fluentbit.priorityClassName | quote }}
+{{- end }}
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -17,13 +17,15 @@ operator:
   container:
     repository: "kubesphere/fluent-operator"
     tag: "latest"
-    # FluentBit operator resources. Usually user needn't to adjust these.
-  # nodeSelector configuration for Fluent Operator pods
+  # nodeSelector configuration for Fluent Operator. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
-  # Tolerations applied to Fluent Operator pods
+  # Node tolerations applied to Fluent Operator. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations: []
-  # Priority Class applied to Fluent Operator pods
+  # Priority class applied to Fluent Operator. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   priorityClassName: ""
+  # Pod security context for Fluent Operator. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext: {}
+  # Fluent Operator resources. Usually user needn't to adjust these.
   resources:
     limits:
       cpu: 100m
@@ -89,12 +91,12 @@ fluentbit:
   additionalVolumes: []
   # Pod volumes to mount into the container's filesystem.
   additionalVolumesMounts: []
-  # nodeSelector configuration for Daemonset pods
+  # nodeSelector configuration for Fluent Bit pods. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
-  # Tolerations applied to Daemonset pods
+  # Node tolerations applied to Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   tolerations: 
   - operator: Exists
-  # Priority Class applied to Daemonset pods
+  # Priority Class applied to Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   priorityClassName: ""
   # Remove the above empty volumes and volumesMounts, and then set additionalVolumes and additionalVolumesMounts as below if you want to collect node exporter metrics
   # additionalVolumes:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -18,6 +18,12 @@ operator:
     repository: "kubesphere/fluent-operator"
     tag: "latest"
     # FluentBit operator resources. Usually user needn't to adjust these.
+  # nodeSelector configuration for Fluent Operator pods
+  nodeSelector: {}
+  # Tolerations applied to Fluent Operator pods
+  tolerations: []
+  # Priority Class applied to Fluent Operator pods
+  priorityClassName: ""
   resources:
     limits:
       cpu: 100m
@@ -83,7 +89,13 @@ fluentbit:
   additionalVolumes: []
   # Pod volumes to mount into the container's filesystem.
   additionalVolumesMounts: []
-
+  # nodeSelector configuration for Daemonset pods
+  nodeSelector: {}
+  # Tolerations applied to Daemonset pods
+  tolerations: 
+  - operator: Exists
+  # Priority Class applied to Daemonset pods
+  priorityClassName: ""
   # Remove the above empty volumes and volumesMounts, and then set additionalVolumes and additionalVolumesMounts as below if you want to collect node exporter metrics
   # additionalVolumes:
   #   - name: hostProc


### PR DESCRIPTION
### What this PR does / why we need it:
Added support for tolerations, nodeSelector, priorityClassName and podSecurityContext to fluent-operator deployment and fluentbit daemonset

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/fluent/helm-charts/issues/314 
Fixes #695 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added support for tolerations, nodeSelector, priorityClassName and podSecurityContext to fluent-operator deployment and fluentbit daemonset
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```