### PR TITLE
feat: added serviceAccountAnnotations to FluentBit resource

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -80,5 +80,9 @@ spec:
   securityContext:
 {{ toYaml .Values.fluentbit.podSecurityContext | nindent 4 }}
   {{- end }}
+  {{- if .Values.fluentbit.serviceAccountAnnotations }}
+  serviceAccountAnnotations:
+{{ toYaml .Values.fluentbit.serviceAccountAnnotations | indent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -91,6 +91,9 @@ fluentbit:
   # Specify additional custom labels for fluentbit-pods
   labels: {}
 
+  # Specify additional custom annotations for fluentbit-serviceaccount
+  serviceAccountAnnotations: {}
+
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

We're deploying the fluent-operator, and corresponding FluentBit resource, on an AWS EKS cluster. As we are using IAM Roles for Service Accounts, we need the ability to add the below annotation to the service account to provide the fluent-bit Pods with access to push to our log sink: 

```
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/fluent-bit-role
```

Without this, we see the follow error messages in the fluent-bit Pods: 

```
[2023/08/25 12:41:41] [error] [aws_credentials] STS assume role request failed
[2023/08/25 12:41:41] [ warn] [aws_credentials] No cached credentials are available and a credential refresh is already in progress. The current co-routine will retry.
```

With the changes in this PR, the service account is correctly annotated to enable the Pods to assume the AWS IAM role. 

I wasn't sure whether:

- The chart version should be bumped in the PR or whether this is automated.
- These changes need to be made to the fluent/fluent-operator chart first.

Please let me know if there are any changes required.

### To reproduce

You'll need an AWS IAM role with a trust relationship that the fluent-bit Pods can assume via [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).

I've installed the Helm chart from thelocal chart directory, i.e. `helm-charts/charts/fluent-operator`, using the following command: 

```bash
helm upgrade --install --namespace kube-system fluent-operator . --values local-values.yaml
```

Where the `local-values.yaml` file contains:

```yaml
namespaceOverride: kube-system
containerRuntime: containerd
operator:
  disableComponentControllers: fluentd
fluentbit:
  serviceAccountAnnotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::781632261136:role/dev-aws-for-fluent-bit-access
fluentd:
  crdsEnable: false
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #897

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```