### PR TITLE
feat: add AWS Kinesis Data Streams output plugin for Fluent Bit

### DIFF
--- a/apis/fluentbit/v1alpha2/clusteroutput_types.go
+++ b/apis/fluentbit/v1alpha2/clusteroutput_types.go
@@ -82,6 +82,8 @@ type OutputSpec struct {
 	DataDog *output.DataDog `json:"datadog,omitempty"`
 	// Firehose defines Firehose Output configuration.
 	Firehose *output.Firehose `json:"firehose,omitempty"`
+	// Kinesis defines Kinesis Output configuration.
+	Kinesis *output.Kinesis `json:"kinesis,omitempty"`
 	// Stackdriver defines Stackdriver Output Configuration
 	Stackdriver *output.Stackdriver `json:"stackdriver,omitempty"`
 	// Splunk defines Splunk Output Configuration

--- a/apis/fluentbit/v1alpha2/plugins/output/kinesis_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/kinesis_types.go
@@ -1,0 +1,78 @@
+package output
+
+import (
+	"fmt"
+	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins"
+	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/params"
+)
+
+// +kubebuilder:object:generate:=true
+
+// The Kinesis output plugin, allows to ingest your records into AWS Kinesis. <br />
+// It uses the new high performance and highly efficient kinesis plugin is called kinesis_streams instead of the older Golang Fluent Bit plugin released in 2019.
+// https://docs.fluentbit.io/manual/pipeline/outputs/kinesis <br />
+// https://github.com/aws/amazon-kinesis-streams-for-fluent-bit <br />
+type Kinesis struct {
+	// The AWS region.
+	Region string `json:"region"`
+	// The name of the Kinesis Streams Delivery stream that you want log records sent to.
+	Stream string `json:"stream"`
+	// Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis.
+	TimeKey string `json:"timeKey,omitempty"`
+	// strftime compliant format string for the timestamp; for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond precision with '%3N' and supports nanosecond precision with '%9N' and '%L'; for example, adding '%3N' to support millisecond '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+	TimeKeyFormat string `json:"timeKeyFormat,omitempty"`
+	// By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Kinesis.
+	LogKey string `json:"logKey,omitempty"`
+	// ARN of an IAM role to assume (for cross account access).
+	RoleARN string `json:"roleARN,omitempty"`
+	// Specify a custom endpoint for the Kinesis API.
+	Endpoint string `json:"endpoint,omitempty"`
+	// Custom endpoint for the STS API.
+	STSEndpoint string `json:"stsEndpoint,omitempty"`
+	// Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true.
+	AutoRetryRequests *bool `json:"autoRetryRequests,omitempty"`
+	// Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.
+	ExternalID string `json:"externalID,omitempty"`
+}
+
+// Name implement Section() method
+func (*Kinesis) Name() string {
+	return "kinesis_streams"
+}
+
+// Params implement Section() method
+func (k *Kinesis) Params(_ plugins.SecretLoader) (*params.KVs, error) {
+	kvs := params.NewKVs()
+	if k.Region != "" {
+		kvs.Insert("region", k.Region)
+	}
+	if k.Stream != "" {
+		kvs.Insert("stream", k.Stream)
+	}
+	if k.TimeKey != "" {
+		kvs.Insert("time_key", k.TimeKey)
+	}
+	if k.TimeKeyFormat != "" {
+		kvs.Insert("time_key_format", k.TimeKeyFormat)
+	}
+	if k.LogKey != "" {
+		kvs.Insert("log_key", k.LogKey)
+	}
+	if k.RoleARN != "" {
+		kvs.Insert("role_arn", k.RoleARN)
+	}
+	if k.Endpoint != "" {
+		kvs.Insert("endpoint", k.Endpoint)
+	}
+	if k.STSEndpoint != "" {
+		kvs.Insert("sts_endpoint", k.STSEndpoint)
+	}
+	if k.AutoRetryRequests != nil {
+		kvs.Insert("auto_retry_requests", fmt.Sprint(*k.AutoRetryRequests))
+	}
+	if k.ExternalID != "" {
+		kvs.Insert("external_id", k.ExternalID)
+	}
+
+	return kvs, nil
+}

--- a/apis/fluentbit/v1alpha2/plugins/output/kinesis_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/kinesis_types_test.go
@@ -1,0 +1,43 @@
+package output
+
+import (
+	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins"
+	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestOutput_Kinesis_Params(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	sl := plugins.NewSecretLoader(nil, "test namespace")
+
+	ki := Kinesis{
+		Region:            "us-east-1",
+		Stream:            "test_stream",
+		TimeKey:           "test_time_key",
+		TimeKeyFormat:     "%Y-%m-%dT%H:%M:%S.%3N",
+		LogKey:            "test_time_key",
+		RoleARN:           "arn:aws:iam:test",
+		Endpoint:          "test_endpoint",
+		STSEndpoint:       "test_sts_endpoint",
+		AutoRetryRequests: ptrBool(true),
+		ExternalID:        "test_external_id",
+	}
+
+	expected := params.NewKVs()
+	expected.Insert("region", "us-east-1")
+	expected.Insert("stream", "test_stream")
+	expected.Insert("time_key", "test_time_key")
+	expected.Insert("time_key_format", "%Y-%m-%dT%H:%M:%S.%3N")
+	expected.Insert("log_key", "test_time_key")
+	expected.Insert("role_arn", "arn:aws:iam:test")
+	expected.Insert("endpoint", "test_endpoint")
+	expected.Insert("sts_endpoint", "test_sts_endpoint")
+	expected.Insert("auto_retry_requests", "true")
+	expected.Insert("external_id", "test_external_id")
+
+	kvs, err := ki.Params(sl)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(kvs).To(gomega.Equal(expected))
+}

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1297,6 +1297,61 @@ spec:
                       will be used.
                     type: string
                 type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
+                type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values
                   are: off, error, warn, info, debug and trace, Defaults to the SERVICE

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -1297,6 +1297,61 @@ spec:
                       will be used.
                     type: string
                 type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
+                type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values
                   are: off, error, warn, info, debug and trace, Defaults to the SERVICE

--- a/cmd/doc-gen/main.go
+++ b/cmd/doc-gen/main.go
@@ -55,7 +55,7 @@ type DocumentsLocation struct {
 
 // Inspired by coreos/prometheus-operator: https://github.com/coreos/prometheus-operator
 func main() {
-	var pluginsLoactions = []DocumentsLocation{
+	var pluginsLocations = []DocumentsLocation{
 		{
 			path: fluentbitPluginPath,
 			name: "fluentbit",
@@ -65,9 +65,9 @@ func main() {
 			name: "fluentd",
 		},
 	}
-	plugins(pluginsLoactions)
+	plugins(pluginsLocations)
 
-	var crdsLoactions = []DocumentsLocation{
+	var crdsLocations = []DocumentsLocation{
 		{
 			path: fluentbitCrdsPath,
 			name: "fluentbit",
@@ -77,7 +77,7 @@ func main() {
 			name: "fluentd",
 		},
 	}
-	crds(crdsLoactions)
+	crds(crdsLocations)
 }
 
 func plugins(docsLocations []DocumentsLocation) {
@@ -140,8 +140,8 @@ func plugins(docsLocations []DocumentsLocation) {
 	}
 }
 
-func crds(docsLoactions []DocumentsLocation) {
-	for _, dl := range docsLoactions {
+func crds(docsLocations []DocumentsLocation) {
+	for _, dl := range docsLocations {
 		var srcs []string
 		err := filepath.Walk(dl.path, func(path string, info os.FileInfo, err error) error {
 			if err != nil {

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1297,6 +1297,61 @@ spec:
                       will be used.
                     type: string
                 type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
+                type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values
                   are: off, error, warn, info, debug and trace, Defaults to the SERVICE

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -1297,6 +1297,61 @@ spec:
                       will be used.
                     type: string
                 type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
+                type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values
                   are: off, error, warn, info, debug and trace, Defaults to the SERVICE

--- a/docs/fluentd.md
+++ b/docs/fluentd.md
@@ -309,6 +309,7 @@ FluentdSpec defines the desired state of Fluentd
 | volumeMounts | Pod volumes to mount into the container's filesystem. Cannot be updated. | []corev1.VolumeMount |
 | volumeClaimTemplates | volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. | []corev1.PersistentVolumeClaim |
 | service | Service represents configurations on the fluentd service. | FluentDService |
+| securityContext | PodSecurityContext represents the security context for the fluentd pods. | *corev1.PodSecurityContext |
 
 [Back to TOC](#table-of-contents)
 # FluentdStatus

--- a/docs/plugins/fluentbit/output/kinesis.md
+++ b/docs/plugins/fluentbit/output/kinesis.md
@@ -1,0 +1,17 @@
+# Kinesis
+
+The Kinesis output plugin, allows to ingest your records into AWS Kinesis. <br /> It uses the new high performance and highly efficient kinesis plugin is called kinesis_streams instead of the older Golang Fluent Bit plugin released in 2019. https://docs.fluentbit.io/manual/pipeline/outputs/kinesis <br /> https://github.com/aws/amazon-kinesis-streams-for-fluent-bit <br />
+
+
+| Field | Description | Scheme |
+| ----- | ----------- | ------ |
+| region | The AWS region. | string |
+| stream | The name of the Kinesis Streams Delivery stream that you want log records sent to. | string |
+| timeKey | Add the timestamp to the record under this key. By default the timestamp from Fluent Bit will not be added to records sent to Kinesis. | string |
+| timeKeyFormat | strftime compliant format string for the timestamp; for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond precision with '%3N' and supports nanosecond precision with '%9N' and '%L'; for example, adding '%3N' to support millisecond '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key. | string |
+| logKey | By default, the whole log record will be sent to Kinesis. If you specify a key name with this option, then only the value of that key will be sent to Kinesis. For example, if you are using the Fluentd Docker log driver, you can specify log_key log and only the log message will be sent to Kinesis. | string |
+| roleARN | ARN of an IAM role to assume (for cross account access). | string |
+| endpoint | Specify a custom endpoint for the Kinesis API. | string |
+| stsEndpoint | Custom endpoint for the STS API. | string |
+| autoRetryRequests | Immediately retry failed requests to AWS services once. This option does not affect the normal Fluent Bit retry mechanism with backoff. Instead, it enables an immediate retry with no delay for networking errors, which may help improve throughput when there are transient/random networking issues. This option defaults to true. | *bool |
+| externalID | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID. | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -3310,6 +3310,61 @@ spec:
                       will be used.
                     type: string
                 type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
+                type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values
                   are: off, error, warn, info, debug and trace, Defaults to the SERVICE
@@ -23371,6 +23426,61 @@ spec:
                       if multiple topics exists, the one set in the record by Topic_Key
                       will be used.
                     type: string
+                type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
                 type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3310,6 +3310,61 @@ spec:
                       will be used.
                     type: string
                 type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
+                type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values
                   are: off, error, warn, info, debug and trace, Defaults to the SERVICE
@@ -23371,6 +23426,61 @@ spec:
                       if multiple topics exists, the one set in the record by Topic_Key
                       will be used.
                     type: string
+                type: object
+              kinesis:
+                description: Kinesis defines Kinesis Output configuration.
+                properties:
+                  autoRetryRequests:
+                    description: Immediately retry failed requests to AWS services
+                      once. This option does not affect the normal Fluent Bit retry
+                      mechanism with backoff. Instead, it enables an immediate retry
+                      with no delay for networking errors, which may help improve
+                      throughput when there are transient/random networking issues.
+                      This option defaults to true.
+                    type: boolean
+                  endpoint:
+                    description: Specify a custom endpoint for the Kinesis API.
+                    type: string
+                  externalID:
+                    description: Specify an external ID for the STS API, can be used
+                      with the role_arn parameter if your role requires an external
+                      ID.
+                    type: string
+                  logKey:
+                    description: By default, the whole log record will be sent to
+                      Kinesis. If you specify a key name with this option, then only
+                      the value of that key will be sent to Kinesis. For example,
+                      if you are using the Fluentd Docker log driver, you can specify
+                      log_key log and only the log message will be sent to Kinesis.
+                    type: string
+                  region:
+                    description: The AWS region.
+                    type: string
+                  roleARN:
+                    description: ARN of an IAM role to assume (for cross account access).
+                    type: string
+                  stream:
+                    description: The name of the Kinesis Streams Delivery stream that
+                      you want log records sent to.
+                    type: string
+                  stsEndpoint:
+                    description: Custom endpoint for the STS API.
+                    type: string
+                  timeKey:
+                    description: Add the timestamp to the record under this key. By
+                      default the timestamp from Fluent Bit will not be added to records
+                      sent to Kinesis.
+                    type: string
+                  timeKeyFormat:
+                    description: strftime compliant format string for the timestamp;
+                      for example, the default is '%Y-%m-%dT%H:%M:%S'. Supports millisecond
+                      precision with '%3N' and supports nanosecond precision with
+                      '%9N' and '%L'; for example, adding '%3N' to support millisecond
+                      '%Y-%m-%dT%H:%M:%S.%3N'. This option is used with time_key.
+                    type: string
+                required:
+                - region
+                - stream
                 type: object
               logLevel:
                 description: 'Set the plugin''s logging verbosity level. Allowed values


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

add another output plugin support for operator with additional minor typo fix

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add AWS Kinesis Data Streams output plugin for Fluent Bit
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```