### PR TITLE
Added SuppressTypeName option to helm, as newer ES needs it for bulk operation

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
@@ -16,6 +16,9 @@ spec:
 {{- if .Values.fluentbit.output.es.path }}
     path: {{ .Values.fluentbit.output.es.path }}
 {{- end }}
+{{- if .Values.fluentbit.output.es.suppressTypeName }}
+    suppressTypeName: {{ .Values.fluentbit.output.es.suppressTypeName | default "Off" | quote }}
+{{- end }}
 {{- if .Values.fluentbit.output.es.bufferSize }}
     bufferSize: {{ .Values.fluentbit.output.es.bufferSize }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -209,6 +209,7 @@ fluentbit:
       host: "<Elasticsearch url like elasticsearch-logging-data.kubesphere-logging-system.svc>"
       port: 9200
       logstashPrefix: ks-logstash-log
+    #      suppressTypeName: "On"
     #      path: ""
     #      bufferSize: "4KB"
     #      index: "fluent-bit"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Newer ElasticSearch versions (more than 7) needs `suppressTypeName: On` for work 
