### PR TITLE
Fix: Correct fluentd prase TimeFormat config key

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
@@ -294,7 +294,7 @@ func (b *Buffer) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 			ps.InsertPairs("time_type", fmt.Sprint(*b.Time.TimeType))
 		}
 		if b.Time.TimeFormat != nil {
-			ps.InsertPairs("time_type", fmt.Sprint(*b.Time.TimeFormat))
+			ps.InsertPairs("time_format", fmt.Sprint(*b.Time.TimeFormat))
 		}
 		if b.Time.Localtime != nil {
 			ps.InsertPairs("localtime", fmt.Sprint(*b.Time.Localtime))

--- a/apis/fluentd/v1alpha1/plugins/common/common_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/common_types.go
@@ -20,10 +20,10 @@ type CommonFields struct {
 
 // Time defines the common parameters for the time plugin
 type Time struct {
-	// parses/formats value according to this type, default is *string
-	// +kubebuilder:validation:Enum:=float;unixtime;*string;mixed
+	// parses/formats value according to this type, default is string
+	// +kubebuilder:validation:Enum:=float;unixtime;string;mixed
 	TimeType *string `json:"timeType,omitempty"`
-	// Process value according to the specified format. This is available only when time_type is *string
+	// Process value according to the specified format. This is available only when time_type is string
 	TimeFormat *string `json:"timeFormat,omitempty"`
 	// If true, uses local time.
 	Localtime *bool `json:"localtime,omitempty"`

--- a/apis/fluentd/v1alpha1/plugins/common/common_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/common_types.go
@@ -199,7 +199,7 @@ func (j *Inject) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 		ps.InsertPairs("time_type", fmt.Sprint(*j.TimeType))
 	}
 	if j.TimeFormat != nil {
-		ps.InsertPairs("time_type", fmt.Sprint(*j.TimeFormat))
+		ps.InsertPairs("time_format", fmt.Sprint(*j.TimeFormat))
 	}
 	if j.Localtime != nil {
 		ps.InsertPairs("localtime", fmt.Sprint(*j.Localtime))

--- a/apis/fluentd/v1alpha1/plugins/common/parse_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/parse_types.go
@@ -75,7 +75,7 @@ func (p *Parse) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 		ps.InsertPairs("time_type", fmt.Sprint(*p.TimeType))
 	}
 	if p.TimeFormat != nil {
-		ps.InsertPairs("time_type", fmt.Sprint(*p.TimeFormat))
+		ps.InsertPairs("time_format", fmt.Sprint(*p.TimeFormat))
 	}
 	if p.Localtime != nil {
 		ps.InsertPairs("localtime", fmt.Sprint(*p.Localtime))

--- a/apis/fluentd/v1alpha1/tests/expected/duplicate-removal-cr-specs.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/duplicate-removal-cr-specs.cfg
@@ -70,7 +70,7 @@
     <parse>
       @type  regexp
       expression  /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) [(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$/
-      time_type  %d/%b/%Y:%H:%M:%S %z
+      time_format  %d/%b/%Y:%H:%M:%S %z
     </parse>
   </filter>
   <match **>
@@ -163,7 +163,7 @@
     <parse>
       @type  regexp
       expression  /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) [(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$/
-      time_type  %d/%b/%Y:%H:%M:%S %z
+      time_format  %d/%b/%Y:%H:%M:%S %z
     </parse>
   </filter>
   <match **>

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusterfilters.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusterfilters.yaml
@@ -180,7 +180,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -194,11 +194,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -338,7 +338,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -348,11 +348,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -392,7 +392,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -402,11 +402,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -200,7 +200,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -210,11 +210,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -549,7 +549,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -559,11 +559,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -1241,7 +1241,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1251,11 +1251,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_filters.yaml
@@ -180,7 +180,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -194,11 +194,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -338,7 +338,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -348,11 +348,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -392,7 +392,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -402,11 +402,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -1747,7 +1747,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1761,11 +1761,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -1996,7 +1996,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -2010,11 +2010,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -200,7 +200,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -210,11 +210,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -549,7 +549,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -559,11 +559,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -1241,7 +1241,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1251,11 +1251,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:

--- a/config/crd/bases/fluentd.fluent.io_clusterfilters.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusterfilters.yaml
@@ -180,7 +180,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -194,11 +194,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -338,7 +338,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -348,11 +348,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -392,7 +392,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -402,11 +402,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -200,7 +200,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -210,11 +210,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -549,7 +549,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -559,11 +559,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -1241,7 +1241,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1251,11 +1251,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:

--- a/config/crd/bases/fluentd.fluent.io_filters.yaml
+++ b/config/crd/bases/fluentd.fluent.io_filters.yaml
@@ -180,7 +180,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -194,11 +194,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -338,7 +338,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -348,11 +348,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -392,7 +392,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -402,11 +402,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -1747,7 +1747,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1761,11 +1761,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -1996,7 +1996,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -2010,11 +2010,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -200,7 +200,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -210,11 +210,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -549,7 +549,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -559,11 +559,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -1241,7 +1241,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1251,11 +1251,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -903,7 +903,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -917,11 +917,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -1061,7 +1061,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1071,11 +1071,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -1115,7 +1115,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -1125,11 +1125,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:
@@ -5051,7 +5051,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -5061,11 +5061,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -5400,7 +5400,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -5410,11 +5410,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -6092,7 +6092,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -6102,11 +6102,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -10755,7 +10755,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -10769,11 +10769,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -10913,7 +10913,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -10923,11 +10923,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -10967,7 +10967,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -10977,11 +10977,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:
@@ -19416,7 +19416,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -19430,11 +19430,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -19665,7 +19665,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -19679,11 +19679,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -25191,7 +25191,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -25201,11 +25201,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -25540,7 +25540,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -25550,11 +25550,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -26232,7 +26232,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -26242,11 +26242,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -903,7 +903,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -917,11 +917,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -1061,7 +1061,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -1071,11 +1071,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -1115,7 +1115,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -1125,11 +1125,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:
@@ -5051,7 +5051,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -5061,11 +5061,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -5400,7 +5400,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -5410,11 +5410,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -6092,7 +6092,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -6102,11 +6102,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -10755,7 +10755,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -10769,11 +10769,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -10913,7 +10913,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -10923,11 +10923,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:
@@ -10967,7 +10967,7 @@ spec:
                                 timeFormat:
                                   description: Process value according to the specified
                                     format. This is available only when time_type
-                                    is *string
+                                    is string
                                   type: string
                                 timeFormatFallbacks:
                                   description: Uses the specified time format as a
@@ -10977,11 +10977,11 @@ spec:
                                   type: string
                                 timeType:
                                   description: parses/formats value according to this
-                                    type, default is *string
+                                    type, default is string
                                   enum:
                                   - float
                                   - unixtime
-                                  - '*string'
+                                  - string
                                   - mixed
                                   type: string
                                 timezone:
@@ -19416,7 +19416,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -19430,11 +19430,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -19665,7 +19665,7 @@ spec:
                               type: string
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -19679,11 +19679,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timeout:
@@ -25191,7 +25191,7 @@ spec:
                           type: string
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -25201,11 +25201,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timekey:
@@ -25540,7 +25540,7 @@ spec:
                           type: boolean
                         timeFormat:
                           description: Process value according to the specified format.
-                            This is available only when time_type is *string
+                            This is available only when time_type is string
                           type: string
                         timeFormatFallbacks:
                           description: Uses the specified time format as a fallback
@@ -25550,11 +25550,11 @@ spec:
                           type: string
                         timeType:
                           description: parses/formats value according to this type,
-                            default is *string
+                            default is string
                           enum:
                           - float
                           - unixtime
-                          - '*string'
+                          - string
                           - mixed
                           type: string
                         timezone:
@@ -26232,7 +26232,7 @@ spec:
                               type: boolean
                             timeFormat:
                               description: Process value according to the specified
-                                format. This is available only when time_type is *string
+                                format. This is available only when time_type is string
                               type: string
                             timeFormatFallbacks:
                               description: Uses the specified time format as a fallback
@@ -26242,11 +26242,11 @@ spec:
                               type: string
                             timeType:
                               description: parses/formats value according to this
-                                type, default is *string
+                                type, default is string
                               enum:
                               - float
                               - unixtime
-                              - '*string'
+                              - string
                               - mixed
                               type: string
                             timezone:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
It changes the TimeFormat config value from `time_type` to `time_format` as it should be.

### Which issue(s) this PR fixes:
Fixes #778
Fixes #781 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fix: Correct fluentd prase TimeFormat config key
Fix: Correct Kubebuilder validation for TimeType from *string to string
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```