### PR TITLE
default cri parser should contain Time_Keep On, otherwise no time tag exists at output

### DIFF
--- a/conf/parsers.conf
+++ b/conf/parsers.conf
@@ -129,6 +129,7 @@
     Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
     Time_Key    time
     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+    Time_Keep   On
 
 [PARSER]
     Name    kube-custom


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Adds Time_Keep parameter to default cri parser so time tag exists at output; matching a change to the parsers.conf in the [fluent-bit repo](https://github.com/fluent/fluent-bit/commit/6315a8a07ab1dd4d40de89002b697f20232f204e)
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #957

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```