### PR TITLE
Add stackdriver output to the Helm Chart

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-stackdriver.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-stackdriver.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.enable -}}
+{{- if .Values.fluentbit.output.stackdriver -}}
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
+metadata:
+  name: stackdriver
+  labels:
+    fluentbit.fluent.io/enabled: "true"
+    fluentbit.fluent.io/component: logging
+spec:
+  matchRegex: (?:kube|service)\.(.*)
+  stackdriver:
+{{ toYaml .Values.fluentbit.output.stackdriver | indent 4}}
+{{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -293,6 +293,8 @@ fluentbit:
       #autoKubernetesLabels: on
       #tenantIDKey:   # String
       #tls: {}        # *plugins.TLS fluentbit docs
+    stackdriver: {}
+    # You can configure the opensearch-related configuration here
 
   service:
     storage: {}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -294,7 +294,7 @@ fluentbit:
       #tenantIDKey:   # String
       #tls: {}        # *plugins.TLS fluentbit docs
     stackdriver: {}
-    # You can configure the opensearch-related configuration here
+    # You can configure the stackdriver configuration here
 
   service:
     storage: {}

--- a/docs/plugins/fluentbit/index.md
+++ b/docs/plugins/fluentbit/index.md
@@ -35,6 +35,7 @@
   - [opentelemetry](output/opentelemetry.md)
   - [prometheus remote write](output/prometheus-remote-write.md)
   - [splunk](output/splunk.md)
+  - [stackdriver](output/stackdriver.md)
   - [stdout](output/stdout.md)
   - [syslog](output/syslog.md)
   - [tcp](output/tcp.md)


### PR DESCRIPTION
### What this PR does / why we need it:

Add the stackdriver fluentbit output for the helm chart for users that deploys to GKE clusters.

### Which issue(s) this PR fixes:

Fixes #1038

### Does this PR introduced a user-facing change?
```release-note
Added stackdriver fluentbit output for the helm chart. 
```

### Additional documentation, usage docs, etc.:
```docs
- [Usage]: https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/stackdriver.md
- [Other doc]: https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver
```