### PR TITLE
add option to configure hostNetwork daemonset propertie

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -19,6 +19,9 @@ spec:
 {{- toYaml .Values.fluentbit.resources | nindent 4  }}
   fluentBitConfigName: fluent-bit-config
   {{- if .Values.fluentbit.namespaceFluentBitCfgSelector }}
+{{- if .Values.fluentbit.hostNetwork }}
+  hostNetwork: {{ .Values.fluentbit.hostNetwork }}
+{{- end }}
   namespaceFluentBitCfgSelector:
 {{ toYaml .Values.fluentbit.namespaceFluentBitCfgSelector | indent 4  }}
   {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -97,6 +97,8 @@ fluentbit:
   imagePullSecrets: []
   # - name: "image-pull-secret"
   secrets: []
+  # fluent-bit daemonset use host network
+  hostNetwork: false 
   # Pod security context for Fluent Bit pods. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   podSecurityContext: {}
   # Security context for Fluent Bit container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
### What this PR does / why we need it:
add option to setup hostNetwork for daemonset

### Which issue(s) this PR fixes:
#862 
Fixes #

### Does this PR introduced a user-facing change?
None

### Additional documentation, usage docs, etc.:
```docs
Add option to setup hostNetwork propertie for fluent-bit DaemonSet for fluentbit-operator helm chart
```