### PR TITLE
fix: dereference pointers in parser filter plugin for fluentd

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/filter/types.go
+++ b/apis/fluentd/v1alpha1/plugins/filter/types.go
@@ -192,28 +192,28 @@ func (f *Filter) parserPlugin(parent *params.PluginStore, loader plugins.SecretL
 	}
 
 	if f.Parser.KeyName != nil {
-		parent.InsertPairs("key_name", fmt.Sprint(f.Parser.KeyName))
+		parent.InsertPairs("key_name", fmt.Sprint(*f.Parser.KeyName))
 	}
 	if f.Parser.ReserveTime != nil {
-		parent.InsertPairs("reserve_time", fmt.Sprint(f.Parser.ReserveTime))
+		parent.InsertPairs("reserve_time", fmt.Sprint(*f.Parser.ReserveTime))
 	}
 	if f.Parser.ReserveData != nil {
-		parent.InsertPairs("reserve_data", fmt.Sprint(f.Parser.ReserveData))
+		parent.InsertPairs("reserve_data", fmt.Sprint(*f.Parser.ReserveData))
 	}
 	if f.Parser.RemoveKeyNameField != nil {
-		parent.InsertPairs("remove_key_name_field", fmt.Sprint(f.Parser.RemoveKeyNameField))
+		parent.InsertPairs("remove_key_name_field", fmt.Sprint(*f.Parser.RemoveKeyNameField))
 	}
 	if f.Parser.ReplaceInvalidSequence != nil {
-		parent.InsertPairs("replace_invalid_sequence", fmt.Sprint(f.Parser.ReplaceInvalidSequence))
+		parent.InsertPairs("replace_invalid_sequence", fmt.Sprint(*f.Parser.ReplaceInvalidSequence))
 	}
 	if f.Parser.InjectKeyPrefix != nil {
-		parent.InsertPairs("inject_key_prefix", fmt.Sprint(f.Parser.InjectKeyPrefix))
+		parent.InsertPairs("inject_key_prefix", fmt.Sprint(*f.Parser.InjectKeyPrefix))
 	}
 	if f.Parser.HashValueField != nil {
-		parent.InsertPairs("hash_value_field", fmt.Sprint(f.Parser.HashValueField))
+		parent.InsertPairs("hash_value_field", fmt.Sprint(*f.Parser.HashValueField))
 	}
 	if f.Parser.EmitInvalidRecordToError != nil {
-		parent.InsertPairs("emit_invalid_record_to_error", fmt.Sprint(f.Parser.EmitInvalidRecordToError))
+		parent.InsertPairs("emit_invalid_record_to_error", fmt.Sprint(*f.Parser.EmitInvalidRecordToError))
 	}
 
 	if child != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR fixes an issue with pointers not being dereferenced in Fluentd "parser" filter plugin
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #741 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```