### PR TITLE
[feat]Support fluentd grok parser plugin

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/common/parse_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/parse_types.go
@@ -12,7 +12,7 @@ type ParseCommon struct {
 	// The @id parameter specifies a unique name for the configuration.
 	Id *string `json:"id,omitempty"`
 	// The @type parameter specifies the type of the plugin.
-	// +kubebuilder:validation:Enum:=regexp;apache2;apache_error;nginx;syslog;csv;tsv;ltsv;json;multiline;none
+	// +kubebuilder:validation:Enum:=regexp;apache2;apache_error;nginx;syslog;csv;tsv;ltsv;json;multiline;none;grok;multiline_grok
 	Type *string `json:"type"`
 	// The @log_level parameter specifies the plugin-specific logging level
 	LogLevel *string `json:"logLevel,omitempty"`
@@ -35,6 +35,33 @@ type Parse struct {
 	// Specify timeout for parse processing.
 	// +kubebuilder:validation:Pattern:="^\\d+(\\.[0-9]{0,2})?(s|m|h|d)?$"
 	Timeout *string `json:"timeout,omitempty"`
+	// The pattern of grok.
+	GrokPattern *string `json:"grokPattern,omitempty"`
+	// Path to the file that includes custom grok patterns.
+	CustomPatternPath *string `json:"customPatternPath,omitempty"`
+	// The key has grok failure reason.
+	GrokFailureKey *string `json:"grokFailureKey,omitempty"`
+	// The regexp to match beginning of multiline. This is only for "multiline_grok".
+	MultiLineStartRegexp *string `json:"multiLineStartRegexp,omitempty"`
+	// Specify grok pattern series set.
+	GrokPatternSeries *string `json:"grokPatternSeries,omitempty"`
+	// Grok Sections
+	Grok []Grok `json:"grok,omitempty"`
+}
+
+type Grok struct {
+	// The name of this grok section.
+	Name *string `json:"name,omitempty"`
+	// The pattern of grok. Required parameter.
+	Pattern *string `json:"pattern,omitempty"`
+	// If true, keep time field in the record.
+	KeepTimeKey *bool `json:"keepTimeKey,omitempty"`
+	// Specify time field for event time. If the event doesn't have this field, current time is used.
+	TimeKey *string `json:"timeKey,omitempty"`
+	// Process value using specified format. This is available only when time_type is string
+	TimeFormat *string `json:"timeFormat,omitempty"`
+	// Use specified timezone. one can parse/format the time value in the specified timezone.
+	TimeZone *string `json:"timeZone,omitempty"`
 }
 
 func (p *Parse) Name() string {
@@ -88,6 +115,44 @@ func (p *Parse) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 	}
 	if p.TimeFormatFallbacks != nil {
 		ps.InsertPairs("time_format_fallbacks", fmt.Sprint(*p.TimeFormatFallbacks))
+	}
+
+	if p.GrokPattern != nil {
+		ps.InsertPairs("grok_pattern", fmt.Sprint(*p.GrokPattern))
+	}
+	if p.CustomPatternPath != nil {
+		ps.InsertPairs("custom_pattern_path", fmt.Sprint(*p.CustomPatternPath))
+	}
+	if p.GrokFailureKey != nil {
+		ps.InsertPairs("grok_failure_key", fmt.Sprint(*p.GrokFailureKey))
+	}
+	if p.MultiLineStartRegexp != nil {
+		ps.InsertPairs("multi_line_start_regexp", fmt.Sprint(*p.MultiLineStartRegexp))
+	}
+	if p.GrokPatternSeries != nil {
+		ps.InsertPairs("grok_pattern_series", fmt.Sprint(*p.GrokPatternSeries))
+	}
+	for _, grok := range p.Grok {
+		g := params.NewPluginStore("grok")
+		if grok.Name != nil {
+			g.InsertPairs("name", fmt.Sprint(*grok.Name))
+		}
+		if grok.Pattern != nil {
+			g.InsertPairs("pattern", fmt.Sprint(*grok.Pattern))
+		}
+		if grok.KeepTimeKey != nil {
+			g.InsertPairs("keep_time_key", fmt.Sprint(*grok.KeepTimeKey))
+		}
+		if grok.TimeKey != nil {
+			g.InsertPairs("time_key", fmt.Sprint(*grok.TimeKey))
+		}
+		if grok.TimeFormat != nil {
+			g.InsertPairs("time_format", fmt.Sprint(*grok.TimeFormat))
+		}
+		if grok.TimeZone != nil {
+			g.InsertPairs("timezone", fmt.Sprint(*grok.TimeZone))
+		}
+		ps.InsertChilds(g)
 	}
 
 	return ps, nil

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusterfilters.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusterfilters.yaml
@@ -156,6 +156,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -163,6 +167,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -177,6 +218,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -223,6 +268,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_filters.yaml
@@ -156,6 +156,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -163,6 +167,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -177,6 +218,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -223,6 +268,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_fluentds.yaml
@@ -1975,6 +1975,10 @@ spec:
                         parse:
                           description: The parse section of http plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -1982,6 +1986,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -1996,6 +2037,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -2042,6 +2087,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -2224,6 +2271,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -2231,6 +2282,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -2245,6 +2333,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -2291,6 +2383,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into

--- a/config/crd/bases/fluentd.fluent.io_clusterfilters.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusterfilters.yaml
@@ -156,6 +156,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -163,6 +167,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -177,6 +218,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -223,6 +268,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into

--- a/config/crd/bases/fluentd.fluent.io_filters.yaml
+++ b/config/crd/bases/fluentd.fluent.io_filters.yaml
@@ -156,6 +156,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -163,6 +167,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -177,6 +218,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -223,6 +268,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into

--- a/config/crd/bases/fluentd.fluent.io_fluentds.yaml
+++ b/config/crd/bases/fluentd.fluent.io_fluentds.yaml
@@ -1975,6 +1975,10 @@ spec:
                         parse:
                           description: The parse section of http plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -1982,6 +1986,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -1996,6 +2037,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -2042,6 +2087,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -2224,6 +2271,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -2231,6 +2282,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -2245,6 +2333,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -2291,6 +2383,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into

--- a/docs/plugins/fluentd/common/parse.md
+++ b/docs/plugins/fluentd/common/parse.md
@@ -21,3 +21,22 @@ Parse defines various parameters for the parse plugin
 | estimateCurrentEvent | If true, use Fluent::Eventnow(current time) as a timestamp when time_key is specified. | *bool |
 | keepTimeKey | If true, keep time field in th record. | *bool |
 | timeout | Specify timeout for parse processing. | *string |
+| grokPattern | The pattern of grok. | *string |
+| customPatternPath | Path to the file that includes custom grok patterns. | *string |
+| grokFailureKey | The key has grok failure reason. | *string |
+| multiLineStartRegexp | The regexp to match beginning of multiline. This is only for "multiline_grok". | *string |
+| grokPatternSeries | Specify grok pattern series set. | *string |
+| grok | Grok Sections. | []Grok |
+
+# Grok
+
+grok defines multiple grok expressions.
+
+| Field       | Description                                                  | Scheme  |
+| ----------- | ------------------------------------------------------------ | ------- |
+| name        | The name of this grok section.                               | *string |
+| pattern     | The pattern of grok. Required parameter.                     | *string |
+| keepTimeKey | If true, keep time field in the record.                      | *bool   |
+| timeKey     | Specify time field for event time. If the event doesn't have this field, current time is used. | *string |
+| timeFormat  | Process value using specified format. This is available only when time_type is string | *string |
+| timeZone    | Use specified timezone. one can parse/format the time value in the specified timezone. | *string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -879,6 +879,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -886,6 +890,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -900,6 +941,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -946,6 +991,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -11132,6 +11179,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -11139,6 +11190,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -11153,6 +11241,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -11199,6 +11291,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -20212,6 +20306,10 @@ spec:
                         parse:
                           description: The parse section of http plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -20219,6 +20317,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -20233,6 +20368,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -20279,6 +20418,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -20461,6 +20602,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -20468,6 +20613,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -20482,6 +20664,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -20528,6 +20714,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -879,6 +879,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -886,6 +890,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -900,6 +941,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -946,6 +991,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -11132,6 +11179,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -11139,6 +11190,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -11153,6 +11241,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -11199,6 +11291,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -20212,6 +20306,10 @@ spec:
                         parse:
                           description: The parse section of http plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -20219,6 +20317,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -20233,6 +20368,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -20279,6 +20418,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into
@@ -20461,6 +20602,10 @@ spec:
                           description: Parse defines various parameters for the parse
                             plugin
                           properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
                             estimateCurrentEvent:
                               description: If true, use Fluent::Eventnow(current time)
                                 as a timestamp when time_key is specified.
@@ -20468,6 +20613,43 @@ spec:
                             expression:
                               description: Specifies the regular expression for matching
                                 logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
                               type: string
                             id:
                               description: The @id parameter specifies a unique name
@@ -20482,6 +20664,10 @@ spec:
                             logLevel:
                               description: The @log_level parameter specifies the
                                 plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
                               type: string
                             timeFormat:
                               description: Process value according to the specified
@@ -20528,6 +20714,8 @@ spec:
                               - json
                               - multiline
                               - none
+                              - grok
+                              - multiline_grok
                               type: string
                             types:
                               description: 'Specify types for converting field into


### PR DESCRIPTION
### What this PR does / why we need it:

Support fluentd grok parser plugin

### Which issue(s) this PR fixes:

Fixes #856

### Does this PR introduced a user-facing change?

```release-note
The following fields were added to the fluentd common.Parse
- 'grokPattern': The pattern of grok.
- 'customPatternPath': Path to the file that includes custom grok patterns.
- 'grokFailureKey': The key has grok failure reason.
- 'multiLineStartRegexp': The regexp to match beginning of multiline. This is only for "multiline_grok".
- 'grokPatternSeries': Specify grok pattern series set.
- 'grok': Grok Sections.
```

### Additional documentation, usage docs, etc.:

```docs
- [Usage]: [Grok Parser for Fluentd](https://github.com/fluent/fluent-plugin-grok-parser)
```