### PR TITLE
Fluentd in_tail plugin

### DIFF
--- a/apis/fluentd/v1alpha1/helper.go
+++ b/apis/fluentd/v1alpha1/helper.go
@@ -168,7 +168,9 @@ func (r *CfgResources) filterForFilters(cfgId, namespace, name, crdtype string,
 	for n, filter := range filters {
 		filterId := fmt.Sprintf("%s::%s::%s::%s-%d", cfgId, namespace, crdtype, name, n)
 		filter.FilterCommon.Id = &filterId
-		filter.FilterCommon.Tag = &params.DefaultTag
+		if filter.FilterCommon.Tag == nil {
+			filter.FilterCommon.Tag = &params.DefaultTag
+		}
 
 		ps, err := filter.Params(sl)
 		if err != nil {
@@ -192,7 +194,9 @@ func (r *CfgResources) filterForOutputs(cfgId, namespace, name, crdtype string,
 	for n, output := range outputs {
 		outputId := fmt.Sprintf("%s::%s::%s::%s-%d", cfgId, namespace, crdtype, name, n)
 		output.OutputCommon.Id = &outputId
-		output.OutputCommon.Tag = &params.DefaultTag
+		if output.OutputCommon.Tag == nil {
+			output.OutputCommon.Tag = &params.DefaultTag
+		}
 
 		ps, err := output.Params(sl)
 		if err != nil {

--- a/apis/fluentd/v1alpha1/plugins/filter/types.go
+++ b/apis/fluentd/v1alpha1/plugins/filter/types.go
@@ -16,7 +16,7 @@ type FilterCommon struct {
 	// The @log_level parameter specifies the plugin-specific logging level
 	LogLevel *string `json:"logLevel,omitempty"`
 	// Which tag to be matched.
-	Tag *string `json:"-"`
+	Tag *string `json:"tag,omitempty"`
 }
 
 // Filter defines all available filter plugins and their parameters.

--- a/apis/fluentd/v1alpha1/plugins/input/tail.go
+++ b/apis/fluentd/v1alpha1/plugins/input/tail.go
@@ -1,0 +1,138 @@
+package input
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins"
+	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/common"
+	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/params"
+)
+// The in_tail Input plugin allows Fluentd to read events from the tail of text files. Its behavior is similar to the tail -F command.
+type Tail struct {
+	// +kubebuilder:validation:Required
+	// The tag of the event.
+	Tag string `json:"tag"`
+	// +kubebuilder:validation:Required
+	// The path(s) to read. Multiple paths can be specified, separated by comma ','.
+	Path string `json:"path"`
+	// This parameter is for strftime formatted path like /path/to/%Y/%m/%d/.
+	PathTimezone string `json:"pathTimezone,omitempty"`
+	// The paths excluded from the watcher list.
+	ExcludePath []string `json:"excludePath,omitempty"`
+	// Avoid to read rotated files duplicately. You should set true when you use * or strftime format in path.
+	FollowInodes *bool `json:"followInodes,omitempty"`
+	// The interval to refresh the list of watch files. This is used when the path includes *.
+	RefreshInterval *uint32 `json:"refreshInterval,omitempty"`
+	// Limits the watching files that the modification time is within the specified time range when using * in path.
+	LimitRecentlyModified *uint32 `json:"limitRecentlyModified,omitempty"`
+	// Skips the refresh of the watch list on startup. This reduces the startup time when * is used in path.
+	SkipRefreshOnStartup *bool `json:"skipRefreshOnStartup,omitempty"`
+	// Starts to read the logs from the head of the file or the last read position recorded in pos_file, not tail.
+	ReadFromHead *bool `json:"readFromHead,omitempty"`
+	// Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.
+	// If encoding is specified, in_tail changes string to encoding.
+	// If encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.
+	Encoding string `json:"encoding,omitempty"`
+	// Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding.
+	// If encoding is specified, in_tail changes string to encoding.
+	// If encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding.
+	FromEncoding string `json:"fromEncoding,omitempty"`
+	// The number of lines to read with each I/O operation.
+	ReadLinesLimit *int32 `json:"readLinesLimit,omitempty"`
+	// The number of reading bytes per second to read with I/O operation. This value should be equal or greater than 8192.
+	ReadBytesLimitPerSecond *int32 `json:"readBytesLimitPerSecond,omitempty"`
+	// The maximum length of a line. Longer lines than it will be just skipped.
+	MaxLineSize *int32 `json:"maxLineSize,omitempty"`
+	// The interval of flushing the buffer for multiline format.
+	MultilineFlushInterval *uint32 `json:"multilineFlushInterval,omitempty"`
+	// (recommended) Fluentd will record the position it last read from this file.
+	// pos_file handles multiple positions in one file so no need to have multiple pos_file parameters per source.
+	// Don't share pos_file between in_tail configurations. It causes unexpected behavior e.g. corrupt pos_file content.
+	PosFile string `json:"posFile,omitempty"`
+	// The interval of doing compaction of pos file.
+	PosFileCompactionInterval *uint32 `json:"posFileCompactionInterval,omitempty"`
+	// +kubebuilder:validation:Required
+	Parse *common.Parse `json:"parse"`
+	// Adds the watching file path to the path_key field.
+	PathKey string `json:"pathKey,omitempty"`
+	// in_tail actually does a bit more than tail -F itself. When rotating a file, some data may still need to be written to the old file as opposed to the new one.
+	// in_tail takes care of this by keeping a reference to the old file (even after it has been rotated) for some time before transitioning completely to the new file.
+	// This helps prevent data designated for the old file from getting lost. By default, this time interval is 5 seconds.
+	// The rotate_wait parameter accepts a single integer representing the number of seconds you want this time interval to be.
+	RotateWait *uint32 `json:"rotateWait,omitempty"`
+	// Enables the additional watch timer. Setting this parameter to false will significantly reduce CPU and I/O consumption when tailing a large number of files on systems with inotify support.
+	// The default is true which results in an additional 1 second timer being used.
+	EnableWatchTimer *bool `json:"enableWatchTimer,omitempty"`
+	// Enables the additional inotify-based watcher. Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.
+	// This option is mainly for avoiding the stuck issue with inotify.
+	EnableStatWatcher *bool `json:"enableStatWatcher,omitempty"`
+	// Opens and closes the file on every update instead of leaving it open until it gets rotated.
+	OpenOnEveryUpdate *bool `json:"openOnEveryUpdate,omitempty"`
+	// Emits unmatched lines when <parse> format is not matched for incoming logs.
+	EmitUnmatchedLines *bool `json:"emitUnmatchedLines,omitempty"`
+	// If you have to exclude the non-permission files from the watch list, set this parameter to true. It suppresses the repeated permission error logs.
+	IgnoreRepatedPermissionError *bool `json:"ignoreRepeatedPermissionError,omitempty"`
+	// The in_tail plugin can assign each log file to a group, based on user defined rules.
+	// The limit parameter controls the total number of lines collected for a group within a rate_period time interval.
+	Group *Group `json:"group,omitempty"`
+}
+
+type Group struct {
+	// Specifies the regular expression for extracting metadata (namespace, podname) from log file path.
+	// Default value of the pattern regexp extracts information about namespace, podname, docker_id, container of the log (K8s specific).
+	Pattern string `json:"pattern,omitempty"`
+	// Time period in which the group line limit is applied. in_tail resets the counter after every rate_period interval.
+	RatePeriod *int32 `json:"ratePeriod,omitempty"`
+	// Grouping rules for log files.
+	// +kubebuilder:validation:Required
+	Rule *Rule `json:"rule"`
+}
+
+type Rule struct {
+	// match parameter is used to check if a file belongs to a particular group based on hash keys (named captures from pattern) and hash values (regexp in string)
+	Match map[string]string `json:"match,omitempty"`
+	// Maximum number of lines allowed from a group in rate_period time interval. The default value of -1 doesn't throttle log files of that group.
+	Limit *int32 `json:"limit,omitempty"`
+}
+
+func (g *Group) Name() string {
+	return "group"
+}
+
+func (g *Group) Params(loader plugins.SecretLoader) (*params.PluginStore, error) {
+	ps := params.NewPluginStore(g.Name())
+
+	if g.Pattern != "" {
+		ps.InsertPairs("pattern", fmt.Sprint(g.Pattern))
+	}
+
+	if g.RatePeriod != nil {
+		ps.InsertPairs("rate_period", fmt.Sprint(*g.RatePeriod))
+	}
+
+	if g.Rule != nil {
+		subchild, _ := g.Rule.Params(loader)
+		ps.InsertChilds(subchild)
+	}
+	return ps, nil
+}
+
+func (r *Rule) Name() string {
+	return "rule"
+}
+
+func (r *Rule) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
+	ps := params.NewPluginStore(r.Name())
+
+	if len(r.Match) > 0 {
+		matches, _ := json.Marshal(r.Match)
+		ps.InsertPairs("match", fmt.Sprint(string(matches)))
+	}
+
+	if r.Limit != nil {
+		ps.InsertPairs("limit", fmt.Sprint(*r.Limit))
+	}
+
+	return ps, nil
+}

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -21,7 +21,7 @@ type OutputCommon struct {
 	// The @label parameter is to route the events to <label> sections
 	Label *string `json:"-"`
 	// Which tag to be matched.
-	Tag *string `json:"-"`
+	Tag *string `json:"tag,omitempty"`
 }
 
 // Output defines all available output plugins and their parameters

--- a/apis/fluentd/v1alpha1/plugins/params/const.go
+++ b/apis/fluentd/v1alpha1/plugins/params/const.go
@@ -48,6 +48,7 @@ const (
 	// Enums the supported input types
 	HttpInputType    InputType = "http"
 	ForwardInputType InputType = "forward"
+	TailInputType    InputType = "tail"
 
 	// Enums the supported filter types
 	RecordTransformerFilterType FilterType = "record_transformer"

--- a/apis/fluentd/v1alpha1/plugins/params/model.go
+++ b/apis/fluentd/v1alpha1/plugins/params/model.go
@@ -155,7 +155,8 @@ func (ps *PluginStore) processBody(buf *bytes.Buffer) {
 
 	keys := make([]string, 0, len(ps.Store))
 	for k := range ps.Store {
-		if k == "tag" {
+		// Don't add tag unless it is an input plugin
+		if k == "tag" && ps.Name != "source" {
 			continue
 		}
 		if ps.Name == string(BufferPlugin) && ps.IgnorePath {

--- a/apis/fluentd/v1alpha1/tests/expected/fluentd-global-cfg-input-tail.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/fluentd-global-cfg-input-tail.cfg
@@ -1,0 +1,51 @@
+<source>
+  @type  tail
+  emit_unmatched_lines  true
+  enable_stat_watcher  true
+  enable_watch_timer  true
+  exclude_path  ["/var/log/foo.log", "/var/log/bar"]
+  follow_inodes  false
+  ignore_repeated_permission_error  false
+  limit_recently_modified  3
+  max_line_size  10000
+  multiline_flush_interval  4
+  open_on_every_update  false
+  path  /var/log/test.log
+  path_key  tailed_path
+  pos_file  /fluentd/pos.db
+  pos_file_compaction_interval  5
+  read_bytes_limit_per_second  8192
+  read_from_head  false
+  read_lines_limit  15
+  refresh_interval  2
+  rotate_wait  30
+  skip_refresh_on_startup  false
+  tag  foo.bar
+  <group>
+    pattern  /^\/home\/logs\/(?<file>.+)\.log$/
+    rate_period  30
+    <rule>
+      limit  2
+      match  {"key1":"val1","key2":"val2"}
+    </rule>
+  </group>
+  <parse>
+    @type  json
+  </parse>
+</source>
+<match **>
+  @id  main
+  @type  label_router
+  <route>
+    @label  @2d9e59757d3bfc66d93c3bc44b408922
+    <match>
+      namespaces  fluent
+    </match>
+  </route>
+</match>
+<label @2d9e59757d3bfc66d93c3bc44b408922>
+  <match foo.*>
+    @id  FluentdConfig-fluent-fluentd-config::cluster::clusteroutput::fluentd-output-stdout-0
+    @type  stdout
+  </match>
+</label>

--- a/apis/fluentd/v1alpha1/tests/helper_test.go
+++ b/apis/fluentd/v1alpha1/tests/helper_test.go
@@ -42,6 +42,29 @@ func Test_Cfg2ES(t *testing.T) {
 	}
 }
 
+func Test_ClusterCfgInputTail(t *testing.T) {
+	g := NewGomegaWithT(t)
+	sl := plugins.NewSecretLoader(nil, Fluentd.Namespace, logr.Logger{})
+
+	psr := fluentdv1alpha1.NewGlobalPluginResources("main")
+	psr.CombineGlobalInputsPlugins(sl, FluentdInputTail.Spec.GlobalInputs)
+
+	clustercfgRouter, err := psr.BuildCfgRouter(&FluentdConfig1)
+	g.Expect(err).NotTo(HaveOccurred())
+	clusterOutputs := []fluentdv1alpha1.ClusterOutput{FluentdClusterOutputTag}
+	clustercfgResources, _ := psr.PatchAndFilterClusterLevelResources(sl, FluentdConfig1.GetCfgId(), []fluentdv1alpha1.ClusterFilter{}, clusterOutputs)
+	err = psr.WithCfgResources(*clustercfgRouter.Label, clustercfgResources)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	for i := 0; i < maxRuntimes; i++ {
+		config, errs := psr.RenderMainConfig(false)
+		// fmt.Println(config)
+		g.Expect(errs).NotTo(HaveOccurred())
+		g.Expect(string(getExpectedCfg("./expected/fluentd-global-cfg-input-tail.cfg"))).To(Equal(config))
+	}
+
+}
+
 func Test_ClusterCfgOutput2ES(t *testing.T) {
 	g := NewGomegaWithT(t)
 	sl := plugins.NewSecretLoader(nil, Fluentd.Namespace, logr.Logger{})

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -35,6 +35,58 @@ spec:
       config.fluentd.fluent.io/enabled: "true"
 `
 
+	FluentdInputTail    fluentdv1alpha1.Fluentd
+	FluentdInputTailRaw = `
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: Fluentd
+metadata:
+  name: fluentd
+  namespace: fluent
+  labels:
+    app.kubernetes.io/name: fluentd
+spec:
+  globalInputs:
+  - tail: 
+      tag: "foo.bar"
+      path: /var/log/test.log
+      emitUnmatchedLines: true
+      enableStatWatcher: true
+      enableWatchTimer: true
+      followInodes: false
+      group:
+        pattern: '/^\/home\/logs\/(?<file>.+)\.log$/'
+        ratePeriod: 30
+        rule:
+          limit: 2
+          match:
+            key1: val1
+            key2: val2
+      ignoreRepeatedPermissionError: false
+      limitRecentlyModified: 3
+      maxLineSize: 10000
+      multilineFlushInterval: 4
+      openOnEveryUpdate: false
+      parse:
+        type: json
+      pathKey: tailed_path
+      posFile: /fluentd/pos.db
+      posFileCompactionInterval: 5
+      readBytesLimitPerSecond: 8192
+      readFromHead: false
+      readLinesLimit: 15
+      refreshInterval: 2
+      rotateWait: 30
+      skipRefreshOnStartup: false
+      excludePath:
+      - /var/log/foo.log
+      - /var/log/bar
+  replicas: 1
+  image: kubesphere/fluentd:v1.15.3
+  fluentdCfgSelector: 
+    matchLabels:
+      config.fluentd.fluent.io/enabled: "true"
+`
+
 	FluentdClusterFluentdConfig1    fluentdv1alpha1.ClusterFluentdConfig
 	FluentdClusterFluentdConfig1Raw = `
 apiVersion: fluentd.fluent.io/v1alpha1
@@ -147,6 +199,20 @@ spec:
       type: file
       path: /buffers/es.log
   `
+
+	FluentdClusterOutputTag    fluentdv1alpha1.ClusterOutput
+	FluentdClusterOutputTagRaw = `
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: ClusterOutput
+metadata:
+  name: fluentd-output-stdout
+  labels:
+    output.fluentd.fluent.io/enabled: "true"
+spec: 
+  outputs: 
+  - stdout: {}
+    tag: foo.*
+`
 
 	FluentdclusterOutput2ES    fluentdv1alpha1.ClusterOutput
 	FluentdclusterOutput2ESRaw = `
@@ -449,6 +515,8 @@ func init() {
 	once.Do(
 		func() {
 			ParseIntoObject(FluentdRaw, &Fluentd)
+			ParseIntoObject(FluentdInputTailRaw, &FluentdInputTail)
+			ParseIntoObject(FluentdClusterOutputTagRaw, &FluentdClusterOutputTag)
 			ParseIntoObject(FluentdClusterFluentdConfig1Raw, &FluentdClusterFluentdConfig1)
 			ParseIntoObject(FluentdClusterFluentdConfig2Raw, &FluentdClusterFluentdConfig2)
 			ParseIntoObject(FluentdConfigUser1Raw, &FluentdConfigUser1)

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusterfilters.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusterfilters.yaml
@@ -427,6 +427,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -1618,6 +1618,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_filters.yaml
@@ -427,6 +427,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -1859,6 +1859,266 @@ spec:
                       description: The @log_level parameter specifies the plugin-specific
                         logging level
                       type: string
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is *string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is *string
+                              enum:
+                              - float
+                              - unixtime
+                              - '*string'
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
                   type: object
                 type: array
               image:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -1618,6 +1618,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/config/crd/bases/fluentd.fluent.io_clusterfilters.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusterfilters.yaml
@@ -427,6 +427,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -1618,6 +1618,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/config/crd/bases/fluentd.fluent.io_filters.yaml
+++ b/config/crd/bases/fluentd.fluent.io_filters.yaml
@@ -427,6 +427,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -1859,6 +1859,266 @@ spec:
                       description: The @log_level parameter specifies the plugin-specific
                         logging level
                       type: string
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is *string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is *string
+                              enum:
+                              - float
+                              - unixtime
+                              - '*string'
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
                   type: object
                 type: array
               image:

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -1618,6 +1618,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/docs/plugins/fluentd/filter/types.md
+++ b/docs/plugins/fluentd/filter/types.md
@@ -6,6 +6,7 @@ FilterCommon defines the common parameters for the filter plugin.
 | Field | Description | Scheme |
 | ----- | ----------- | ------ |
 | logLevel | The @log_level parameter specifies the plugin-specific logging level | *string |
+| tag | Which tag to be matched. | *string |
 # Filter
 
 Filter defines all available filter plugins and their parameters.

--- a/docs/plugins/fluentd/input/tail.md
+++ b/docs/plugins/fluentd/input/tail.md
@@ -1,0 +1,52 @@
+# Tail
+
+The in_tail Input plugin allows Fluentd to read events from the tail of text files. Its behavior is similar to the tail -F command.
+
+
+| Field | Description | Scheme |
+| ----- | ----------- | ------ |
+| tag | The tag of the event. | string |
+| path | The path(s) to read. Multiple paths can be specified, separated by comma ','. | string |
+| pathTimezone | This parameter is for strftime formatted path like /path/to/%Y/%m/%d/. | string |
+| excludePath | The paths excluded from the watcher list. | []string |
+| followInodes | Avoid to read rotated files duplicately. You should set true when you use * or strftime format in path. | *bool |
+| refreshInterval | The interval to refresh the list of watch files. This is used when the path includes *. | *uint32 |
+| limitRecentlyModified | Limits the watching files that the modification time is within the specified time range when using * in path. | *uint32 |
+| skipRefreshOnStartup | Skips the refresh of the watch list on startup. This reduces the startup time when * is used in path. | *bool |
+| readFromHead | Starts to read the logs from the head of the file or the last read position recorded in pos_file, not tail. | *bool |
+| encoding | Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding. If encoding is specified, in_tail changes string to encoding. If encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding. | string |
+| fromEncoding | Specifies the encoding of reading lines. By default, in_tail emits string value as ASCII-8BIT encoding. If encoding is specified, in_tail changes string to encoding. If encoding and fromEncoding both are specified, in_tail tries to encode string from fromEncoding to encoding. | string |
+| readLinesLimit | The number of lines to read with each I/O operation. | *int32 |
+| readBytesLimitPerSecond | The number of reading bytes per second to read with I/O operation. This value should be equal or greater than 8192. | *int32 |
+| maxLineSize | The maximum length of a line. Longer lines than it will be just skipped. | *int32 |
+| multilineFlushInterval | The interval of flushing the buffer for multiline format. | *uint32 |
+| posFile | (recommended) Fluentd will record the position it last read from this file. pos_file handles multiple positions in one file so no need to have multiple pos_file parameters per source. Don't share pos_file between in_tail configurations. It causes unexpected behavior e.g. corrupt pos_file content. | string |
+| posFileCompactionInterval | The interval of doing compaction of pos file. | *uint32 |
+| parse |  | *common.Parse |
+| pathKey | Adds the watching file path to the path_key field. | string |
+| rotateWait | in_tail actually does a bit more than tail -F itself. When rotating a file, some data may still need to be written to the old file as opposed to the new one. in_tail takes care of this by keeping a reference to the old file (even after it has been rotated) for some time before transitioning completely to the new file. This helps prevent data designated for the old file from getting lost. By default, this time interval is 5 seconds. The rotate_wait parameter accepts a single integer representing the number of seconds you want this time interval to be. | *uint32 |
+| enableWatchTimer | Enables the additional watch timer. Setting this parameter to false will significantly reduce CPU and I/O consumption when tailing a large number of files on systems with inotify support. The default is true which results in an additional 1 second timer being used. | *bool |
+| enableStatWatcher | Enables the additional inotify-based watcher. Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing. This option is mainly for avoiding the stuck issue with inotify. | *bool |
+| openOnEveryUpdate | Opens and closes the file on every update instead of leaving it open until it gets rotated. | *bool |
+| emitUnmatchedLines | Emits unmatched lines when <parse> format is not matched for incoming logs. | *bool |
+| ignoreRepeatedPermissionError | If you have to exclude the non-permission files from the watch list, set this parameter to true. It suppresses the repeated permission error logs. | *bool |
+| group | The in_tail plugin can assign each log file to a group, based on user defined rules. The limit parameter controls the total number of lines collected for a group within a rate_period time interval. | *Group |
+# Group
+
+
+
+
+| Field | Description | Scheme |
+| ----- | ----------- | ------ |
+| pattern | Specifies the regular expression for extracting metadata (namespace, podname) from log file path. Default value of the pattern regexp extracts information about namespace, podname, docker_id, container of the log (K8s specific). | string |
+| ratePeriod | Time period in which the group line limit is applied. in_tail resets the counter after every rate_period interval. | *int32 |
+| rule | Grouping rules for log files. | *Rule |
+# Rule
+
+
+
+
+| Field | Description | Scheme |
+| ----- | ----------- | ------ |
+| match | match parameter is used to check if a file belongs to a particular group based on hash keys (named captures from pattern) and hash values (regexp in string) | map[string]string |
+| limit | Maximum number of lines allowed from a group in rate_period time interval. The default value of -1 doesn't throttle log files of that group. | *int32 |

--- a/docs/plugins/fluentd/input/types.md
+++ b/docs/plugins/fluentd/input/types.md
@@ -17,3 +17,4 @@ Input defines all available input plugins and their parameters
 | ----- | ----------- | ------ |
 | forward | in_forward plugin | *Forward |
 | http | in_http plugin | *Http |
+| tail | in_tail plugin | *Tail |

--- a/docs/plugins/fluentd/output/types.md
+++ b/docs/plugins/fluentd/output/types.md
@@ -6,6 +6,7 @@ OutputCommon defines the common parameters for output plugin
 | Field | Description | Scheme |
 | ----- | ----------- | ------ |
 | logLevel | The @log_level parameter specifies the plugin-specific logging level | *string |
+| tag | Which tag to be matched. | *string |
 # Output
 
 Output defines all available output plugins and their parameters

--- a/go.mod
+++ b/go.mod
@@ -58,12 +58,14 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
@@ -72,7 +74,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
+	k8s.io/code-generator v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
+	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
@@ -349,6 +350,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -503,6 +506,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -513,6 +517,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -640,8 +645,13 @@ k8s.io/apimachinery v0.27.1 h1:EGuZiLI95UQQcClhanryclaQE6xjg1Bts6/L3cD7zyc=
 k8s.io/apimachinery v0.27.1/go.mod h1:5ikh59fK3AJ287GUvpUsryoMFtH9zj/ARfWCo3AyXTM=
 k8s.io/client-go v0.26.3 h1:k1UY+KXfkxV2ScEL3gilKcF7761xkYsSD6BC9szIu8s=
 k8s.io/client-go v0.26.3/go.mod h1:ZPNu9lm8/dbRIPAgteN30RSXea6vrCpFvq+MateTUuQ=
+k8s.io/code-generator v0.26.1 h1:dusFDsnNSKlMFYhzIM0jAO1OlnTN5WYwQQ+Ai12IIlo=
+k8s.io/code-generator v0.26.1/go.mod h1:OMoJ5Dqx1wgaQzKgc+ZWaZPfGjdRq/Y3WubFrZmeI3I=
 k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
 k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d h1:U9tB195lKdzwqicbJvyJeOXV7Klv+wNAWENRnXEGi08=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
 k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a h1:gmovKNur38vgoWfGtP5QOGNOA7ki4n6qNYoFAgMlNvg=
@@ -657,5 +667,6 @@ sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMm
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -1150,6 +1150,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object
@@ -6388,6 +6391,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object
@@ -10914,6 +10920,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object
@@ -19433,6 +19442,266 @@ spec:
                       description: The @log_level parameter specifies the plugin-specific
                         logging level
                       type: string
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is *string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is *string
+                              enum:
+                              - float
+                              - unixtime
+                              - '*string'
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
                   type: object
                 type: array
               image:
@@ -25992,6 +26261,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -1150,6 +1150,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object
@@ -6388,6 +6391,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object
@@ -10914,6 +10920,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object
@@ -19433,6 +19442,266 @@ spec:
                       description: The @log_level parameter specifies the plugin-specific
                         logging level
                       type: string
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is *string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is *string
+                              enum:
+                              - float
+                              - unixtime
+                              - '*string'
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
                   type: object
                 type: array
               image:
@@ -25992,6 +26261,9 @@ spec:
                     stdout:
                       description: out_stdout plugin
                       type: object
+                    tag:
+                      description: Which tag to be matched.
+                      type: string
                   type: object
                 type: array
             type: object


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR adds tail plugin to Fluentd globalInputs. It also enables setting tags for all Fluentd plugin types though I believe this has more or less no effect at the moment.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #632 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Users can now utilize tail input for Fluentd
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://docs.fluentd.org/input/tail
```