### PR TITLE
Align CRDs and Operator with the fluentbit loki output 

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
@@ -38,6 +38,7 @@ type Loki struct {
 	// Optional list of keys to remove.
 	RemoveKeys []string `json:"removeKeys,omitempty"`
 	// If set to true and after extracting labels only a single key remains, the log line sent to Loki will be the value of that key in line_format.
+	// +kubebuilder:validation:Enum:=on;off
 	DropSingleKey string `json:"dropSingleKey,omitempty"`
 	// Format to use when flattening the record to a log line. Valid values are json or key_value.
 	// If set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON.

--- a/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
@@ -33,6 +33,12 @@ type Loki struct {
 	// Optional list of record keys that will be placed as stream labels.
 	// This configuration property is for records key only.
 	LabelKeys []string `json:"labelKeys,omitempty"`
+	// Specify the label map file path. The file defines how to extract labels from each record.
+	LabelMapPath string `json:"labelMapPath,omitempty"`
+	// Optional list of keys to remove.
+	RemoveKeys []string `json:"removeKeys,omitempty"`
+	// If set to true and after extracting labels only a single key remains, the log line sent to Loki will be the value of that key in line_format.
+	DropSingleKey string `json:"dropSingleKey,omitempty"`
 	// Format to use when flattening the record to a log line. Valid values are json or key_value.
 	// If set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON.
 	// If set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format.
@@ -41,6 +47,9 @@ type Loki struct {
 	// If set to true, it will add all Kubernetes labels to the Stream labels.
 	// +kubebuilder:validation:Enum:=on;off
 	AutoKubernetesLabels string `json:"autoKubernetesLabels,omitempty"`
+	// Specify the name of the key from the original record that contains the Tenant ID. 
+	// The value of the key is set as X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+	TenantIDKey string `json:"tenantIDKey,omitempty"`
 	*plugins.TLS         `json:"tls,omitempty"`
 }
 
@@ -85,11 +94,23 @@ func (l *Loki) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	if l.LabelKeys != nil && len(l.LabelKeys) > 0 {
 		kvs.Insert("label_keys", utils.ConcatString(l.LabelKeys, ","))
 	}
+	if l.LabelMapPath != "" {
+		kvs.Insert("label_map_path", l.LabelMapPath)
+	}
+	if l.RemoveKeys != nil && len(l.RemoveKeys) > 0 {
+		kvs.Insert("remove_keys", utils.ConcatString(l.RemoveKeys, ","))
+	}
+	if l.DropSingleKey != "" {
+		kvs.Insert("drop_single_key", l.DropSingleKey)
+	}
 	if l.LineFormat != "" {
 		kvs.Insert("line_format", l.LineFormat)
 	}
 	if l.AutoKubernetesLabels != "" {
 		kvs.Insert("auto_kubernetes_labels", l.AutoKubernetesLabels)
+	}
+	if l.TenantIDKey != "" {
+		kvs.Insert("tenant_id_key", l.TenantIDKey)
 	}
 	if l.TLS != nil {
 		tls, err := l.TLS.Params(sl)

--- a/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
@@ -512,6 +512,11 @@ func (in *Loki) DeepCopyInto(out *Loki) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.RemoveKeys != nil {
+		in, out := &in.RemoveKeys, &out.RemoveKeys
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
 		*out = new(plugins.TLS)

--- a/apis/generated/clientset/versioned/fake/register.go
+++ b/apis/generated/clientset/versioned/fake/register.go
@@ -38,14 +38,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/apis/generated/clientset/versioned/scheme/register.go
+++ b/apis/generated/clientset/versioned/scheme/register.go
@@ -38,14 +38,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//	import (
-//	  "k8s.io/client-go/kubernetes"
-//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//	)
+//   import (
+//     "k8s.io/client-go/kubernetes"
+//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//   )
 //
-//	kclientset, _ := kubernetes.NewForConfig(c)
-//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//   kclientset, _ := kubernetes.NewForConfig(c)
+//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1321,8 +1321,8 @@ spec:
                     type: string
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
-                      single key remains, the log line sent to Loki will be the
-                      value of that key in line_format.
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
                     enum:
                     - "on"
                     - "off"
@@ -1461,7 +1461,8 @@ spec:
                   tenantIDKey:
                     description: Specify the name of the key from the original record
                       that contains the Tenant ID. The value of the key is set as
-                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
                     type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1319,6 +1319,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the
+                      value of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -1386,6 +1394,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -1411,6 +1423,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -1441,6 +1458,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -1321,8 +1321,8 @@ spec:
                     type: string
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
-                      single key remains, the log line sent to Loki will be the
-                      value of that key in line_format.
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
                     enum:
                     - "on"
                     - "off"
@@ -1461,7 +1461,8 @@ spec:
                   tenantIDKey:
                     description: Specify the name of the key from the original record
                       that contains the Tenant ID. The value of the key is set as
-                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
                     type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -1319,6 +1319,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the
+                      value of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -1386,6 +1394,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -1411,6 +1423,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -1441,6 +1458,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1321,8 +1321,8 @@ spec:
                     type: string
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
-                      single key remains, the log line sent to Loki will be the
-                      value of that key in line_format.
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
                     enum:
                     - "on"
                     - "off"
@@ -1461,7 +1461,8 @@ spec:
                   tenantIDKey:
                     description: Specify the name of the key from the original record
                       that contains the Tenant ID. The value of the key is set as
-                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
                     type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1319,6 +1319,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the
+                      value of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -1386,6 +1394,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -1411,6 +1423,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -1441,6 +1458,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -1321,8 +1321,8 @@ spec:
                     type: string
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
-                      single key remains, the log line sent to Loki will be the
-                      value of that key in line_format.
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
                     enum:
                     - "on"
                     - "off"
@@ -1461,7 +1461,8 @@ spec:
                   tenantIDKey:
                     description: Specify the name of the key from the original record
                       that contains the Tenant ID. The value of the key is set as
-                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
                     type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -1319,6 +1319,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the
+                      value of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -1386,6 +1394,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -1411,6 +1423,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -1441,6 +1458,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/go.mod
+++ b/go.mod
@@ -58,12 +58,14 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.7.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
@@ -72,7 +74,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
+	k8s.io/code-generator v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
+	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
@@ -349,6 +350,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -503,6 +506,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -513,6 +517,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -640,8 +645,13 @@ k8s.io/apimachinery v0.27.1 h1:EGuZiLI95UQQcClhanryclaQE6xjg1Bts6/L3cD7zyc=
 k8s.io/apimachinery v0.27.1/go.mod h1:5ikh59fK3AJ287GUvpUsryoMFtH9zj/ARfWCo3AyXTM=
 k8s.io/client-go v0.26.3 h1:k1UY+KXfkxV2ScEL3gilKcF7761xkYsSD6BC9szIu8s=
 k8s.io/client-go v0.26.3/go.mod h1:ZPNu9lm8/dbRIPAgteN30RSXea6vrCpFvq+MateTUuQ=
+k8s.io/code-generator v0.26.1 h1:dusFDsnNSKlMFYhzIM0jAO1OlnTN5WYwQQ+Ai12IIlo=
+k8s.io/code-generator v0.26.1/go.mod h1:OMoJ5Dqx1wgaQzKgc+ZWaZPfGjdRq/Y3WubFrZmeI3I=
 k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
 k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d h1:U9tB195lKdzwqicbJvyJeOXV7Klv+wNAWENRnXEGi08=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
 k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20230308215209-15aac26d736a h1:gmovKNur38vgoWfGtP5QOGNOA7ki4n6qNYoFAgMlNvg=
@@ -657,5 +667,6 @@ sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMm
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -3329,6 +3329,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the
+                      value of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -3396,6 +3404,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -3421,6 +3433,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -3451,6 +3468,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -3331,8 +3331,8 @@ spec:
                     type: string
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
-                      single key remains, the log line sent to Loki will be the
-                      value of that key in line_format.
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
                     enum:
                     - "on"
                     - "off"
@@ -3471,7 +3471,8 @@ spec:
                   tenantIDKey:
                     description: Specify the name of the key from the original record
                       that contains the Tenant ID. The value of the key is set as
-                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
                     type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
@@ -22955,6 +22956,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -23022,6 +23031,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -23047,6 +23060,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -23077,6 +23095,12 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3329,6 +3329,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the
+                      value of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -3396,6 +3404,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -3421,6 +3433,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -3451,6 +3468,11 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3331,8 +3331,8 @@ spec:
                     type: string
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
-                      single key remains, the log line sent to Loki will be the
-                      value of that key in line_format.
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
                     enum:
                     - "on"
                     - "off"
@@ -3471,7 +3471,8 @@ spec:
                   tenantIDKey:
                     description: Specify the name of the key from the original record
                       that contains the Tenant ID. The value of the key is set as
-                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
                     type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
@@ -22955,6 +22956,14 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  dropSingleKey:
+                    description: If set to true and after extracting labels only a
+                      single key remains, the log line sent to Loki will be the value
+                      of that key in line_format.
+                    enum:
+                    - "on"
+                    - "off"
+                    type: string
                   host:
                     description: Loki hostname or IP address.
                     type: string
@@ -23022,6 +23031,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  labelMapPath:
+                    description: Specify the label map file path. The file defines
+                      how to extract labels from each record.
+                    type: string
                   labels:
                     description: Stream labels for API request. It can be multiple
                       comma separated of strings specifying  key=value pairs. In addition
@@ -23047,6 +23060,11 @@ spec:
                     maximum: 65535
                     minimum: 1
                     type: integer
+                  removeKeys:
+                    description: Optional list of keys to remove.
+                    items:
+                      type: string
+                    type: array
                   tenantID:
                     description: Tenant ID used by default to push logs to Loki. If
                       omitted or empty it assumes Loki is running in single-tenant
@@ -23077,6 +23095,12 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                     type: object
+                  tenantIDKey:
+                    description: Specify the name of the key from the original record
+                      that contains the Tenant ID. The value of the key is set as
+                      X-Scope-OrgID of HTTP header. It is useful to set Tenant ID
+                      dynamically.
+                    type: string
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer


### PR DESCRIPTION
### What this PR does / why we need it:
This PR aligns the fluent-operator CRDs and Operator with the fluentbit loki output [plugin](https://docs.fluentbit.io/manual/pipeline/outputs/loki) by adding the properties `labelMapPath`, `removeKeys`, `dropSingleKey` and `tenantIDKey`.


### Which issue(s) this PR fixes:
Fixes #737 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```