### PR TITLE
Add fluentbit.affinity configuration

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -33,13 +33,10 @@ spec:
 {{- if .Values.fluentbit.priorityClassName }}
   priorityClassName: {{ .Values.fluentbit.priorityClassName | quote }}
 {{- end }}
+  {{- with .Values.fluentbit.affinity }}
   affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: node-role.kubernetes.io/edge
-                operator: DoesNotExist
+{{ toYaml . | indent 4 }}
+  {{- end }}
   {{- if .Values.fluentbit.secrets }}
   secrets:
 {{ toYaml .Values.fluentbit.secrets | indent 4 }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -91,6 +91,14 @@ fluentbit:
   additionalVolumes: []
   # Pod volumes to mount into the container's filesystem.
   additionalVolumesMounts: []
+  # affinity configuration for Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: node-role.kubernetes.io/edge
+                operator: DoesNotExist
   # nodeSelector configuration for Fluent Bit pods. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
   # Node tolerations applied to Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Allows to configure fluentbit pods affinity,  which is useful for adding a rule to not to schedule a pod on a node based on a label.

values.yaml example:
```
fluentbit:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: node-role.kubernetes.io/edge
            operator: DoesNotExist
          - key: fluentbit.cluster.local/schedulable
            operator: NotIn
            values:
            - "false"
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```