### PR TITLE
fix: resource deletion and adoption for 3 controllers

### DIFF
--- a/controllers/fluent_controller_finalizer.go
+++ b/controllers/fluent_controller_finalizer.go
@@ -2,10 +2,12 @@ package controllers
 
 import (
 	"context"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -64,33 +66,34 @@ func (r *FluentdReconciler) handleFinalizer(ctx context.Context, instance *fluen
 }
 
 func (r *FluentdReconciler) delete(ctx context.Context, fd *fluentdv1alpha1.Fluentd) error {
-	var sa corev1.ServiceAccount
-	err := r.Get(ctx, client.ObjectKey{Namespace: fd.Namespace, Name: fd.Name}, &sa)
-	if err == nil {
-		if err := r.Delete(ctx, &sa); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else if !errors.IsNotFound(err) {
+	sa := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fd.Name,
+			Namespace: fd.Namespace,
+		},
+	}
+	if err := r.Delete(ctx, &sa); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	// TODO: clusterrole, clusterrolebinding
+
+	sts := appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fd.Name,
+			Namespace: fd.Namespace,
+		},
+	}
+	if err := r.Delete(ctx, &sts); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
-	var svc corev1.Service
-	err = r.Get(ctx, client.ObjectKey{Namespace: fd.Namespace, Name: fd.Name}, &svc)
-	if err == nil {
-		if err := r.Delete(ctx, &svc); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else if !errors.IsNotFound(err) {
-		return err
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fd.Name,
+			Namespace: fd.Namespace,
+		},
 	}
