### PR TITLE
feat: add scheduler support for fluentbit & fluentd

### DIFF
--- a/apis/fluentbit/v1alpha2/fluentbit_types.go
+++ b/apis/fluentbit/v1alpha2/fluentbit_types.go
@@ -96,6 +96,8 @@ type FluentBitSpec struct {
 	MetricsPort int32 `json:"metricsPort,omitempty"`
 	// Service represents configurations on the fluent-bit service.
 	Service FluentBitService `json:"service,omitempty"`
+	// SchedulerName represents the desired scheduler for fluent-bit pods.
+	SchedulerName string `json:"schedulerName,omitempty"`
 }
 
 // FluentBitService defines the service of the FluentBit

--- a/apis/fluentd/v1alpha1/fluentd_types.go
+++ b/apis/fluentd/v1alpha1/fluentd_types.go
@@ -88,6 +88,8 @@ type FluentdSpec struct {
 	Service FluentDService `json:"service,omitempty"`
 	// PodSecurityContext represents the security context for the fluentd pods.
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	// SchedulerName represents the desired scheduler for fluentd pods.
+	SchedulerName string `json:"schedulerName,omitempty"`
 }
 
 // FluentDService the service of the FluentD

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -4302,6 +4302,10 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluent-bit
+                  pods.
+                type: string
               secrets:
                 description: The Secrets are mounted into /fluent-bit/secrets/<secret-name>.
                 items:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -2253,6 +2253,10 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluentd
+                  pods.
+                type: string
               securityContext:
                 description: PodSecurityContext represents the security context for
                   the fluentd pods.

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -41,6 +41,9 @@ spec:
   affinity:
 {{ toYaml . | indent 4 }}
   {{- end }}
+  {{- if .Values.fluentbit.schedulerName }}
+  schedulerName: {{ .Values.fluentbit.schedulerName }}
+  {{- end }}
   {{- if .Values.fluentbit.secrets }}
   secrets:
 {{ toYaml .Values.fluentbit.secrets | indent 4 }}

--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -18,5 +18,8 @@ spec:
   fluentdCfgSelector:
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"
+  {{- if .Values.fluentd.schedulerName }}
+  schedulerName: {{ .Values.fluentd.schedulerName }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -110,6 +110,7 @@ fluentbit:
   envVars: []
   #  - name: FOO
   #    value: "bar"
+  schedulerName: ""
 
   # Remove the above empty volumes and volumesMounts, and then set additionalVolumes and additionalVolumesMounts as below if you want to collect node exporter metrics
   # additionalVolumes:
@@ -240,6 +241,7 @@ fluentd:
     requests:
       cpu: 100m
       memory: 128Mi
+  schedulerName: ""
   # Configure the output plugin parameter in Fluentd.
   # Fluentd is disabled by default, if you enable it make sure to also set up an output to use.
   output:

--- a/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
@@ -4302,6 +4302,10 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluent-bit
+                  pods.
+                type: string
               secrets:
                 description: The Secrets are mounted into /fluent-bit/secrets/<secret-name>.
                 items:

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -2253,6 +2253,10 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluentd
+                  pods.
+                type: string
               securityContext:
                 description: PodSecurityContext represents the security context for
                   the fluentd pods.

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -15537,6 +15537,10 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluent-bit
+                  pods.
+                type: string
               secrets:
                 description: The Secrets are mounted into /fluent-bit/secrets/<secret-name>.
                 items:
@@ -19913,6 +19917,10 @@ spec:
                 type: object
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
+                type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluentd
+                  pods.
                 type: string
               securityContext:
                 description: PodSecurityContext represents the security context for

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -15537,6 +15537,10 @@ spec:
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
                 type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluent-bit
+                  pods.
+                type: string
               secrets:
                 description: The Secrets are mounted into /fluent-bit/secrets/<secret-name>.
                 items:
@@ -19913,6 +19917,10 @@ spec:
                 type: object
               runtimeClassName:
                 description: RuntimeClassName represents the container runtime configuration.
+                type: string
+              schedulerName:
+                description: SchedulerName represents the desired scheduler for fluentd
+                  pods.
                 type: string
               securityContext:
                 description: PodSecurityContext represents the security context for

--- a/pkg/operator/daemonset.go
+++ b/pkg/operator/daemonset.go
@@ -176,6 +176,10 @@ func MakeDaemonSet(fb fluentbitv1alpha2.FluentBit, logPath string) *appsv1.Daemo
 		ds.Spec.Template.Spec.PriorityClassName = fb.Spec.PriorityClassName
 	}
 
+	if fb.Spec.SchedulerName != "" {
+		ds.Spec.Template.Spec.SchedulerName = fb.Spec.SchedulerName
+	}
+
 	if fb.Spec.Volumes != nil {
 		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, fb.Spec.Volumes...)
 	}

--- a/pkg/operator/sts.go
+++ b/pkg/operator/sts.go
@@ -149,6 +149,10 @@ func MakeStatefulset(fd fluentdv1alpha1.Fluentd) *appsv1.StatefulSet {
 		sts.Spec.Template.Spec.SecurityContext = fd.Spec.SecurityContext
 	}
 
+	if fd.Spec.SchedulerName != "" {
+		sts.Spec.Template.Spec.SchedulerName = fd.Spec.SchedulerName
+	}
+
 	// Mount host or emptydir VolumeSource
 	if fd.Spec.BufferVolume != nil && !fd.Spec.BufferVolume.DisableBufferVolume {
 		bufferVolName := fmt.Sprintf("%s-buffer", fd.Name)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

allow customers to specify custom scheduler for fluentbit and fluentd pods

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #758

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
add scheduler support for fluentbit & fluentd
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```