### PR TITLE
fix: fluentd watchedNamespaces Helm mapping

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.1
+version: 2.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/templates/fluentd-clusterfluentdconfig.yaml
+++ b/charts/fluent-operator/templates/fluentd-clusterfluentdconfig.yaml
@@ -8,9 +8,7 @@ metadata:
     config.fluentd.fluent.io/enabled: "true"
 spec:
   watchedNamespaces:
-  {{- range .Values.fluentd.watchedNamespaces }}
-  - {{ . }}
-  {{- end }}
+    {{- toYaml .Values.fluentd.watchedNamespaces | nindent 4 }}
   clusterFilterSelector:
     matchLabels:
       filter.fluentd.fluent.io/enabled: "true"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

To be able to set an empty array for watchedNamespaces, we need to change the way properties are added. Currently, if we set an empty array as a property, we get the following error message:  `ClusterFluentdConfig.fluentd.fluent.io "fluentd-config" is invalid: spec.watchedNamespaces: Invalid value: "null": spec.watchedNamespaces in body must be of type array: "null"`. The reason for this error message is that `[]` does not count as a value with an index, so the CR key is set to `null`, which is not a valid value.

### Which issue(s) this PR fixes:

See description above.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```