### PR TITLE
Add ImagePullSecret for fluentd

### DIFF
--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -13,6 +13,10 @@ spec:
         port: {{ .Values.fluentd.port }}
   replicas: {{ .Values.fluentd.replicas }}
   image: {{ .Values.fluentd.image.repository }}:{{ .Values.fluentd.image.tag }}
+  {{- if .Values.fluentd.imagePullSecrets }}
+  imagePullSecrets:
+  {{ toYaml .Values.fluentd.imagePullSecrets | indent 4 }}
+  {{- end }}
   mode: {{ .Values.fluentd.mode }}
   resources:
   {{- toYaml .Values.fluentd.resources | nindent 4  }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -98,7 +98,7 @@ fluentbit:
   # - name: "image-pull-secret"
   secrets: []
   # fluent-bit daemonset use host network
-  hostNetwork: false 
+  hostNetwork: false
   # Pod security context for Fluent Bit pods. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   podSecurityContext: {}
   # Security context for Fluent Bit container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -355,6 +355,10 @@ fluentd:
       cpu: 100m
       memory: 128Mi
   schedulerName: ""
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
   logLevel: ""
   extras: {}
   # Configure the output plugin parameter in Fluentd.


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #879 `, or `Fixes (paste link of issue)`.
-->
Fixes #879 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

We already have support for fluentd. It was just not added in values.yaml.

In FluentdSpec:
<img width="779" alt="image" src="https://github.com/fluent/fluent-operator/assets/56467449/1a42bfb7-75ee-4406-ad7d-fde1f1b10b12">


In MakeFluentdDaemonSet:
<img width="591" alt="image" src="https://github.com/fluent/fluent-operator/assets/56467449/3eb0258f-b397-4a64-a095-92aad6608f88">

