### PR TITLE
fix: incorrect field names in fluentd buffer plugin

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
@@ -210,7 +210,7 @@ func (b *Buffer) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 	}
 
 	if b.TotalLimitSize != nil {
-		ps.InsertPairs("chunk_limit_size", *b.TotalLimitSize)
+		ps.InsertPairs("total_limit_size", *b.TotalLimitSize)
 	}
 
 	if b.QueueLimitLength != nil {
@@ -254,7 +254,7 @@ func (b *Buffer) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 	}
 
 	if b.RetrySecondaryThreshold != nil {
-		ps.InsertPairs("retry_secondary_threshold", fmt.Sprint(*b.RetryTimeout))
+		ps.InsertPairs("retry_secondary_threshold", fmt.Sprint(*b.RetrySecondaryThreshold))
 	}
 
 	if b.RetryType != nil {

--- a/apis/fluentd/v1alpha1/tests/expected/duplicate-removal-cr-specs.cfg
+++ b/apis/fluentd/v1alpha1/tests/expected/duplicate-removal-cr-specs.cfg
@@ -79,8 +79,8 @@
     <buffer buffertag.*>
       @id  common_buffer
       @type  file
-      chunk_limit_size  5GB
       path  /buffers/fd.log
+      total_limit_size  5GB
     </buffer>
     <server>
       host  host
@@ -98,8 +98,8 @@
     <buffer buffertag.*>
       @id  common_buffer
       @type  file
-      chunk_limit_size  5GB
       path  /buffers/fd.log
+      total_limit_size  5GB
     </buffer>
     <format>
       @type  json
@@ -116,8 +116,8 @@
     <buffer buffertag.*>
       @id  common_buffer
       @type  file
-      chunk_limit_size  5GB
       path  /buffers/fd.log
+      total_limit_size  5GB
     </buffer>
   </match>
 </label>
@@ -172,8 +172,8 @@
     <buffer buffertag.*>
       @id  common_buffer
       @type  file
-      chunk_limit_size  5GB
       path  /buffers/fd.log
+      total_limit_size  5GB
     </buffer>
     <server>
       host  host
@@ -191,8 +191,8 @@
     <buffer buffertag.*>
       @id  common_buffer
       @type  file
-      chunk_limit_size  5GB
       path  /buffers/fd.log
+      total_limit_size  5GB
     </buffer>
     <format>
       @type  json
@@ -209,8 +209,8 @@
     <buffer buffertag.*>
       @id  common_buffer
       @type  file
-      chunk_limit_size  5GB
       path  /buffers/fd.log
+      total_limit_size  5GB
     </buffer>
   </match>
 </label>


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it: fixes a couple of incorrect field mappings in the fluentd buffer plugin.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```