### PR TITLE
Expose ports on collector statefulset

### DIFF
--- a/pkg/operator/collector-statefulset.go
+++ b/pkg/operator/collector-statefulset.go
@@ -117,6 +117,10 @@ func MakefbStatefulset(co fluentbitv1alpha2.Collector) *appsv1.StatefulSet {
 		statefulset.Spec.Template.Spec.Containers[0].VolumeMounts = append(statefulset.Spec.Template.Spec.Containers[0].VolumeMounts, co.Spec.VolumesMounts...)
 	}
 
+	if co.Spec.Ports != nil {
+		statefulset.Spec.Template.Spec.Containers[0].Ports = append(statefulset.Spec.Template.Spec.Containers[0].Ports, co.Spec.Ports...)
+	}
+	
 	// Mount Secrets
 	for _, secret := range co.Spec.Secrets {
 		statefulset.Spec.Template.Spec.Volumes = append(statefulset.Spec.Template.Spec.Volumes, corev1.Volume{


### PR DESCRIPTION
### What this PR does / why we need it:

Pods created by the statefulset of a collector, doesn't expose the ports defined. Only, the service expose the ports.
This PR add those ports to the definition of the statefulset.

### Which issue(s) this PR fixes:
Fixes #916

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```