### PR TITLE
Adds the fluent-plugin-prometheus plugin to fluentd.

### DIFF
--- a/cmd/fluent-watcher/fluentd/Dockerfile.amd64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.amd64
@@ -50,6 +50,7 @@ RUN apk update \
          fluent-plugin-grafana-loki \
          fluent-plugin-cloudwatch-logs \
          fluent-plugin-datadog \
+         fluent-plugin-prometheus \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test
 

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64
@@ -56,6 +56,7 @@ RUN apt-get update \
          fluent-plugin-aws-elasticsearch-service \
          fluent-plugin-opensearch \
          fluent-plugin-datadog \
+         fluent-plugin-prometheus \
  && echo "plugin installed." \
  && wget -O /tmp/jemalloc-5.3.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-5.3.0.tar.bz2 && cd jemalloc-5.3.0/ \

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
@@ -46,6 +46,7 @@ RUN apt-get update \
          fluent-plugin-aws-elasticsearch-service \
          fluent-plugin-opensearch \
          fluent-plugin-datadog \
+         fluent-plugin-prometheus \
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-4.5.0.tar.bz2 && cd jemalloc-4.5.0/ \
  && ./configure && make \


### PR DESCRIPTION
### What this PR does / why we need it:

This PR installs the `fluent-plugin-prometheus` plugin.  This plugin is required for work related to #813 

### Which issue(s) this PR fixes:
Complements #725 

### Does this PR introduced a user-facing change?
None.
