### PR TITLE
Adds the fluentd output plugin for Datadog

### DIFF
--- a/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
@@ -961,6 +961,11 @@ func (in *FluentBitSpec) DeepCopyInto(out *FluentBitSpec) {
 		*out = new(v1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ContainerSecurityContext != nil {
+		in, out := &in.ContainerSecurityContext, &out.ContainerSecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnvVars != nil {
 		in, out := &in.EnvVars, &out.EnvVars
 		*out = make([]v1.EnvVar, len(*in))

--- a/apis/fluentd/v1alpha1/plugins/output/datadog.go
+++ b/apis/fluentd/v1alpha1/plugins/output/datadog.go
@@ -1,0 +1,53 @@
+package output
+
+import "github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins"
+
+// Opensearch defines the parameters for out_opensearch plugin
+type Datadog struct {
+	// This parameter is required in order to authenticate your fluent agent.
+	ApiKey *plugins.Secret `json:"apiKey,omitempty"`
+    // Event format, if true, the event is sent in json format. Othwerwise, in plain text.
+	UseJson *bool `json:"useJson,omitempty"`
+    // Automatically include the Fluentd tag in the record.	
+	IncludeTagKey *bool `json:"includeTagKey,omitempty"`
+	// Where to store the Fluentd tag.
+	TagKey *string `json:"tagKey,omitempty"`
+	// Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added.
+	TimestampKey *string `json:"timestampKey,omitempty"`
+	// If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise.	
+	UseSSL *bool `json:"timestampKey,omitempty"`
+	// Disable SSL validation (useful for proxy forwarding)
+	NoSSLValidation *bool `json:"noSSLValidation,omitempty"`
+	// Port used to send logs over a SSL encrypted connection to Datadog. If use_http is disabled, use 10516 for the US region and 443 for the EU region.
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=65535
+	SSLPort *uint32 `json:"sslPort,omitempty"`
+	// The number of retries before the output plugin stops. Set to -1 for unlimited retries	
+	MaxRetries *uint32 `json:"maxRetries,omitempty"`
+	// The maximum time waited between each retry in seconds
+	MaxBackoff *uint32 `json:"maxBackoff,omitempty"`
+	// Enable HTTP forwarding. If you disable it, make sure to change the port to 10514 or ssl_port to 10516	
+	UseHTTP *bool `json:"useHTTP,omitempty"`
+	// Enable log compression for HTTP	
+	UseCompression *bool `json:"useCompression,omitempty"`
+	// Set the log compression level for HTTP (1 to 9, 9 being the best ratio)	
+	CompressionLevel *uint32 `json:"compressionLevel,omitempty"`
+	// This tells Datadog what integration it is	
+	DDSource *string `json:"ddSource,omitempty"`
+	// Multiple value attribute. Can be used to refine the source attribute	
+	DDSourceCategory *string `json:"ddSourceCategory,omitempty"`
+	// Custom tags with the following format "key1:value1, key2:value2"	
+	DDTags *string `json:"ddTags,omitempty"`
+	// Used by Datadog to identify the host submitting the logs.
+	DDHostname *string `json:"ddHostname,omitempty"`
+	// Used by Datadog to correlate between logs, traces and metrics.	
+	Service *string `json:"service,omitempty"`
+	// Proxy port when logs are not directly forwarded to Datadog and ssl is not used	
+	// +kubebuilder:validation:Minimum:=1
+	// +kubebuilder:validation:Maximum:=65535
+	ProxyPort *uint32 `json:"proxyPort,omitempty"`
+	// Proxy endpoint when logs are not directly forwarded to Datadog	
+	Host *string `json:"host,omitempty"`
+	// HTTP proxy, only takes effect if HTTP forwarding is enabled (use_http). Defaults to HTTP_PROXY/http_proxy env vars.
+	HttpProxy *string `json:"httpProxy,omitempty"`
+}

--- a/apis/fluentd/v1alpha1/plugins/output/datadog.go
+++ b/apis/fluentd/v1alpha1/plugins/output/datadog.go
@@ -2,7 +2,7 @@ package output
 
 import "github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins"
 
-// Opensearch defines the parameters for out_opensearch plugin
+// Data defines the parameters for out_datadog plugin
 type Datadog struct {
 	// This parameter is required in order to authenticate your fluent agent.
 	ApiKey *plugins.Secret `json:"apiKey,omitempty"`

--- a/apis/fluentd/v1alpha1/plugins/output/datadog.go
+++ b/apis/fluentd/v1alpha1/plugins/output/datadog.go
@@ -6,47 +6,47 @@ import "github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins"
 type Datadog struct {
 	// This parameter is required in order to authenticate your fluent agent.
 	ApiKey *plugins.Secret `json:"apiKey,omitempty"`
-    // Event format, if true, the event is sent in json format. Othwerwise, in plain text.
+	// Event format, if true, the event is sent in json format. Othwerwise, in plain text.
 	UseJson *bool `json:"useJson,omitempty"`
-    // Automatically include the Fluentd tag in the record.	
+	// Automatically include the Fluentd tag in the record.
 	IncludeTagKey *bool `json:"includeTagKey,omitempty"`
 	// Where to store the Fluentd tag.
 	TagKey *string `json:"tagKey,omitempty"`
 	// Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added.
 	TimestampKey *string `json:"timestampKey,omitempty"`
-	// If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise.	
-	UseSSL *bool `json:"timestampKey,omitempty"`
+	// If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise.
+	UseSSL *bool `json:"useSSL,omitempty"`
 	// Disable SSL validation (useful for proxy forwarding)
 	NoSSLValidation *bool `json:"noSSLValidation,omitempty"`
 	// Port used to send logs over a SSL encrypted connection to Datadog. If use_http is disabled, use 10516 for the US region and 443 for the EU region.
 	// +kubebuilder:validation:Minimum:=1
 	// +kubebuilder:validation:Maximum:=65535
 	SSLPort *uint32 `json:"sslPort,omitempty"`
-	// The number of retries before the output plugin stops. Set to -1 for unlimited retries	
+	// The number of retries before the output plugin stops. Set to -1 for unlimited retries
 	MaxRetries *uint32 `json:"maxRetries,omitempty"`
 	// The maximum time waited between each retry in seconds
 	MaxBackoff *uint32 `json:"maxBackoff,omitempty"`
-	// Enable HTTP forwarding. If you disable it, make sure to change the port to 10514 or ssl_port to 10516	
+	// Enable HTTP forwarding. If you disable it, make sure to change the port to 10514 or ssl_port to 10516
 	UseHTTP *bool `json:"useHTTP,omitempty"`
-	// Enable log compression for HTTP	
+	// Enable log compression for HTTP
 	UseCompression *bool `json:"useCompression,omitempty"`
-	// Set the log compression level for HTTP (1 to 9, 9 being the best ratio)	
+	// Set the log compression level for HTTP (1 to 9, 9 being the best ratio)
 	CompressionLevel *uint32 `json:"compressionLevel,omitempty"`
-	// This tells Datadog what integration it is	
+	// This tells Datadog what integration it is
 	DDSource *string `json:"ddSource,omitempty"`
-	// Multiple value attribute. Can be used to refine the source attribute	
+	// Multiple value attribute. Can be used to refine the source attribute
 	DDSourceCategory *string `json:"ddSourceCategory,omitempty"`
-	// Custom tags with the following format "key1:value1, key2:value2"	
+	// Custom tags with the following format "key1:value1, key2:value2"
 	DDTags *string `json:"ddTags,omitempty"`
 	// Used by Datadog to identify the host submitting the logs.
 	DDHostname *string `json:"ddHostname,omitempty"`
-	// Used by Datadog to correlate between logs, traces and metrics.	
+	// Used by Datadog to correlate between logs, traces and metrics.
 	Service *string `json:"service,omitempty"`
-	// Proxy port when logs are not directly forwarded to Datadog and ssl is not used	
+	// Proxy port when logs are not directly forwarded to Datadog and ssl is not used
 	// +kubebuilder:validation:Minimum:=1
 	// +kubebuilder:validation:Maximum:=65535
 	ProxyPort *uint32 `json:"proxyPort,omitempty"`
-	// Proxy endpoint when logs are not directly forwarded to Datadog	
+	// Proxy endpoint when logs are not directly forwarded to Datadog
 	Host *string `json:"host,omitempty"`
 	// HTTP proxy, only takes effect if HTTP forwarding is enabled (use_http). Defaults to HTTP_PROXY/http_proxy env vars.
 	HttpProxy *string `json:"httpProxy,omitempty"`

--- a/apis/fluentd/v1alpha1/plugins/output/datadog.go
+++ b/apis/fluentd/v1alpha1/plugins/output/datadog.go
@@ -1,6 +1,6 @@
 package output
 
-import "github.com/fluent/fluent-operator/apis/fluentd/v1alpha1/plugins"
+import "github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins"
 
 // Opensearch defines the parameters for out_opensearch plugin
 type Datadog struct {

--- a/apis/fluentd/v1alpha1/plugins/output/datadog.go
+++ b/apis/fluentd/v1alpha1/plugins/output/datadog.go
@@ -2,7 +2,7 @@ package output
 
 import "github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins"
 
-// Data defines the parameters for out_datadog plugin
+// Datadog defines the parameters for out_datadog plugin
 type Datadog struct {
 	// This parameter is required in order to authenticate your fluent agent.
 	ApiKey *plugins.Secret `json:"apiKey,omitempty"`

--- a/apis/fluentd/v1alpha1/plugins/output/datadog.go
+++ b/apis/fluentd/v1alpha1/plugins/output/datadog.go
@@ -45,7 +45,7 @@ type Datadog struct {
 	// Proxy port when logs are not directly forwarded to Datadog and ssl is not used
 	// +kubebuilder:validation:Minimum:=1
 	// +kubebuilder:validation:Maximum:=65535
-	ProxyPort *uint32 `json:"proxyPort,omitempty"`
+	Port *uint32 `json:"port,omitempty"`
 	// Proxy endpoint when logs are not directly forwarded to Datadog
 	Host *string `json:"host,omitempty"`
 	// HTTP proxy, only takes effect if HTTP forwarding is enabled (use_http). Defaults to HTTP_PROXY/http_proxy env vars.

--- a/apis/fluentd/v1alpha1/plugins/output/datadog.go
+++ b/apis/fluentd/v1alpha1/plugins/output/datadog.go
@@ -35,7 +35,7 @@ type Datadog struct {
 	// This tells Datadog what integration it is
 	DDSource *string `json:"ddSource,omitempty"`
 	// Multiple value attribute. Can be used to refine the source attribute
-	DDSourceCategory *string `json:"ddSourceCategory,omitempty"`
+	DDSourcecategory *string `json:"ddSourcecategory,omitempty"`
 	// Custom tags with the following format "key1:value1, key2:value2"
 	DDTags *string `json:"ddTags,omitempty"`
 	// Used by Datadog to identify the host submitting the logs.

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -162,7 +162,7 @@ func (o *Output) Params(loader plugins.SecretLoader) (*params.PluginStore, error
 
 	if o.Datadog != nil {
 		ps.InsertType(string(params.DatadogOutputType))
-		return o.datadogPlugin(ps, loader)
+		return o.datadogPlugin(ps, loader), nil
 	}
 	return o.customOutput(ps, loader), nil
 
@@ -781,11 +781,11 @@ func (o *Output) customOutput(parent *params.PluginStore, loader plugins.SecretL
 	return parent
 }
 
-func (o *Output) datadogPlugin(parent *params.PluginStore, loader plugins.SecretLoader) (*params.PluginStore, error) {
+func (o *Output) datadogPlugin(parent *params.PluginStore, sl plugins.SecretLoader) *params.PluginStore {
 	if o.Datadog.ApiKey != nil {
-		apiKey, err := loader.LoadSecret(*o.Datadog.ApiKey)
+		apiKey, err := sl.LoadSecret(*o.Datadog.ApiKey)
 		if err != nil {
-			return nil, err
+			return nil
 		}
 		parent.InsertPairs("api_key", apiKey)
 	}
@@ -869,7 +869,7 @@ func (o *Output) datadogPlugin(parent *params.PluginStore, loader plugins.Secret
 	if o.Datadog.HttpProxy != nil {
 		parent.InsertPairs("http_proxy", fmt.Sprint(*o.Datadog.HttpProxy))
 	}
-	return parent, nil
+	return parent
 }
 
 var _ plugins.Plugin = &Output{}

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -843,7 +843,7 @@ func (o *Output) datadogPlugin(parent *params.PluginStore, sl plugins.SecretLoad
 	}
 
 	if o.Datadog.DDSourceCategory != nil {
-		parent.InsertPairs("dd_source_category", fmt.Sprint(*o.Datadog.DDSourceCategory))
+		parent.InsertPairs("dd_sourcecategory", fmt.Sprint(*o.Datadog.DDSourceCategory))
 	}
 
 	if o.Datadog.DDTags != nil {

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"strings"
 
+	"strconv"
+
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins"
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/common"
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/custom"
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/params"
 	"github.com/fluent/fluent-operator/v2/pkg/utils"
-	"strconv"
 )
 
 // OutputCommon defines the common parameters for output plugin
@@ -49,6 +50,8 @@ type Output struct {
 	CustomPlugin *custom.CustomPlugin `json:"customPlugin,omitempty"`
 	// out_cloudwatch plugin
 	CloudWatch *CloudWatch `json:"cloudWatch,omitempty"`
+	// datadog plugin
+	Datadog *Datadog `json:"datadog,omitempty"`
 }
 
 // DeepCopyInto implements the DeepCopyInto interface.
@@ -155,6 +158,11 @@ func (o *Output) Params(loader plugins.SecretLoader) (*params.PluginStore, error
 	if o.CloudWatch != nil {
 		ps.InsertType(string(params.CloudWatchOutputType))
 		return o.cloudWatchPlugin(ps, loader), nil
+	}
+
+	if o.Datadog != nil {
+		ps.InsertType(string(params.DatadogOutputType))
+		return o.datadogPlugin(ps, loader), nil
 	}
 	return o.customOutput(ps, loader), nil
 
@@ -771,6 +779,97 @@ func (o *Output) customOutput(parent *params.PluginStore, loader plugins.SecretL
 	customPlugin, _ := o.CustomPlugin.Params(loader)
 	parent.Content = customPlugin.Content
 	return parent
+}
+
+func (o *Output) datadogPlugin(parent *params.PluginStore, loader plugins.SecretLoader) (*params.PluginStore, error) {
+	if o.Datadog.ApiKey != nil {
+		apiKey, err := loader.LoadSecret(*o.Datadog.ApiKey)
+		if err != nil {
+			return nil, err
+		}
+		parent.InsertPairs("api_key", apiKey)
+	}
+
+	if o.Datadog.UseJson != nil {
+		parent.InsertPairs("use_json", fmt.Sprint(*o.Datadog.UseJson))
+	}
+
+	if o.Datadog.IncludeTagKey != nil {
+		parent.InsertPairs("include_tag_key", fmt.Sprint(*o.Datadog.IncludeTagKey))
+	}
+
+	if o.Datadog.TagKey != nil {
+		parent.InsertPairs("tag_key", fmt.Sprint(*o.Datadog.TagKey))
+	}
+
+	if o.Datadog.TimestampKey != nil {
+		parent.InsertPairs("timestamp_key", fmt.Sprint(*o.Datadog.TimestampKey))
+	}
+
+	if o.Datadog.UseSSL != nil {
+		parent.InsertPairs("use_ssl", fmt.Sprint(*o.Datadog.UseSSL))
+	}
+
+	if o.Datadog.NoSSLValidation != nil {
+		parent.InsertPairs("no_ssl_validation", fmt.Sprint(*o.Datadog.NoSSLValidation))
+	}
+
+	if o.Datadog.SSLPort != nil {
+		parent.InsertPairs("ssl_port", fmt.Sprint(*o.Datadog.SSLPort))
+	}
+
+	if o.Datadog.MaxRetries != nil {
+		parent.InsertPairs("max_retries", fmt.Sprint(*o.Datadog.MaxRetries))
+	}
+
+	if o.Datadog.MaxBackoff != nil {
+		parent.InsertPairs("max_backoff", fmt.Sprint(*o.Datadog.MaxBackoff))
+	}
+
+	if o.Datadog.UseHTTP != nil {
+		parent.InsertPairs("use_http", fmt.Sprint(*o.Datadog.UseHTTP))
+	}
+
+	if o.Datadog.UseCompression != nil {
+		parent.InsertPairs("use_compression", fmt.Sprint(*o.Datadog.UseCompression))
+	}
+
+	if o.Datadog.CompressionLevel != nil {
+		parent.InsertPairs("compression_level", fmt.Sprint(*o.Datadog.CompressionLevel))
+	}
+
+	if o.Datadog.DDSource != nil {
+		parent.InsertPairs("dd_source", fmt.Sprint(*o.Datadog.DDSource))
+	}
+
+	if o.Datadog.DDSourceCategory != nil {
+		parent.InsertPairs("dd_source_category", fmt.Sprint(*o.Datadog.DDSourceCategory))
+	}
+
+	if o.Datadog.DDTags != nil {
+		parent.InsertPairs("dd_tags", fmt.Sprint(*o.Datadog.DDTags))
+	}
+
+	if o.Datadog.DDHostname != nil {
+		parent.InsertPairs("dd_hostname", fmt.Sprint(*o.Datadog.DDHostname))
+	}
+
+	if o.Datadog.Service != nil {
+		parent.InsertPairs("service", fmt.Sprint(*o.Datadog.Service))
+	}
+
+	if o.Datadog.ProxyPort != nil {
+		parent.InsertPairs("proxy_port", fmt.Sprint(*o.Datadog.ProxyPort))
+	}
+
+	if o.Datadog.Host != nil {
+		parent.InsertPairs("host", fmt.Sprint(*o.Datadog.Host))
+	}
+
+	if o.Datadog.HttpProxy != nil {
+		parent.InsertPairs("http_proxy", fmt.Sprint(*o.Datadog.HttpProxy))
+	}
+	return parent, nil
 }
 
 var _ plugins.Plugin = &Output{}

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -858,8 +858,8 @@ func (o *Output) datadogPlugin(parent *params.PluginStore, sl plugins.SecretLoad
 		parent.InsertPairs("service", fmt.Sprint(*o.Datadog.Service))
 	}
 
-	if o.Datadog.ProxyPort != nil {
-		parent.InsertPairs("proxy_port", fmt.Sprint(*o.Datadog.ProxyPort))
+	if o.Datadog.Port != nil {
+		parent.InsertPairs("port", fmt.Sprint(*o.Datadog.Port))
 	}
 
 	if o.Datadog.Host != nil {

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -842,8 +842,8 @@ func (o *Output) datadogPlugin(parent *params.PluginStore, sl plugins.SecretLoad
 		parent.InsertPairs("dd_source", fmt.Sprint(*o.Datadog.DDSource))
 	}
 
-	if o.Datadog.DDSourceCategory != nil {
-		parent.InsertPairs("dd_sourcecategory", fmt.Sprint(*o.Datadog.DDSourceCategory))
+	if o.Datadog.DDSourcecategory != nil {
+		parent.InsertPairs("dd_sourcecategory", fmt.Sprint(*o.Datadog.DDSourcecategory))
 	}
 
 	if o.Datadog.DDTags != nil {

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -162,7 +162,7 @@ func (o *Output) Params(loader plugins.SecretLoader) (*params.PluginStore, error
 
 	if o.Datadog != nil {
 		ps.InsertType(string(params.DatadogOutputType))
-		return o.datadogPlugin(ps, loader), nil
+		return o.datadogPlugin(ps, loader)
 	}
 	return o.customOutput(ps, loader), nil
 

--- a/apis/fluentd/v1alpha1/plugins/params/const.go
+++ b/apis/fluentd/v1alpha1/plugins/params/const.go
@@ -35,6 +35,7 @@ const (
 	MatchPlugin         PluginName = "match"
 	BufferPlugin        PluginName = "buffer"
 	CloudWatchPlugin    PluginName = "cloudwatch_logs"
+	DatadogPlugin       PluginName = "datadog"
 
 	BufferTag    string = "tag"
 	LabelTag     string = "tag"
@@ -66,6 +67,7 @@ const (
 	S3OutputType            OutputType = "s3"
 	LokiOutputType          OutputType = "loki"
 	CloudWatchOutputType    OutputType = "cloudwatch_logs"
+	DatadogOutputType       OutputType = "datadog"
 )
 
 var (

--- a/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
@@ -27,5 +27,7 @@
     @type  datadog
     dd_source  kubernetes
     dd_sourcecategory  kubernetes
+    host  http-intake.logs.datadoghq.com
+    port  443
   </match>
 </label>

--- a/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
@@ -27,5 +27,5 @@
     @type  datadog
     dd_source  kubernetes
     dd_sourcecategory  kubernetes
-   </match>
+  </match>
 </label>

--- a/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
@@ -23,11 +23,9 @@
     </record>
   </filter>
   <match **>
-    @id ClusterFluentdConfig-cluster-fluentd-config::cluster::clusteroutput::fluentd-output-datadog-0
+    @id  ClusterFluentdConfig-cluster-fluentd-config::cluster::clusteroutput::fluentd-output-datadog-0
     @type  datadog
-    dd_source  kubernetes
-    dd_source_category  kubernetes
-    host  http-intake.logs.datadoghq.com
-    port  443
+    service  http-intake.logs.datadoghq.com
+    host  test
   </match>
 </label>

--- a/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
@@ -25,7 +25,7 @@
   <match **>
     @id  ClusterFluentdConfig-cluster-fluentd-config::cluster::clusteroutput::fluentd-output-datadog-0
     @type  datadog
-    service  http-intake.logs.datadoghq.com
-    host  test
-  </match>
+    dd_source  kubernetes
+    dd_sourcecategory  kubernetes
+   </match>
 </label>

--- a/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/fluentd-cluster-cfg-output-datadog.cfg
@@ -1,0 +1,33 @@
+<source>
+  @type  forward
+  bind  0.0.0.0
+  port  24224
+</source>
+<match **>
+  @id  main
+  @type  label_router
+  <route>
+    @label  @a2170d34e9940ec56d328100e375c43e
+    <match>
+      namespaces  default,kube-system
+    </match>
+  </route>
+</match>
+<label @a2170d34e9940ec56d328100e375c43e>
+  <filter **>
+    @id  ClusterFluentdConfig-cluster-fluentd-config::cluster::clusterfilter::fluentd-filter-0
+    @type  record_transformer
+    enable_ruby  true
+    <record>
+      kubernetes_ns  ${record["kubernetes"]["namespace_name"]}
+    </record>
+  </filter>
+  <match **>
+    @id ClusterFluentdConfig-cluster-fluentd-config::cluster::clusteroutput::fluentd-output-datadog-0
+    @type  datadog
+    dd_source  kubernetes
+    dd_source_category  kubernetes
+    host  http-intake.logs.datadoghq.com
+    port  443
+  </match>
+</label>

--- a/apis/fluentd/v1alpha1/tests/helper_test.go
+++ b/apis/fluentd/v1alpha1/tests/helper_test.go
@@ -266,7 +266,7 @@ func Test_ClusterCfgOutput2Datadog(t *testing.T) {
 
 	clustercfgRouter, err := psr.BuildCfgRouter(&FluentdClusterFluentdConfig1)
 	g.Expect(err).NotTo(HaveOccurred())
-	clusterFilters := []fluentdv1alpha1.ClusterFilter{}
+	clusterFilters := []fluentdv1alpha1.ClusterFilter{FluentdClusterFilter1}
 	clusterOutputs := []fluentdv1alpha1.ClusterOutput{FluentdClusterOutput2Datadog}
 	clustercfgResources, _ := psr.PatchAndFilterClusterLevelResources(sl, FluentdClusterFluentdConfig1.GetCfgId(), clusterFilters, clusterOutputs)
 	err = psr.WithCfgResources(*clustercfgRouter.Label, clustercfgResources)
@@ -277,7 +277,7 @@ func Test_ClusterCfgOutput2Datadog(t *testing.T) {
 	for i < maxRuntimes {
 		config, errs := psr.RenderMainConfig(false)
 		g.Expect(errs).NotTo(HaveOccurred())
-		g.Expect(string(getExpectedCfg("./expected/fluentd-cluster-cfg-output-datadog.cfg"))).To(Equal(config))
+		g.Expect(strings.TrimSpace(string(getExpectedCfg("./expected/fluentd-cluster-cfg-output-datadog.cfg")))).To(Equal(config))
 
 		i++
 	}

--- a/apis/fluentd/v1alpha1/tests/helper_test.go
+++ b/apis/fluentd/v1alpha1/tests/helper_test.go
@@ -259,7 +259,7 @@ func Test_ClusterCfgOutput2CloudWatch(t *testing.T) {
 
 func Test_ClusterCfgOutput2Datadog(t *testing.T) {
 	g := NewGomegaWithT(t)
-	sl := plugins.NewSecretLoader(nil, Fluentd.Namespace, nil)
+	sl := plugins.NewSecretLoader(nil, Fluentd.Namespace, logr.Logger{})
 
 	psr := fluentdv1alpha1.NewGlobalPluginResources("main")
 	psr.CombineGlobalInputsPlugins(sl, Fluentd.Spec.GlobalInputs)

--- a/apis/fluentd/v1alpha1/tests/helper_test.go
+++ b/apis/fluentd/v1alpha1/tests/helper_test.go
@@ -1,9 +1,10 @@
 package cfgrender
 
 import (
-	"github.com/go-logr/logr"
 	"strings"
 	"testing"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -251,6 +252,32 @@ func Test_ClusterCfgOutput2CloudWatch(t *testing.T) {
 		config, errs := psr.RenderMainConfig(false)
 		g.Expect(errs).NotTo(HaveOccurred())
 		g.Expect(strings.TrimSpace(string(getExpectedCfg("./expected/fluentd-cluster-cfg-output-cloudwatch.cfg")))).To(Equal(config))
+
+		i++
+	}
+}
+
+func Test_ClusterCfgOutput2Datadog(t *testing.T) {
+	g := NewGomegaWithT(t)
+	sl := plugins.NewSecretLoader(nil, Fluentd.Namespace, nil)
+
+	psr := fluentdv1alpha1.NewGlobalPluginResources("main")
+	psr.CombineGlobalInputsPlugins(sl, Fluentd.Spec.GlobalInputs)
+
+	clustercfgRouter, err := psr.BuildCfgRouter(&FluentdClusterFluentdConfig1)
+	g.Expect(err).NotTo(HaveOccurred())
+	clusterFilters := []fluentdv1alpha1.ClusterFilter{}
+	clusterOutputs := []fluentdv1alpha1.ClusterOutput{FluentdClusterOutput2Datadog}
+	clustercfgResources, _ := psr.PatchAndFilterClusterLevelResources(sl, FluentdClusterFluentdConfig1.GetCfgId(), clusterFilters, clusterOutputs)
+	err = psr.WithCfgResources(*clustercfgRouter.Label, clustercfgResources)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// we should not see any permutations in serialized config
+	i := 0
+	for i < maxRuntimes {
+		config, errs := psr.RenderMainConfig(false)
+		g.Expect(errs).NotTo(HaveOccurred())
+		g.Expect(string(getExpectedCfg("./expected/fluentd-cluster-cfg-output-datadog.cfg"))).To(Equal(config))
 
 		i++
 	}

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -411,7 +411,7 @@ spec:
   outputs: 
   - datadog:
       ddSource: kubernetes
-	  ddSourcecategory: kubernetes
+      ddSourcecategory: kubernetes
 `
 	once sync.Once
 )

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -399,6 +399,23 @@ spec:
       webIdentityTokenFile: /var/run/secrets/something/token
 `
 
+	FluentdClusterOutput2Datadog    fluentdv1alpha1.ClusterOutput
+	FluentdClusterOutput2DatadogRaw = `
+apiVersion: fluentd.fluent.io/v1alpha1
+kind: ClusterOutput
+metadata:
+  name: fluentd-output-datadog
+  labels:
+    output.fluentd.fluent.io/enabled: "true"
+spec: 
+  outputs: 
+  - datadog:
+	  dd_source: kubernetes
+	  dd_sourcecategory: kubernetes
+	  host: http-intake.logs.datadoghq.com
+	  port: 443
+`
+
 	once sync.Once
 )
 
@@ -532,6 +549,7 @@ func init() {
 			ParseIntoObject(FluentdOutputUser1Raw, &FluentdOutputUser1)
 			ParseIntoObject(FluentdClusterOutputCustomRaw, &FluentdClusterOutputCustom)
 			ParseIntoObject(FluentdClusterOutput2CloudWatchRaw, &FluentdClusterOutput2CloudWatch)
+			ParseIntoObject(FluentdClusterOutput2DatadogRaw, &FluentdClusterOutput2Datadog)
 		},
 	)
 }

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -410,10 +410,8 @@ metadata:
 spec: 
   outputs: 
   - datadog:
-	  dd_source: kubernetes
-	  dd_sourcecategory: kubernetes
-	  host: http-intake.logs.datadoghq.com
-	  port: 443
+      service: http-intake.logs.datadoghq.com
+      host: test
 `
 
 	once sync.Once

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -410,6 +410,8 @@ metadata:
 spec: 
   outputs: 
   - datadog:
+      host: http-intake.logs.datadoghq.com
+      port: 443
       ddSource: kubernetes
       ddSourcecategory: kubernetes
 `

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -410,10 +410,9 @@ metadata:
 spec: 
   outputs: 
   - datadog:
-      service: http-intake.logs.datadoghq.com
-      host: test
+      dd_source: kubernetes
+	  dd_sourcecategory: kubernetes
 `
-
 	once sync.Once
 )
 

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -410,8 +410,8 @@ metadata:
 spec: 
   outputs: 
   - datadog:
-      dd_source: kubernetes
-	  dd_sourcecategory: kubernetes
+      ddSource: kubernetes
+	  ddSourcecategory: kubernetes
 `
 	once sync.Once
 )

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
+  creationTimestamp: null
   name: fluentbits.fluentbit.fluent.io
 spec:
   group: fluentbit.fluent.io

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -413,6 +413,129 @@ spec:
                       required:
                       - config
                       type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
+                      type: object
                     elasticsearch:
                       description: out_es plugin
                       properties:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -460,7 +460,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -494,7 +494,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -413,6 +413,129 @@ spec:
                       required:
                       - config
                       type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
+                      type: object
                     elasticsearch:
                       description: out_es plugin
                       properties:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -460,7 +460,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -494,7 +494,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32

--- a/cmd/fluent-watcher/fluentd/Dockerfile.amd64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.amd64
@@ -49,6 +49,7 @@ RUN apk update \
          fluent-plugin-opensearch \
          fluent-plugin-grafana-loki \
          fluent-plugin-cloudwatch-logs \
+         fluent-plugin-datadog \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test
 

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64
@@ -55,6 +55,7 @@ RUN apt-get update \
          fluent-plugin-multi-format-parser \
          fluent-plugin-aws-elasticsearch-service \
          fluent-plugin-opensearch \
+         fluent-plugin-datadog \
  && echo "plugin installed." \
  && wget -O /tmp/jemalloc-5.3.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-5.3.0.tar.bz2 && cd jemalloc-5.3.0/ \

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
@@ -45,6 +45,7 @@ RUN apt-get update \
          fluent-plugin-multi-format-parser \
          fluent-plugin-aws-elasticsearch-service \
          fluent-plugin-opensearch \
+         fluent-plugin-datadog \
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-4.5.0.tar.bz2 && cd jemalloc-4.5.0/ \
  && ./configure && make \

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -413,6 +413,129 @@ spec:
                       required:
                       - config
                       type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
+                      type: object
                     elasticsearch:
                       description: out_es plugin
                       properties:

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -460,7 +460,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -494,7 +494,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -413,6 +413,129 @@ spec:
                       required:
                       - config
                       type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
+                      type: object
                     elasticsearch:
                       description: out_es plugin
                       properties:

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -460,7 +460,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -494,7 +494,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -214,6 +214,7 @@ CollectorSpec defines the desired state of FluentBit
 | bufferPath | The path where buffer chunks are stored. | *string |
 | ports | Ports represents the pod's ports. | []corev1.ContainerPort |
 | service | Service represents configurations on the fluent-bit service. | CollectorService |
+| schedulerName | SchedulerName represents the desired scheduler for the Fluentbit collector pods | string |
 
 [Back to TOC](#table-of-contents)
 # Decorder
@@ -396,6 +397,7 @@ FluentBitSpec defines the desired state of FluentBit
 | dnsPolicy | Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. | corev1.DNSPolicy |
 | metricsPort | MetricsPort is the port used by the metrics server. If this option is set, HttpPort from ClusterFluentBitConfig needs to match this value. Default is 2020. | int32 |
 | service | Service represents configurations on the fluent-bit service. | FluentBitService |
+| schedulerName | SchedulerName represents the desired scheduler for fluent-bit pods. | string |
 
 [Back to TOC](#table-of-contents)
 # InputSpec

--- a/docs/fluentd.md
+++ b/docs/fluentd.md
@@ -311,6 +311,7 @@ FluentdSpec defines the desired state of Fluentd
 | volumeClaimTemplates | volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. | []corev1.PersistentVolumeClaim |
 | service | Service represents configurations on the fluentd service. | FluentDService |
 | securityContext | PodSecurityContext represents the security context for the fluentd pods. | *corev1.PodSecurityContext |
+| schedulerName | SchedulerName represents the desired scheduler for fluentd pods. | string |
 
 [Back to TOC](#table-of-contents)
 # FluentdStatus

--- a/docs/plugins/fluentd/common/common.md
+++ b/docs/plugins/fluentd/common/common.md
@@ -15,8 +15,8 @@ Time defines the common parameters for the time plugin
 
 | Field | Description | Scheme |
 | ----- | ----------- | ------ |
-| timeType | parses/formats value according to this type, default is *string | *string |
-| timeFormat | Process value according to the specified format. This is available only when time_type is *string | *string |
+| timeType | parses/formats value according to this type, default is string | *string |
+| timeFormat | Process value according to the specified format. This is available only when time_type is string | *string |
 | localtime | If true, uses local time. | *bool |
 | utc | If true, uses UTC. | *bool |
 | timezone | Uses the specified timezone. | *string |

--- a/docs/plugins/fluentd/output/datadog.md
+++ b/docs/plugins/fluentd/output/datadog.md
@@ -1,0 +1,28 @@
+# Datadog
+
+Datadog defines the parameters for out_datadog plugin
+
+
+| Field | Description | Scheme |
+| ----- | ----------- | ------ |
+| apiKey | This parameter is required in order to authenticate your fluent agent. | *[plugins.Secret](../secret.md) |
+| useJson | Event format, if true, the event is sent in json format. Othwerwise, in plain text. | *bool |
+| includeTagKey | Automatically include the Fluentd tag in the record. | *bool |
+| tagKey | Where to store the Fluentd tag. | *string |
+| timestampKey | Name of the attribute which will contain timestamp of the log event. If nil, timestamp attribute is not added. | *string |
+| useSSL | If true, the agent initializes a secure connection to Datadog. In clear TCP otherwise. | *bool |
+| noSSLValidation | Disable SSL validation (useful for proxy forwarding) | *bool |
+| sslPort | Port used to send logs over a SSL encrypted connection to Datadog. If use_http is disabled, use 10516 for the US region and 443 for the EU region. | *uint32 |
+| maxRetries | The number of retries before the output plugin stops. Set to -1 for unlimited retries | *uint32 |
+| maxBackoff | The maximum time waited between each retry in seconds | *uint32 |
+| useHTTP | Enable HTTP forwarding. If you disable it, make sure to change the port to 10514 or ssl_port to 10516 | *bool |
+| useCompression | Enable log compression for HTTP | *bool |
+| compressionLevel | Set the log compression level for HTTP (1 to 9, 9 being the best ratio) | *uint32 |
+| ddSource | This tells Datadog what integration it is | *string |
+| ddSourcecategory | Multiple value attribute. Can be used to refine the source attribute | *string |
+| ddTags | Custom tags with the following format \"key1:value1, key2:value2\" | *string |
+| ddHostname | Used by Datadog to identify the host submitting the logs. | *string |
+| service | Used by Datadog to correlate between logs, traces and metrics. | *string |
+| port | Proxy port when logs are not directly forwarded to Datadog and ssl is not used | *uint32 |
+| host | Proxy endpoint when logs are not directly forwarded to Datadog | *string |
+| httpProxy | HTTP proxy, only takes effect if HTTP forwarding is enabled (use_http). Defaults to HTTP_PROXY/http_proxy env vars. | *string |

--- a/docs/plugins/fluentd/output/types.md
+++ b/docs/plugins/fluentd/output/types.md
@@ -24,3 +24,4 @@ Output defines all available output plugins and their parameters
 | loki | out_loki plugin | *Loki |
 | customPlugin | Custom plugin type | *custom.CustomPlugin |
 | cloudWatch | out_cloudwatch plugin | *CloudWatch |
+| datadog | datadog plugin | *Datadog |

--- a/go.mod
+++ b/go.mod
@@ -58,12 +58,14 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/tools v0.9.1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
@@ -72,7 +74,9 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
+	k8s.io/code-generator v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
+	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
@@ -349,6 +350,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
+golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -503,6 +506,7 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -513,6 +517,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.9.1 h1:8WMNJAz3zrtPmnYC7ISf5dEn3MT0gY7jBJfw27yrrLo=
+golang.org/x/tools v0.9.1/go.mod h1:owI94Op576fPu3cIGQeHs3joujW/2Oc6MtlxbF5dfNc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -640,8 +645,13 @@ k8s.io/apimachinery v0.27.2 h1:vBjGaKKieaIreI+oQwELalVG4d8f3YAMNpWLzDXkxeg=
 k8s.io/apimachinery v0.27.2/go.mod h1:XNfZ6xklnMCOGGFNqXG7bUrQCoR04dh/E7FprV6pb+E=
 k8s.io/client-go v0.26.3 h1:k1UY+KXfkxV2ScEL3gilKcF7761xkYsSD6BC9szIu8s=
 k8s.io/client-go v0.26.3/go.mod h1:ZPNu9lm8/dbRIPAgteN30RSXea6vrCpFvq+MateTUuQ=
+k8s.io/code-generator v0.26.1 h1:dusFDsnNSKlMFYhzIM0jAO1OlnTN5WYwQQ+Ai12IIlo=
+k8s.io/code-generator v0.26.1/go.mod h1:OMoJ5Dqx1wgaQzKgc+ZWaZPfGjdRq/Y3WubFrZmeI3I=
 k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
 k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d h1:U9tB195lKdzwqicbJvyJeOXV7Klv+wNAWENRnXEGi08=
+k8s.io/gengo v0.0.0-20220902162205-c0856e24416d/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
 k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f h1:2kWPakN3i/k81b0gvD5C5FJ2kxm1WrQFanWchyKuqGg=
@@ -657,5 +667,6 @@ sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMm
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5345,7 +5345,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32
@@ -25768,7 +25768,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5311,7 +5311,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string
@@ -25734,7 +25734,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5264,6 +5264,129 @@ spec:
                       required:
                       - config
                       type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
+                      type: object
                     elasticsearch:
                       description: out_es plugin
                       properties:
@@ -25563,6 +25686,129 @@ spec:
                           type: string
                       required:
                       - config
+                      type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
                       type: object
                     elasticsearch:
                       description: out_es plugin

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5345,7 +5345,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32
@@ -25768,7 +25768,7 @@ spec:
                         noSSLValidation:
                           description: Disable SSL validation (useful for proxy forwarding)
                           type: boolean
-                        proxyPort:
+                        port:
                           description: Proxy port when logs are not directly forwarded
                             to Datadog and ssl is not used
                           format: int32

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5311,7 +5311,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string
@@ -25734,7 +25734,7 @@ spec:
                         ddSource:
                           description: This tells Datadog what integration it is
                           type: string
-                        ddSourceCategory:
+                        ddSourcecategory:
                           description: Multiple value attribute. Can be used to refine
                             the source attribute
                           type: string

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5264,6 +5264,129 @@ spec:
                       required:
                       - config
                       type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
+                      type: object
                     elasticsearch:
                       description: out_es plugin
                       properties:
@@ -25563,6 +25686,129 @@ spec:
                           type: string
                       required:
                       - config
+                      type: object
+                    datadog:
+                      description: datadog plugin
+                      properties:
+                        apiKey:
+                          description: This parameter is required in order to authenticate
+                            your fluent agent.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
+                        compressionLevel:
+                          description: Set the log compression level for HTTP (1 to
+                            9, 9 being the best ratio)
+                          format: int32
+                          type: integer
+                        ddHostname:
+                          description: Used by Datadog to identify the host submitting
+                            the logs.
+                          type: string
+                        ddSource:
+                          description: This tells Datadog what integration it is
+                          type: string
+                        ddSourceCategory:
+                          description: Multiple value attribute. Can be used to refine
+                            the source attribute
+                          type: string
+                        ddTags:
+                          description: Custom tags with the following format "key1:value1,
+                            key2:value2"
+                          type: string
+                        host:
+                          description: Proxy endpoint when logs are not directly forwarded
+                            to Datadog
+                          type: string
+                        httpProxy:
+                          description: HTTP proxy, only takes effect if HTTP forwarding
+                            is enabled (use_http). Defaults to HTTP_PROXY/http_proxy
+                            env vars.
+                          type: string
+                        includeTagKey:
+                          description: Automatically include the Fluentd tag in the
+                            record.
+                          type: boolean
+                        maxBackoff:
+                          description: The maximum time waited between each retry
+                            in seconds
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          description: The number of retries before the output plugin
+                            stops. Set to -1 for unlimited retries
+                          format: int32
+                          type: integer
+                        noSSLValidation:
+                          description: Disable SSL validation (useful for proxy forwarding)
+                          type: boolean
+                        proxyPort:
+                          description: Proxy port when logs are not directly forwarded
+                            to Datadog and ssl is not used
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        service:
+                          description: Used by Datadog to correlate between logs,
+                            traces and metrics.
+                          type: string
+                        sslPort:
+                          description: Port used to send logs over a SSL encrypted
+                            connection to Datadog. If use_http is disabled, use 10516
+                            for the US region and 443 for the EU region.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        tagKey:
+                          description: Where to store the Fluentd tag.
+                          type: string
+                        timestampKey:
+                          description: Name of the attribute which will contain timestamp
+                            of the log event. If nil, timestamp attribute is not added.
+                          type: string
+                        useCompression:
+                          description: Enable log compression for HTTP
+                          type: boolean
+                        useHTTP:
+                          description: Enable HTTP forwarding. If you disable it,
+                            make sure to change the port to 10514 or ssl_port to 10516
+                          type: boolean
+                        useJson:
+                          description: Event format, if true, the event is sent in
+                            json format. Othwerwise, in plain text.
+                          type: boolean
+                        useSSL:
+                          description: If true, the agent initializes a secure connection
+                            to Datadog. In clear TCP otherwise.
+                          type: boolean
                       type: object
                     elasticsearch:
                       description: out_es plugin


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

This PR adds support for the Fluentd [datadog](https://github.com/DataDog/fluent-plugin-datadog) output plugin.

### Which issue(s) this PR fixes:
Fixes #797 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```