### PR TITLE
change SIGTERM to SIGHUP

### DIFF
--- a/cmd/fluent-watcher/fluentbit/main.go
+++ b/cmd/fluent-watcher/fluentbit/main.go
@@ -197,6 +197,7 @@ func start() {
 	} else {
 		cmd = exec.Command(binPath, "-c", configPath)
 	}
+	cmd =exec.Command(binPath,"-Y")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	flbTerminated = make(chan bool, 1)
@@ -275,11 +276,11 @@ func stop() {
 		return
 	}
 
-	// Send SIGTERM, if fluent-bit doesn't terminate in the specified timeframe, send SIGKILL
-	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+	// Send SIGHUP, if fluent-bit doesn't terminate in the specified timeframe, send SIGKILL
+	if err := cmd.Process.Signal(syscall.SIGHUP); err != nil {
 		_ = level.Info(logger).Log("msg", "Error while terminating FluentBit", "error", err)
 	} else {
-		_ = level.Info(logger).Log("msg", "Sent SIGTERM to FluentBit, waiting max "+flbTerminationTimeout.String())
+		_ = level.Info(logger).Log("msg", "Sent SIGTHUP to FluentBit, waiting max "+flbTerminationTimeout.String())
 	}
 
 	select {


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Hot reloading also can be kicked via SIGHUP.
SIGHUP signal is not supported on Windows. So, users can't enable this feature on Windows.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
![1683883877068](https://github.com/fluent/fluent-operator/assets/39892300/b0857f5a-2aef-4066-9546-95aafb10d788)
