### PR TITLE
Fix(docs): Update cluster outputs docs link

### DIFF
--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -150,7 +150,7 @@ fluentbit:
   # Configure the output plugin parameter in FluentBit.
   # You can set enable to true to output logs to the specified location.
   output:
-    #  You can find more supported output plugins here: https://github.com/fluent/fluent-operator/tree/master/docs/plugins/fluentbit/clusteroutput
+    #  You can find more supported output plugins here: https://github.com/fluent/fluent-operator/tree/master/docs/plugins/fluentbit/output
     es:
       enable: false
       host: "<Elasticsearch url like elasticsearch-logging-data.kubesphere-logging-system.svc>"


### PR DESCRIPTION
### What this PR does / why we need it:

The link to the GitHub path containing all outputs plugins has changed from `clusteroutput` to `output `

Update link in Helm values file to correct link.

### Which issue(s) this PR fixes:

N/A

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```