### PR TITLE
fix: Add RBAC permissions for input and clusterinput

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -83,6 +83,8 @@ rules:
       - filters
       - clusteroutputs
       - outputs
+      - inputs
+      - clusterinputs
     verbs:
       - create
       - delete


### PR DESCRIPTION

### What this PR does / why we need it:

Followup fix for https://github.com/fluent/fluent-operator/pull/972 that adds `ClusterInput` and `Input` to the helm charts cluster role.

### Which issue(s) this PR fixes:

n.a.

### Does this PR introduced a user-facing change?

No user-facing changes added.

### Additional documentation, usage docs, etc.:

n.a.