### PR TITLE
fix: support datadog plugin api key to allow for secret injection

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/filter/rewritetag_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/filter/rewritetag_types.go
@@ -18,7 +18,7 @@ type RewriteTag struct {
 	// When the filter emits a record under the new Tag, there is an internal emitter
 	// plugin that takes care of the job. Since this emitter expose metrics as any other
 	// component of the pipeline, you can use this property to configure an optional name for it.
-	EmitterName string `json:"emitterName,omitempty"`
+	EmitterName        string `json:"emitterName,omitempty"`
 	EmitterMemBufLimit string `json:"emitterMemBufLimit,omitempty"`
 	EmitterStorageType string `json:"emitterStorageType,omitempty"`
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/datadog_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/datadog_types.go
@@ -21,7 +21,7 @@ type DataDog struct {
 	// Datadog supports and recommends setting this to gzip.
 	Compress string `json:"compress,omitempty"`
 	// Your Datadog API key.
-	APIKey string `json:"apikey,omitempty"`
+	APIKey *plugins.Secret `json:"apikey,omitempty"`
 	// Specify an HTTP Proxy.
 	Proxy string `json:"proxy,omitempty"`
 	// To activate the remapping, specify configuration flag provider.
@@ -61,8 +61,12 @@ func (s *DataDog) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	if s.Compress != "" {
 		kvs.Insert("compress", s.Compress)
 	}
-	if s.APIKey != "" {
-		kvs.Insert("apikey", s.APIKey)
+	if s.APIKey != nil {
+		apiKey, err := sl.LoadSecret(*s.APIKey)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Insert("apikey", apiKey)
 	}
 	if s.Proxy != "" {
 		kvs.Insert("proxy", s.Proxy)

--- a/apis/fluentbit/v1alpha2/plugins/output/datadog_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/datadog_types_test.go
@@ -15,7 +15,6 @@ func TestOutput_DataDog_Params(t *testing.T) {
 
 	dd := DataDog{
 		Host:          "http-intake.logs.datadoghq.com",
-		APIKey:        "1234apikey",
 		TLS:           ptrBool(true),
 		Compress:      "gzip",
 		Service:       "service_name",
@@ -31,7 +30,6 @@ func TestOutput_DataDog_Params(t *testing.T) {
 	expected.Insert("Host", "http-intake.logs.datadoghq.com")
 	expected.Insert("TLS", "true")
 	expected.Insert("compress", "gzip")
-	expected.Insert("apikey", "1234apikey")
 	expected.Insert("json_date_key", "timestamp")
 	expected.Insert("include_tag_key", "true")
 	expected.Insert("tag_key", "tagkey")

--- a/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
@@ -118,6 +118,11 @@ func (in *DataDog) DeepCopyInto(out *DataDog) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.APIKey != nil {
+		in, out := &in.APIKey, &out.APIKey
+		*out = new(plugins.Secret)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.IncludeTagKey != nil {
 		in, out := &in.IncludeTagKey, &out.IncludeTagKey
 		*out = new(bool)

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -348,7 +348,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -348,7 +348,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -348,7 +348,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -348,7 +348,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.

--- a/docs/plugins/fluentbit/output/datadog.md
+++ b/docs/plugins/fluentbit/output/datadog.md
@@ -8,7 +8,7 @@ DataDog output plugin allows you to ingest your logs into Datadog. <br /> **For 
 | host | Host is the Datadog server where you are sending your logs. | string |
 | tls | TLS controls whether to use end-to-end security communications security protocol. Datadog recommends setting this to on. | *bool |
 | compress | Compress  the payload in GZIP format. Datadog supports and recommends setting this to gzip. | string |
-| apikey | Your Datadog API key. | string |
+| apikey | Your Datadog API key. | *[plugins.Secret](../secret.md) |
 | proxy | Specify an HTTP Proxy. | string |
 | provider | To activate the remapping, specify configuration flag provider. | string |
 | json_date_key | Date key name for output. | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -2986,7 +2986,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.
@@ -26616,7 +26641,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -2986,7 +2986,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.
@@ -26616,7 +26641,32 @@ spec:
                 properties:
                   apikey:
                     description: Your Datadog API key.
-                    type: string
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   compress:
                     description: Compress  the payload in GZIP format. Datadog supports
                       and recommends setting this to gzip.


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Modified datadog_types.go file to support datadog plugin api key for allowing the value to take from secret.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #1060 `, or `Fixes (paste link of issue)`.
-->
Fixes #1060 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```