### PR TITLE
remove the deprecated -i flag in go build

### DIFF
--- a/cmd/fluent-watcher/fluentd/Dockerfile.amd64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.amd64
@@ -5,7 +5,7 @@ RUN mkdir -p /code
 COPY . /code/
 WORKDIR /code
 RUN echo $(ls -al /code)
-RUN CGO_ENABLED=0 go build -i -ldflags '-w -s' -o /fluentd/fluentd-watcher /code/cmd/fluent-watcher/fluentd/main.go
+RUN CGO_ENABLED=0 go build -ldflags '-w -s' -o /fluentd/fluentd-watcher /code/cmd/fluent-watcher/fluentd/main.go
 
 # Fluentd main image
 FROM alpine:3.17

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64
@@ -5,7 +5,7 @@ RUN mkdir -p /code
 COPY . /code/
 WORKDIR /code
 RUN echo $(ls -al /code)
-RUN CGO_ENABLED=0 go build -i -ldflags '-w -s' -o /fluentd/fluentd-watcher /code/cmd/fluent-watcher/fluentd/main.go
+RUN CGO_ENABLED=0 go build -ldflags '-w -s' -o /fluentd/fluentd-watcher /code/cmd/fluent-watcher/fluentd/main.go
 
 # To set multiarch build for Docker hub automated build.
 FROM golang:alpine AS builderqemu

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64.quick
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64.quick
@@ -5,7 +5,7 @@ RUN mkdir -p /code
 COPY . /code/
 WORKDIR /code
 RUN echo $(ls -al /code)
-RUN CGO_ENABLED=0 go build -i -ldflags '-w -s' -o /fluentd/fluentd-watcher /code/cmd/fluent-watcher/fluentd/main.go
+RUN CGO_ENABLED=0 go build -ldflags '-w -s' -o /fluentd/fluentd-watcher /code/cmd/fluent-watcher/fluentd/main.go
 
 # Fluentd main image
 FROM kubesphere/fluentd:v1.15.3-arm64-base


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```