### PR TITLE
add missing fluentd buffer options

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/custom/custom_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/custom/custom_types.go
@@ -13,7 +13,7 @@ import (
 // +kubebuilder:object:generate:=true
 
 // CustomPlugin is used to support filter plugins that are not implemented yet. <br />
-// **For example usage, refer to https://github.com/jjsiv/fluent-operator/blob/master/docs/best-practice/custom-plugin.md**
+// **For example usage, refer to https://github.com/fluent/fluent-operator/blob/master/docs/best-practice/custom-plugin.md**
 type CustomPlugin struct {
 	Config string `json:"config,omitempty"`
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
@@ -48,10 +48,10 @@ type Loki struct {
 	// If set to true, it will add all Kubernetes labels to the Stream labels.
 	// +kubebuilder:validation:Enum:=on;off
 	AutoKubernetesLabels string `json:"autoKubernetesLabels,omitempty"`
-	// Specify the name of the key from the original record that contains the Tenant ID. 
+	// Specify the name of the key from the original record that contains the Tenant ID.
 	// The value of the key is set as X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically.
-	TenantIDKey string `json:"tenantIDKey,omitempty"`
-	*plugins.TLS         `json:"tls,omitempty"`
+	TenantIDKey  string `json:"tenantIDKey,omitempty"`
+	*plugins.TLS `json:"tls,omitempty"`
 }
 
 // implement Section() method

--- a/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
@@ -261,6 +261,14 @@ func (b *Buffer) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 		ps.InsertPairs("retry_type", fmt.Sprint(*b.RetryType))
 	}
 
+	if b.RetryMaxTimes != nil {
+		ps.InsertPairs("retry_max_times", fmt.Sprint(*b.RetryMaxTimes))
+	}
+
+	if b.RetryForever != nil {
+		ps.InsertPairs("retry_forever", fmt.Sprint(*b.RetryForever))
+	}
+
 	if b.RetryWait != nil {
 		ps.InsertPairs("retry_wait", fmt.Sprint(*b.RetryWait))
 	}

--- a/apis/fluentd/v1alpha1/plugins/input/tail.go
+++ b/apis/fluentd/v1alpha1/plugins/input/tail.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/common"
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/params"
 )
+
 // The in_tail Input plugin allows Fluentd to read events from the tail of text files. Its behavior is similar to the tail -F command.
 type Tail struct {
 	// +kubebuilder:validation:Required

--- a/apis/generated/clientset/versioned/fake/register.go
+++ b/apis/generated/clientset/versioned/fake/register.go
@@ -38,14 +38,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/apis/generated/clientset/versioned/scheme/register.go
+++ b/apis/generated/clientset/versioned/scheme/register.go
@@ -38,14 +38,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/docs/plugins/fluentbit/custom/custom.md
+++ b/docs/plugins/fluentbit/custom/custom.md
@@ -1,6 +1,6 @@
 # CustomPlugin
 
-CustomPlugin is used to support filter plugins that are not implemented yet. <br /> **For example usage, refer to https://github.com/jjsiv/fluent-operator/blob/master/docs/best-practice/custom-plugin.md**
+CustomPlugin is used to support filter plugins that are not implemented yet. <br /> **For example usage, refer to https://github.com/fluent/fluent-operator/blob/master/docs/best-practice/custom-plugin.md**
 
 
 | Field | Description | Scheme |

--- a/docs/plugins/fluentbit/output/loki.md
+++ b/docs/plugins/fluentbit/output/loki.md
@@ -12,6 +12,10 @@ The loki output plugin, allows to ingest your records into a Loki service. <br /
 | tenantID | Tenant ID used by default to push logs to Loki. If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent. | *[plugins.Secret](../secret.md) |
 | labels | Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs. In addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property). | []string |
 | labelKeys | Optional list of record keys that will be placed as stream labels. This configuration property is for records key only. | []string |
+| labelMapPath | Specify the label map file path. The file defines how to extract labels from each record. | string |
+| removeKeys | Optional list of keys to remove. | []string |
+| dropSingleKey | If set to true and after extracting labels only a single key remains, the log line sent to Loki will be the value of that key in line_format. | string |
 | lineFormat | Format to use when flattening the record to a log line. Valid values are json or key_value. If set to json,  the log line sent to Loki will be the Fluent Bit record dumped as JSON. If set to key_value, the log line will be each item in the record concatenated together (separated by a single space) in the format. | string |
 | autoKubernetesLabels | If set to true, it will add all Kubernetes labels to the Stream labels. | string |
+| tenantIDKey | Specify the name of the key from the original record that contains the Tenant ID. The value of the key is set as X-Scope-OrgID of HTTP header. It is useful to set Tenant ID dynamically. | string |
 | tls |  | *[plugins.TLS](../tls.md) |


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Adds 2 missing parameters to Fluentd output buffer section + make fmt & make docs-update
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #752

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```