### PR TITLE
feat(chart): Add operator.extraArgs to add extra args to the fluent-operator container

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -98,9 +98,11 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-        {{- with .Values.operator.disableComponentControllers }}
-        args: ["--disable-component-controllers","{{ . }}"]
-        {{- end }}
+        args:
+          {{- with .Values.operator.extraArgs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          - --disable-component-controllers={{ .Values.operator.disableComponentControllers | quote }}
         volumeMounts:
         - name: env
           mountPath: /fluent-operator

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -64,6 +64,9 @@ operator:
   # setting fluentbit.crdsEnable or fluentd.crdsEnable values to false.
   # By default all CRDs are deployed.
   disableComponentControllers: ""
+  # Extra arguments given to the controller flags
+  extraArgs: []
+    # - --watch-namespaces=logging
 
 fluentbit:
   # Installs a sub chart carrying the CRDs for the fluent-bit controller. The sub chart is enabled by default.


### PR DESCRIPTION
This would allow users to provide extra arguments like --watch-namespaces

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1073

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Helm Chart: Add operator.extraArgs in chart values to add extra args to the fluent-operator container.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```