### PR TITLE
Specify init container resources for fluent-operator deployment

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -40,6 +40,8 @@ spec:
         - '-c'
         - set -ex;
           echo CONTAINER_ROOT_DIR=$(docker info -f '{{`{{.DockerRootDir}}`}}' 2> /dev/null) > /fluent-operator/fluent-bit.env
+        resources:
+          {{- toYaml .Values.operator.initcontainer.resources | nindent 10 }}
         volumeMounts:
         - name: env
           mountPath: /fluent-operator
@@ -58,6 +60,8 @@ spec:
         - '-c'
         - set -ex;
           echo CONTAINER_ROOT_DIR={{ .Values.operator.logPath.containerd }} > /fluent-operator/fluent-bit.env
+        resources:
+          {{- toYaml .Values.operator.initcontainer.resources | nindent 10 }}
         volumeMounts:
         - name: env
           mountPath: /fluent-operator
@@ -73,6 +77,8 @@ spec:
         - '-c'
         - set -ex;
           echo CONTAINER_ROOT_DIR={{ .Values.operator.logPath.crio }} > /fluent-operator/fluent-bit.env
+        resources:
+          {{- toYaml .Values.operator.initcontainer.resources | nindent 10 }}
         volumeMounts:
         - name: env
           mountPath: /fluent-operator

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -14,6 +14,14 @@ operator:
   initcontainer:
     repository: "docker"
     tag: "20.10"
+
+    resources:
+      limits:
+        cpu: 100m
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
   container:
     repository: "kubesphere/fluent-operator"
     tag: "latest"
@@ -108,8 +116,8 @@ fluentbit:
   # nodeSelector configuration for Fluent Bit pods. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
   # Node tolerations applied to Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-  tolerations: 
-  - operator: Exists
+  tolerations:
+    - operator: Exists
   # Priority Class applied to Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   priorityClassName: ""
   # Environment variables that can be passed to fluentbit pods
@@ -224,9 +232,9 @@ fluentbit:
   kubeedge:
     enable: false
     prometheusRemoteWrite:
-    # Change the host to the address of a cloud-side Prometheus-compatible server that can receive Prometheus remote write data
+      # Change the host to the address of a cloud-side Prometheus-compatible server that can receive Prometheus remote write data
       host: "<cloud-prometheus-service-host>"
-    # Change the port to the port of a cloud-side Prometheus-compatible server that can receive Prometheus remote write data
+      # Change the port to the port of a cloud-side Prometheus-compatible server that can receive Prometheus remote write data
       port: "<cloud-prometheus-service-port>"
 
 fluentd:


### PR DESCRIPTION
### What this PR does / why we need it:

Not having resources specified for init containers prevents deployments in environments where resource definitions are mandated by policy.

### Which issue(s) this PR fixes:
Fixes #816 

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

None.