### PR TITLE
Add clusterinput tail resource to support setting bufferMaxSize

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
@@ -22,6 +22,9 @@ spec:
     {{- end }}
     refreshIntervalSeconds: {{ .Values.fluentbit.input.tail.refreshIntervalSeconds }}
     memBufLimit: {{ .Values.fluentbit.input.tail.memBufLimit }}
+    {{- if .Values.fluentbit.input.tail.bufferMaxSize }}
+    bufferMaxSize: {{ .Values.fluentbit.input.tail.bufferMaxSize }}
+    {{- end }}
     skipLongLines: {{ .Values.fluentbit.input.tail.skipLongLines }}
     db: /fluent-bit/tail/pos.db
     dbSync: Normal

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -171,6 +171,7 @@ fluentbit:
       enable: true
       refreshIntervalSeconds: 10
       memBufLimit: 100MB
+      bufferMaxSize: ""
       path: "/var/log/containers/*.log"
       skipLongLines: true
       readFromHead: false


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->
Add clusterinput tail resource to support setting **bufferMaxSize**

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1043 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```