### PR TITLE
envVars support in fluentbit helm template

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -18,6 +18,10 @@ spec:
   resources:
 {{- toYaml .Values.fluentbit.resources | nindent 4  }}
   fluentBitConfigName: fluent-bit-config
+{{- if .Values.fluentbit.envVars }}
+  envVars:
+{{ toYaml .Values.fluentbit.envVars | indent 4 }}
+{{- end }}
 {{- with .Values.fluentbit.tolerations }}
   tolerations:
 {{ toYaml . | indent 4 }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -98,6 +98,11 @@ fluentbit:
   - operator: Exists
   # Priority Class applied to Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   priorityClassName: ""
+  # Environment variables that can be passed to fluentbit pods
+  envVars: []
+  #  - name: FOO
+  #    value: "bar"
+
   # Remove the above empty volumes and volumesMounts, and then set additionalVolumes and additionalVolumesMounts as below if you want to collect node exporter metrics
   # additionalVolumes:
   #   - name: hostProc


### PR DESCRIPTION
### What this PR does / why we need it:
Added possibility to set envVars for the fluent-bit template.

Useful for when you would want to set and use a environment variable in your filters and you don't want to configure your own `FluentBit` and instead use the templated one from the helm chart.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added possibility to set envVars for the fluent-bit template.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```