### PR TITLE
fix: add parserSelector to clusterFluentBitConfig chart templates

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,12 +15,12 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.5.0
+appVersion: 2.5.1
 
 dependencies:
   - name: fluent-bit-crds

--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -20,6 +20,9 @@ spec:
   filterSelector:
     matchLabels:
       fluentbit.fluent.io/enabled: "true"
+  parserSelector:
+    matchLabels:
+      fluentbit.fluent.io/enabled: "true"
   outputSelector:
     matchLabels:
       fluentbit.fluent.io/enabled: "true"

--- a/charts/fluent-operator/templates/fluentbitconfig-fluentbitconfig-edge.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentbitconfig-edge.yaml
@@ -16,6 +16,10 @@ spec:
     matchLabels:
       fluentbit.fluent.io/enabled: "true"
       node-role.kubernetes.io/edge: "true"
+  parserSelector:
+    matchLabels:
+      fluentbit.fluent.io/enabled: "true"
+      node-role.kubernetes.io/edge: "true"
   outputSelector:
     matchLabels:
       fluentbit.fluent.io/enabled: "true"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Add parserSelector for helm chart ClusterFluentBitConfig templates, allowing this config to use custom Parser resources

e.g.
```
{{- if .Values.Kubernetes -}}
{{- if .Values.fluentbit.enable -}}
apiVersion: fluentbit.fluent.io/v1alpha2
kind: ClusterFluentBitConfig
metadata:
  name: fluent-bit-config
  labels:
    app.kubernetes.io/name: fluent-bit
spec:
  service:
    parsersFile: parsers.conf
    httpServer: true
{{- if .Values.fluentbit.service.storage }}
    storage:
{{ toYaml .Values.fluentbit.service.storage | indent 6 }}
{{- end }}
  inputSelector:
    matchLabels:
      fluentbit.fluent.io/enabled: "true"
  filterSelector:
    matchLabels:
      fluentbit.fluent.io/enabled: "true"
  outputSelector:
    matchLabels:
      fluentbit.fluent.io/enabled: "true"
{{- end }}
{{- end }}
```

### Which issue(s) this PR fixes:
<!--
`Fixes ##955`
-->
Fixes #955


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```