### PR TITLE
feat: add global log_level support for fluentd

### DIFF
--- a/apis/fluentd/v1alpha1/fluentd_types.go
+++ b/apis/fluentd/v1alpha1/fluentd_types.go
@@ -42,6 +42,11 @@ type FluentdSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Numbers of the workers in Fluentd instance
 	Workers *int32 `json:"workers,omitempty"`
+	// Global logging verbosity
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum:=fatal;error;warn;info;debug;trace
+	// +kubebuilder:default:=info
+	LogLevel string `json:"logLevel,omitempty"`
 	// Fluentd image.
 	Image string `json:"image,omitempty"`
 	// Fluentd Watcher command line arguments.

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -2140,6 +2140,17 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              logLevel:
+                default: info
+                description: Global logging verbosity
+                enum:
+                - fatal
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -18,5 +18,8 @@ spec:
   fluentdCfgSelector:
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"
+  {{- if .Values.fluentd.logLevel }}
+  logLevel: {{ .Values.fluentd.logLevel }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -240,6 +240,7 @@ fluentd:
     requests:
       cpu: 100m
       memory: 128Mi
+  logLevel: ""
   # Configure the output plugin parameter in Fluentd.
   # Fluentd is disabled by default, if you enable it make sure to also set up an output to use.
   output:

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -2140,6 +2140,17 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              logLevel:
+                default: info
+                description: Global logging verbosity
+                enum:
+                - fatal
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/controllers/fluentdconfig_controller.go
+++ b/controllers/fluentdconfig_controller.go
@@ -55,7 +55,7 @@ const (
 	SYSTEM = `# Enable RPC endpoint
 <system>
 	rpc_endpoint 127.0.0.1:24444
-	log_level info
+	log_level %s
 	workers %d
 </system>
 `
@@ -186,7 +186,7 @@ func (r *FluentdConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{}, err
 			}
 
-			systemCfg = fmt.Sprintf(SYSTEM, workers)
+			systemCfg = fmt.Sprintf(SYSTEM, fd.Spec.LogLevel, workers)
 		}
 
 		secName := fmt.Sprintf("%s-config", fd.Name)

--- a/docs/fluentd.md
+++ b/docs/fluentd.md
@@ -289,6 +289,7 @@ FluentdSpec defines the desired state of Fluentd
 | disableService | By default will build the related service according to the globalinputs definition. | bool |
 | replicas | Numbers of the Fluentd instance | *int32 |
 | workers | Numbers of the workers in Fluentd instance | *int32 |
+| logLevel | Global logging verbosity | string |
 | image | Fluentd image. | string |
 | args | Fluentd Watcher command line arguments. | []string |
 | envVars | EnvVars represent environment variables that can be passed to fluentd pods. | []corev1.EnvVar |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -19801,6 +19801,17 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              logLevel:
+                default: info
+                description: Global logging verbosity
+                enum:
+                - fatal
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -19801,6 +19801,17 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              logLevel:
+                default: info
+                description: Global logging verbosity
+                enum:
+                - fatal
+                - error
+                - warn
+                - info
+                - debug
+                - trace
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

allow customers to configure global log_level setting for fluentd
related fluentd doc for reference: https://docs.fluentd.org/deployment/logging

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #761

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add global log_level support for fluentd
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```