### PR TITLE
#864 Helm chart generation of ClusterOutput for loki

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-loki.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-loki.yaml
@@ -1,0 +1,117 @@
+{{ if .Values.Kubernetes -}}
+{{ if .Values.fluentbit.enable -}}
+{{ if .Values.fluentbit.output.loki -}}
+
+{{ with .Values.fluentbit.output.loki -}}
+{{/* 
+When http{User,Password} or tenantID is a string, make a secret for them
+When these keys are objects, they specify a secret to use generated elsewhere, assumed to exist in the k8s cluster 
+*/}}
+{{ $userSecret := "loki-http-auth" -}}
+{{ $passSecret := "loki-http-pass" -}}
+{{ $tenantIDSecret := "loki-tenant-id" -}}
+
+{{ range $k, $v := dict $userSecret .httpUser $passSecret .httpPassword $tenantIDSecret .tenantID -}}
+{{ if kindIs "string" $v -}}
+---
+secretapiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $k |quote }}
+type: Opaque
+data:
+  value: {{ $v | quote }}
+{{ end -}}
+{{ end -}}
+
+---
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
+metadata:
+  name: loki
+  labels:
+    fluentbit.fluent.io/enabled: "true"
+    fluentbit.fluent.io/component: logging
+spec:
+  loki:
+    {{ if .host }}host: {{ .host | quote }}{{ end }}
+    {{ if .port }}port: {{ .port }}{{ end }}
+    {{- if ne .autoKubernetesLabels nil }}
+    autoKubernetesLabels: {{ .autoKubernetesLabels | quote }}
+    {{- end }}
+    {{- if .labelMapPath }}
+    labelMapPath: {{ .labelMapPath }}
+    {{- end }}
+    {{- if ne .dropSingleKey nil }}
+    dropSingleKey: {{ .dropSingleKey | quote }}
+    {{- end }}
+    {{- if .lineFormat }}
+    lineFormat: {{ .lineFormat }}
+    {{- end }}
+    {{- if .tenantIDKey }}
+    tenantIDKey: {{ .tenantIDKey }}
+    {{- end }}
+
+    {{- if .httpUser }}
+    httpUser: 
+      {{- if kindIs "string" .httpUser }}
+      valueFrom:
+        secretKeyRef:
+          key: 'value'
+          name: {{ $userSecret }}
+          optional: false
+        {{- else }}
+{{ .httpUser | toYaml | indent 6 }}
+      {{- end }}
+    {{- end }}
+
+    {{- if .httpPassword }}
+    httpPassword: 
+      {{- if kindIs "string" .httpPassword }}
+      valueFrom:
+        secretKeyRef:
+          key: 'value'
+          name: {{ $passSecret }}
+          optional: false
+      {{- else }}
+{{ .httpPassword | toYaml | indent 6 }}
+      {{- end }}
+    {{- end }}
+
+    {{- if .tenantID }}
+    tenantID: 
+      {{- if kindIs "string" .tenantID }}
+      valueFrom:
+        secretKeyRef:
+          key: 'value'
+          name: {{ $tenantIDSecret }}
+          optional: false
+      {{- else }}
+{{ .tenantID | toYaml | indent 6 }}
+      {{- end }}
+    {{- end }}
+
+    {{- if .labels }}
+    labels:
+{{ .labels | toYaml | indent 6 }}
+    {{ end -}}
+    
+    {{ if .labelKeys -}}
+    labelKeys:
+{{ .labelKeys | toYaml | indent 6 }}
+    {{ end -}}
+
+    {{ if .removeKeys -}}
+    removeKeys:
+{{ .removeKeys | toYaml | indent 6 }}
+    {{ end -}}
+    
+    {{ if .tls -}}
+{{ .tls | toYaml | indent 6 }}
+    {{ end -}}
+
+{{ end -}}
+
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fluent-operator/templates/fluentbit-output-loki.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-loki.yaml
@@ -1,6 +1,7 @@
 {{ if .Values.Kubernetes -}}
 {{ if .Values.fluentbit.enable -}}
 {{ if .Values.fluentbit.output.loki -}}
