### PR TITLE
Introduce stripUnderscores in fluent-operator helm values for fluentbit Input Systemd

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-systemd.yaml
@@ -14,6 +14,7 @@ spec:
     path: {{ .Values.fluentbit.input.systemd.path }}
     db: /fluent-bit/tail/systemd.db
     dbSync: Normal
+    stripUnderscores: {{ .Values.fluentbit.input.systemd.stripUnderscores | quote }}
     systemdFilter:
       - _SYSTEMD_UNIT={{ .Values.containerRuntime }}.service
       {{- if .Values.fluentbit.input.systemd.includeKubelet }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -149,6 +149,7 @@ fluentbit:
       enable: true
       path: "/var/log/journal"
       includeKubelet: true
+      stripUnderscores: "off"
     nodeExporterMetrics: {}
     # uncomment below nodeExporterMetrics section if you want to collect node exporter metrics
   #   nodeExporterMetrics:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Introducing stripUnderscores in fluent-operator helm chart to strip the underscore prefix coming out from the Systemd input. By default, it is set as "off"

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #774 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```