### PR TITLE
fix(fluentd): Use custom plugin content for hash generation

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/params/model.go
+++ b/apis/fluentd/v1alpha1/plugins/params/model.go
@@ -72,6 +72,13 @@ func (ps *PluginStore) Hash() string {
 		c.Store[k] = v
 	}
 
+	// Custom plugins don't have stored properties but only contain the config
+	// as plain text.
+	// Set the content here to avoid generating the same hash code for all
+	// custom plugins resulting in only one custom plugin being ever set for
+	// one config.
+	c.Content = ps.Content
+
 	c.InsertChilds(ps.Childs...)
 	return utils.HashCode(c.String())
 }


### PR DESCRIPTION
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

This fixes a small issue regarding custom plugins by adding `PluginStore.Content` to the hash generation. Otherwise every custom plugin would have the same hash and only one would be added to the final config.

Since `PluginStore.Content` is empty for all plugins except custom ones it is safe to just set it when calculating the hash.

### Does this PR introduced a user-facing change?

No.

### Additional documentation, usage docs, etc.:

n.a.