-
-	var sts appsv1.StatefulSet
-	err = r.Get(ctx, client.ObjectKey{Namespace: fd.Namespace, Name: fd.Name}, &sts)
-	if err == nil {
-		if err := r.Delete(ctx, &sts); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else if !errors.IsNotFound(err) {
+	if err := r.Delete(ctx, &svc); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
@@ -99,13 +102,38 @@ func (r *FluentdReconciler) delete(ctx context.Context, fd *fluentdv1alpha1.Flue
 
 func (r *FluentdReconciler) mutate(obj client.Object, fd *fluentdv1alpha1.Fluentd) controllerutil.MutateFn {
 	switch o := obj.(type) {
+	case *rbacv1.ClusterRole:
+		expected, _, _ := operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd", fd.Spec.RBACRules, fd.Spec.ServiceAccountAnnotations)
+
+		return func() error {
+			o.Rules = expected.Rules
+			return nil
+		}
+	case *corev1.ServiceAccount:
+		_, expected, _ := operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd", fd.Spec.RBACRules, fd.Spec.ServiceAccountAnnotations)
+
+		return func() error {
+			o.Labels = expected.Labels
+			o.Annotations = expected.Annotations
+			if err := ctrl.SetControllerReference(fd, o, r.Scheme); err != nil {
+				return err
+			}
+			return nil
+		}
+	case *rbacv1.ClusterRoleBinding:
+		_, _, expected := operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd", fd.Spec.RBACRules, fd.Spec.ServiceAccountAnnotations)
+
+		return func() error {
+			o.RoleRef = expected.RoleRef
+			o.Subjects = expected.Subjects
+			return nil
+		}
 	case *appsv1.StatefulSet:
 		expected := operator.MakeStatefulset(*fd)
 
 		return func() error {
 			o.Labels = expected.Labels
 			o.Spec = expected.Spec
-			o.SetOwnerReferences(nil)
 			if err := ctrl.SetControllerReference(fd, o, r.Scheme); err != nil {
 				return err
 			}
@@ -118,13 +146,11 @@ func (r *FluentdReconciler) mutate(obj client.Object, fd *fluentdv1alpha1.Fluent
 			o.Labels = expected.Labels
 			o.Spec.Selector = expected.Spec.Selector
 			o.Spec.Ports = expected.Spec.Ports
-			o.SetOwnerReferences(nil)
 			if err := ctrl.SetControllerReference(fd, o, r.Scheme); err != nil {
 				return err
 			}
 			return nil
 		}
-
 	default:
 	}
 

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -97,45 +97,33 @@ func (r *FluentBitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Install RBAC resources for the filter plugin kubernetes
-	var rbacObj, saObj, bindingObj client.Object
+	var role, sa, binding client.Object
 	if r.Namespaced {
-		rbacObj, saObj, bindingObj = operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
+		role, sa, binding = operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
 	} else {
-		rbacObj, saObj, bindingObj = operator.MakeRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
+		role, sa, binding = operator.MakeRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 	}
-	// Set ServiceAccount's owner to this fluentbit
-	if err := ctrl.SetControllerReference(&fb, saObj, r.Scheme); err != nil {
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &fb)); err != nil {
 		return ctrl.Result{}, err
 	}
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, rbacObj, r.mutate(rbacObj, fb)); err != nil {
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, sa, r.mutate(sa, &fb)); err != nil {
 		return ctrl.Result{}, err
 	}
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, saObj, r.mutate(saObj, fb)); err != nil {
-		return ctrl.Result{}, err
-	}
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, bindingObj, r.mutate(bindingObj, fb)); err != nil {
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, binding, r.mutate(binding, &fb)); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Deploy Fluent Bit DaemonSet
 	logPath := r.getContainerLogPath(fb)
 	ds := operator.MakeDaemonSet(fb, logPath)
-	if err := ctrl.SetControllerReference(&fb, ds, r.Scheme); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, ds, r.mutate(ds, fb)); err != nil {
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, ds, r.mutate(ds, &fb)); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// Deploy FluentBit Service
 	if !fb.Spec.DisableService {
 		svc := operator.MakeFluentbitService(fb)
-		if err := ctrl.SetControllerReference(&fb, svc, r.Scheme); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		if _, err := controllerutil.CreateOrPatch(ctx, r.Client, svc, r.mutate(svc, fb)); err != nil {
+		if _, err := controllerutil.CreateOrPatch(ctx, r.Client, svc, r.mutate(svc, &fb)); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -153,33 +141,31 @@ func (r *FluentBitReconciler) getContainerLogPath(fb fluentbitv1alpha2.FluentBit
 	}
 }
 
-func (r *FluentBitReconciler) mutate(obj client.Object, fb fluentbitv1alpha2.FluentBit) controllerutil.MutateFn {
-	logPath := r.getContainerLogPath(fb)
+func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.FluentBit) controllerutil.MutateFn {
+	logPath := r.getContainerLogPath(*fb)
 
 	switch o := obj.(type) {
 	case *appsv1.DaemonSet:
-		expected := operator.MakeDaemonSet(fb, logPath)
+		expected := operator.MakeDaemonSet(*fb, logPath)
 
 		return func() error {
 			o.Labels = expected.Labels
 			o.Annotations = expected.Annotations
 			o.Spec = expected.Spec
-			o.SetOwnerReferences(nil)
-			if err := ctrl.SetControllerReference(&fb, o, r.Scheme); err != nil {
+			if err := ctrl.SetControllerReference(fb, o, r.Scheme); err != nil {
 				return err
 			}
 			return nil
 		}
 
 	case *corev1.Service:
-		expected := operator.MakeFluentbitService(fb)
+		expected := operator.MakeFluentbitService(*fb)
 
 		return func() error {
 			o.Labels = expected.Labels
 			o.Spec.Selector = expected.Spec.Selector
 			o.Spec.Ports = expected.Spec.Ports
-			o.SetOwnerReferences(nil)
-			if err := ctrl.SetControllerReference(&fb, o, r.Scheme); err != nil {
+			if err := ctrl.SetControllerReference(fb, o, r.Scheme); err != nil {
 				return err
 			}
 			return nil
@@ -188,25 +174,24 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb fluentbitv1alpha2.Flu
 		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
 
 		return func() error {
-			o.Name = expected.Name
 			o.Rules = expected.Rules
+			if err := ctrl.SetControllerReference(fb, o, r.Scheme); err != nil {
+				return err
+			}
 			return nil
 		}
 	case *rbacv1.ClusterRole:
 		expected, _, _ := operator.MakeRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 		return func() error {
-			o.Name = expected.Name
 			o.Rules = expected.Rules
 			return nil
 		}
-
 	case *corev1.ServiceAccount:
 		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
 
 		return func() error {
-			o.Name = expected.Name
 			o.Annotations = expected.Annotations
-			if err := ctrl.SetControllerReference(&fb, o, r.Scheme); err != nil {
+			if err := ctrl.SetControllerReference(fb, o, r.Scheme); err != nil {
 				return err
 			}
 			return nil
@@ -214,20 +199,20 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb fluentbitv1alpha2.Flu
 	case *rbacv1.RoleBinding:
 		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
 		return func() error {
-			o.Name = expected.Name
 			o.Subjects = expected.Subjects
 			o.RoleRef = expected.RoleRef
+			if err := ctrl.SetControllerReference(fb, o, r.Scheme); err != nil {
+				return err
+			}
 			return nil
 		}
 	case *rbacv1.ClusterRoleBinding:
 		_, _, expected := operator.MakeRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 		return func() error {
-			o.Name = expected.Name
 			o.Subjects = expected.Subjects
 			o.RoleRef = expected.RoleRef
 			return nil
 		}
-
 	default:
 	}
 
@@ -235,23 +220,57 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb fluentbitv1alpha2.Flu
 }
 
 func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.FluentBit) error {
-	var sa corev1.ServiceAccount
-	err := r.Get(ctx, client.ObjectKey{Namespace: fb.Namespace, Name: fb.Name}, &sa)
-	if err == nil {
-		if err := r.Delete(ctx, &sa); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else if !errors.IsNotFound(err) {
+	sa := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fb.Name,
+			Namespace: fb.Namespace,
+		},
+	}
+	if err := r.Delete(ctx, &sa); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
-	var ds appsv1.DaemonSet
-	err = r.Get(ctx, client.ObjectKey{Namespace: fb.Namespace, Name: fb.Name}, &ds)
-	if err == nil {
-		if err := r.Delete(ctx, &ds); err != nil && !errors.IsNotFound(err) {
+	if r.Namespaced {
+		roleName, _, roleBindingName := operator.MakeScopedRBACNames(fb.Name)
+		role := rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      roleName,
+				Namespace: fb.Namespace,
+			},
+		}
+		if err := r.Delete(ctx, &role); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
-	} else if !errors.IsNotFound(err) {
+
+		rolebinding := rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      roleBindingName,
+				Namespace: fb.Namespace,
+			},
+		}
+		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	// TODO: clusterrole, clusterrolebinding
+
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fb.Name,
+			Namespace: fb.Namespace,
+		},
+	}
+	if err := r.Delete(ctx, &ds); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fb.Name,
+			Namespace: fb.Namespace,
+		},
+	}
+	if err := r.Delete(ctx, &svc); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

~resources like sa, svc and sts haven't been generated before calling `Delete()` which leads to the remaining finalizer for collector.~
resource deletion and adoption cleanup and fix for 3 controllers

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```