### PR TITLE
[Fix]Fluentd's s3 output plugin is compatible with minio

### DIFF
--- a/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/zz_generated.deepcopy.go
@@ -894,6 +894,11 @@ func (in *FluentBitSpec) DeepCopyInto(out *FluentBitSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.InternalMountPropagation != nil {
+		in, out := &in.InternalMountPropagation, &out.InternalMountPropagation
+		*out = new(v1.MountPropagationMode)
+		**out = **in
+	}
 	in.PositionDB.DeepCopyInto(&out.PositionDB)
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.NodeSelector != nil {

--- a/apis/fluentd/v1alpha1/plugins/output/s3.go
+++ b/apis/fluentd/v1alpha1/plugins/output/s3.go
@@ -10,6 +10,12 @@ type S3 struct {
 	S3Bucket *string `json:"s3Bucket,omitempty"`
 	// The Amazon S3 region name
 	S3Region *string `json:"s3Region,omitempty"`
+	// The endpoint URL (like "http://localhost:9000/")
+	S3Endpoint *string `json:"s3Endpoint,omitempty"`
+	// This prevents AWS SDK from breaking endpoint URL
+	ForcePathStyle *bool `json:"forcePathStyle,omitempty"`
+	// This timestamp is added to each file name
+	TimeSliceFormat *string `json:"timeSliceFormat,omitempty"`
 	// The path prefix of the files on S3.
 	Path *string `json:"path,omitempty"`
 	// The actual S3 path. This is interpolated to the actual path.

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -3,9 +3,8 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	"strconv"
+	"strings"
 
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins"
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins/common"
@@ -513,6 +512,18 @@ func (o *Output) s3Plugin(parent *params.PluginStore, loader plugins.SecretLoade
 	}
 	if o.S3.S3Bucket != nil {
 		parent.InsertPairs("s3_bucket", fmt.Sprint(*o.S3.S3Bucket))
+	}
+	if o.S3.S3Region != nil {
+		parent.InsertPairs("s3_region", fmt.Sprint(*o.S3.S3Region))
+	}
+	if o.S3.S3Endpoint != nil {
+		parent.InsertPairs("s3_endpoint", fmt.Sprint(*o.S3.S3Endpoint))
+	}
+	if o.S3.ForcePathStyle != nil {
+		parent.InsertPairs("force_path_style", fmt.Sprint(*o.S3.ForcePathStyle))
+	}
+	if o.S3.TimeSliceFormat != nil {
+		parent.InsertPairs("time_slice_format", fmt.Sprint(*o.S3.TimeSliceFormat))
 	}
 	if o.S3.Path != nil {
 		parent.InsertPairs("path", fmt.Sprint(*o.S3.Path))

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -1710,6 +1710,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -1718,6 +1722,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -1736,6 +1743,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -1710,6 +1710,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -1718,6 +1722,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -1736,6 +1743,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -1710,6 +1710,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -1718,6 +1722,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -1736,6 +1743,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -1710,6 +1710,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -1718,6 +1722,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -1736,6 +1743,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:

--- a/docs/plugins/fluentd/output/s3.md
+++ b/docs/plugins/fluentd/output/s3.md
@@ -9,6 +9,9 @@ S3 defines the parameters for out_s3 output plugin
 | awsSecKey | The AWS secret key. | *string |
 | s3Bucket | The Amazon S3 bucket name. | *string |
 | s3Region | The Amazon S3 region name | *string |
+| s3Endpoint | The endpoint URL (like "http://localhost:9000/") | *string |
+| forcePathStyle | This prevents AWS SDK from breaking endpoint URL | *bool |
+| timeSliceFormat | This timestamp is added to each file name | *string |
 | path | The path prefix of the files on S3. | *string |
 | s3ObjectKeyFormat | The actual S3 path. This is interpolated to the actual path. | *string |
 | storeAs | The compression type. | *string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -6829,6 +6829,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -6837,6 +6841,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -6855,6 +6862,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:
@@ -29208,6 +29218,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -29216,6 +29230,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -29234,6 +29251,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -6829,6 +6829,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -6837,6 +6841,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -6855,6 +6862,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:
@@ -29208,6 +29218,10 @@ spec:
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        forcePathStyle:
+                          description: This prevents AWS SDK from breaking endpoint
+                            URL
+                          type: boolean
                         path:
                           description: The path prefix of the files on S3.
                           type: string
@@ -29216,6 +29230,9 @@ spec:
                           type: string
                         s3Bucket:
                           description: The Amazon S3 bucket name.
+                          type: string
+                        s3Endpoint:
+                          description: The endpoint URL (like "http://localhost:9000/")
                           type: string
                         s3ObjectKeyFormat:
                           description: The actual S3 path. This is interpolated to
@@ -29234,6 +29251,9 @@ spec:
                           - lzo
                           - json
                           - txt
+                          type: string
+                        timeSliceFormat:
+                          description: This timestamp is added to each file name
                           type: string
                       type: object
                     stdout:


### PR DESCRIPTION
### What this PR does / why we need it:
For the s3 output plugin of Fluentd, parameters are added to be compatible with minio

### Which issue(s) this PR fixes:

Fixes #849

### Does this PR introduced a user-facing change?

```release-note
The following fields were added to the fluentd S3 output plugin
- 's3Endpoint': The endpoint URL (like "http://localhost:9000/")
- 'forcePathStyle': This prevents AWS SDK from breaking endpoint URL
- 'timeSliceFormat': This timestamp is added to each file name
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: [Send Apache Logs to Minio](https://docs.fluentd.org/how-to-guides/apache-to-minio)
- [Other doc]: [S3](https://docs.fluentd.org/output/s3)
```