+{{ if .Values.fluentbit.output.loki.enable -}}
 
 {{ with .Values.fluentbit.output.loki -}}
 {{/* 
@@ -113,6 +114,7 @@ spec:
 
 {{ end -}}
 
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-output-loki.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-loki.yaml
@@ -33,6 +33,7 @@ metadata:
     fluentbit.fluent.io/enabled: "true"
     fluentbit.fluent.io/component: logging
 spec:
+  matchRegex: (?:kube|service)\.(.*)
   loki:
     {{ if .host }}host: {{ .host | quote }}{{ end }}
     {{ if .port }}port: {{ .port }}{{ end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -246,52 +246,47 @@ fluentbit:
 #        addLabels:
 #          app: "fluentbit"
     
-#    # Loki output. Uncomment to produce a ClusterOutput, to be encapsulated in fluentbit config
-#    # See https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/loki.md
-#    loki:
-#      host: 127.0.0.1
-#      port: 3100
-#      # The following three keys need an entry in 
-#      # Either, give http{User,Password},tenantID string values specifying them directly
-#      httpUser: myuser
-#      httpPassword: mypass
-#      tenantID: mytenant
-#      # Or give them as reference to secrets that you have installed into your kubernetes cluster
-#      httpUser:
-#        valueFrom:
-#          secretKeyRef:
-#            key: value
-#            name: husersecret
-#            optional: true
-#      httpPassword:
-#        valueFrom:
-#          secretKeyRef:
-#            key: value
-#            name: hpasssecret
-#            optional: true
-#      tenantID:
-#        valueFrom:
-#          secretKeyRef:
-#            key: value
-#            name: tenantsecret
-#            optional: true
-#      labels:
-#        - test=me
-#        - once=twice
-#      labelKeys:
-#        - one
-#        - two
-#        - three
-#      removeKeys:
-#        - 'on'
-#        - tw
-#        - th
-#      labelMapPath: /here/it/is
-#      dropSingleKey: off
-#      lineFormat: abc
-#      autoKubernetesLabels: on
-#      tenantIDKey: tidkey
-#      tls:
+    # Loki fluentbit ClusterOutput, to be encapsulated in fluentbit config
+    # See https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/loki.md
+    # See https://docs.fluentbit.io/manual/pipeline/outputs/loki
+    loki:
+      # Switch for generation of fluentbit loki ClusterOutput (and loki basic auth http user and pass secrets if required)
+      enable: false   # Bool
+      host: 127.0.0.1 # String
+      port: 3100      # Int
+      # Either, give http{User,Password},tenantID string values specifying them directly
+      httpUser: myuser
+      httpPassword: mypass
+      tenantID: ''
+      # Or give {http{User,Password},tenantID} as reference to secrets that you have manually installed into your kubernetes cluster
+      #httpUser:
+      #  valueFrom:
+      #    secretKeyRef:
+      #      key: value
+      #      name: husersecret
+      #      optional: true
+      #httpPassword:
+      #  valueFrom:
+      #    secretKeyRef:
+      #      key: value
+      #      name: hpasssecret
+      #      optional: true
+      #tenantID:
+      #  valueFrom:
+      #    secretKeyRef:
+      #      key: value
+      #      name: tenantsecret
+      #      optional: true
+      #
+      #labels: []      # String list of <name>=<value>
+      #labelKeys: []   # String list of <key>
+      #removeKeys: []  # String list of <key> 
+      #labelMapPath: '' # String, path to file, ex /here/it/is
+      #dropSingleKey: off
+      #lineFormat: '' # String
+      #autoKubernetesLabels: on
+      #tenantIDKey:   # String
+      #tls: {}        # *plugins.TLS fluentbit docs
 
   service:
     storage: {}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -245,6 +245,54 @@ fluentbit:
 #        port: 2020
 #        addLabels:
 #          app: "fluentbit"
+    
+#    # Loki output. Uncomment to produce a ClusterOutput, to be encapsulated in fluentbit config
+#    # See https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/loki.md
+#    loki:
+#      host: 127.0.0.1
+#      port: 3100
+#      # The following three keys need an entry in 
+#      # Either, give http{User,Password},tenantID string values specifying them directly
+#      httpUser: myuser
+#      httpPassword: mypass
+#      tenantID: mytenant
+#      # Or give them as reference to secrets that you have installed into your kubernetes cluster
+#      httpUser:
+#        valueFrom:
+#          secretKeyRef:
+#            key: value
+#            name: husersecret
+#            optional: true
+#      httpPassword:
+#        valueFrom:
+#          secretKeyRef:
+#            key: value
+#            name: hpasssecret
+#            optional: true
+#      tenantID:
+#        valueFrom:
+#          secretKeyRef:
+#            key: value
+#            name: tenantsecret
+#            optional: true
+#      labels:
+#        - test=me
+#        - once=twice
+#      labelKeys:
+#        - one
+#        - two
+#        - three
+#      removeKeys:
+#        - 'on'
+#        - tw
+#        - th
+#      labelMapPath: /here/it/is
+#      dropSingleKey: off
+#      lineFormat: abc
+#      autoKubernetesLabels: on
+#      tenantIDKey: tidkey
+#      tls:
+
   service:
     storage: {}
 # Remove the above storage section and uncomment below section if you want to configure file-system as storage for buffer


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
See #864 
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #864

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
No changes required for existing installations/users. Users wishing to use the extra functionality should add a loki section to their values.yaml as documented therein
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```