### PR TITLE
feat(1062): Configure logLevel in ClusterFluentBitConfig

### DIFF
--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -10,6 +10,9 @@ spec:
   service:
     parsersFile: parsers.conf
     httpServer: true
+  {{- if .Values.fluentbit.logLevel }}
+    logLevel: {{ .Values.fluentbit.logLevel }}
+    {{- end }}
 {{- if .Values.fluentbit.service.storage }}
     storage:
 {{ toYaml .Values.fluentbit.service.storage | indent 6 }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -99,6 +99,7 @@ fluentbit:
   ##
   imagePullSecrets: []
   # - name: "image-pull-secret"
+  logLevel: ""
   secrets: []
   # fluent-bit daemonset use host network
   hostNetwork: false


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/fluent/fluent-operator/issues/1062

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
allow configuration of logLevel in ClusterFluentBitConfig helm template
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```