### PR TITLE
feat: sort custom resources by metadata.name

### DIFF
--- a/apis/fluentd/v1alpha1/helper.go
+++ b/apis/fluentd/v1alpha1/helper.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/fluent/fluent-operator/v2/apis/fluentd/v1alpha1/plugins"
@@ -120,7 +121,16 @@ func (pgr *PluginResources) PatchAndFilterClusterLevelResources(
 	cfgResources := NewCfgResources()
 
 	errs := make([]string, 0)
-
+	// sort all the CRs by metadata.name
+	sort.SliceStable(clusterInputs[:], func(i, j int) bool {
+		return clusterInputs[i].Name < clusterInputs[j].Name
+	})
+	sort.SliceStable(clusterfilters[:], func(i, j int) bool {
+		return clusterfilters[i].Name < clusterfilters[j].Name
+	})
+	sort.SliceStable(clusteroutputs[:], func(i, j int) bool {
+		return clusteroutputs[i].Name < clusteroutputs[j].Name
+	})
 	// List all inputs matching the label selector.
 	for _, i := range clusterInputs {
 		// patch filterId


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Currently, there is no determined order of clusterinputs, clusterfilters, and clusteroutputs. If a user wants to use fluentd rewrite_tag_filter, then unordered clusterfilters may affect the final results of log entries.

fluent-bit has similar feature.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fluentd  clusterinputs, clusterfilters, and clusteroutputs will be sorted by metadata.name
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```