### PR TITLE
add fluentbit daemonset hostPath toggle

### DIFF
--- a/apis/fluentbit/v1alpha2/fluentbit_types.go
+++ b/apis/fluentbit/v1alpha2/fluentbit_types.go
@@ -70,6 +70,8 @@ type FluentBitSpec struct {
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 	// Pod volumes to mount into the container's filesystem.
 	VolumesMounts []corev1.VolumeMount `json:"volumesMounts,omitempty"`
+	// DisableLogVolumes removes the hostPath mounts for varlibcontainers, varlogs and systemd.
+	DisableLogVolumes bool `json:"disableLogVolumes,omitempty"`
 	// Annotations to add to each Fluentbit pod.
 	Annotations map[string]string `json:"annotations,omitempty"`
 	// Annotations to add to the Fluentbit service account

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbits.yaml
@@ -1043,6 +1043,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              disableLogVolumes:
+                description: DisableLogVolumes removes the hostPath mounts for varlibcontainers,
+                  varlogs and systemd.
+                type: boolean
               disableService:
                 description: DisableService tells if the fluentbit service should
                   be deployed.

--- a/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbits.yaml
@@ -1043,6 +1043,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              disableLogVolumes:
+                description: DisableLogVolumes removes the hostPath mounts for varlibcontainers,
+                  varlogs and systemd.
+                type: boolean
               disableService:
                 description: DisableService tells if the fluentbit service should
                   be deployed.

--- a/config/samples/fluentbit_v1alpha2_fluentbit.yaml
+++ b/config/samples/fluentbit_v1alpha2_fluentbit.yaml
@@ -11,3 +11,4 @@ spec:
     hostPath:
       path: /var/lib/fluent-bit/
   fluentBitConfigName: fluentbitconfig-sample
+  disableLogVolumes: false

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -400,6 +400,7 @@ FluentBitSpec defines the desired state of FluentBit
 | metricsPort | MetricsPort is the port used by the metrics server. If this option is set, HttpPort from ClusterFluentBitConfig needs to match this value. Default is 2020. | int32 |
 | service | Service represents configurations on the fluent-bit service. | FluentBitService |
 | schedulerName | SchedulerName represents the desired scheduler for fluent-bit pods. | string |
+| disableLogVolumes | DisableLogVolumes removes the hostPath mounts for varlibcontainers, varlogs and systemd. | bool |
 
 [Back to TOC](#table-of-contents)
 # InputSpec

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -13109,6 +13109,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              disableLogVolumes:
+                description: DisableLogVolumes removes the hostPath mounts for varlibcontainers,
+                  varlogs and systemd.
+                type: boolean
               disableService:
                 description: DisableService tells if the fluentbit service should
                   be deployed.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -13109,6 +13109,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              disableLogVolumes:
+                description: DisableLogVolumes removes the hostPath mounts for varlibcontainers,
+                  varlogs and systemd.
+                type: boolean
               disableService:
                 description: DisableService tells if the fluentbit service should
                   be deployed.


### PR DESCRIPTION
### What this PR does / why we need it:
Currenly, fluentbit daemonset mounts three hostPath volumes. HostPath is forbidden in some k8s environments. This PR adds a flag `disableLogVolumes` to disable these mounts. 

### Which issue(s) this PR fixes:
Fixes #907 

### Does this PR introduced a user-facing change?

### Additional documentation, usage docs, etc.:
