### PR TITLE
fluentbit/output/elasticsearch: Add writeOperation option

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/elasticsearch_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/elasticsearch_types.go
@@ -85,6 +85,8 @@ type Elasticsearch struct {
 	GenerateID *bool `json:"generateID,omitempty"`
 	// If set, _id will be the value of the key from incoming record and Generate_ID option is ignored.
 	IdKey string `json:"idKey,omitempty"`
+	// Operation to use to write in bulk requests.
+	WriteOperation string `json:"writeOperation,omitempty"`
 	// When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.
 	ReplaceDots *bool `json:"replaceDots,omitempty"`
 	// When enabled print the elasticsearch API calls to stdout (for diag only)
@@ -196,6 +198,9 @@ func (es *Elasticsearch) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if es.IdKey != "" {
 		kvs.Insert("ID_KEY", es.IdKey)
+	}
+	if es.WriteOperation != "" {
+		kvs.Insert("Write_Operation", es.WriteOperation)
 	}
 	if es.ReplaceDots != nil {
 		kvs.Insert("Replace_Dots", fmt.Sprint(*es.ReplaceDots))

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -513,6 +513,9 @@ spec:
                     description: If set, _id will be the value of the key from incoming
                       record and Generate_ID option is ignored.
                     type: string
+                  writeOperation:
+                    description: Operation to use to write in bulk requests.
+                    type: string
                   includeTagKey:
                     description: When enabled, it append the Tag name to the record.
                     type: boolean

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -513,6 +513,9 @@ spec:
                     description: If set, _id will be the value of the key from incoming
                       record and Generate_ID option is ignored.
                     type: string
+                  writeOperation:
+                    description: Operation to use to write in bulk requests.
+                    type: string
                   includeTagKey:
                     description: When enabled, it append the Tag name to the record.
                     type: boolean

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -228,6 +228,7 @@ fluentbit:
     #      logstashFormat: true
     #      replaceDots: false
     #      enableTLS: false
+    #      writeOperation: upsert
     #      tls:
     #        verify: On
     #        debug: 1
@@ -256,7 +257,7 @@ fluentbit:
 #        port: 2020
 #        addLabels:
 #          app: "fluentbit"
-    
+
     # Loki fluentbit ClusterOutput, to be encapsulated in fluentbit config
     # See https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/loki.md
     # See https://docs.fluentbit.io/manual/pipeline/outputs/loki
@@ -291,7 +292,7 @@ fluentbit:
       #
       #labels: []      # String list of <name>=<value>
       #labelKeys: []   # String list of <key>
-      #removeKeys: []  # String list of <key> 
+      #removeKeys: []  # String list of <key>
       #labelMapPath: '' # String, path to file, ex /here/it/is
       #dropSingleKey: off
       #lineFormat: '' # String

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -513,6 +513,9 @@ spec:
                     description: If set, _id will be the value of the key from incoming
                       record and Generate_ID option is ignored.
                     type: string
+                  writeOperation:
+                    description: Operation to use to write in bulk requests.
+                    type: string
                   includeTagKey:
                     description: When enabled, it append the Tag name to the record.
                     type: boolean

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -513,6 +513,9 @@ spec:
                     description: If set, _id will be the value of the key from incoming
                       record and Generate_ID option is ignored.
                     type: string
+                  writeOperation:
+                    description: Operation to use to write in bulk requests.
+                    type: string
                   includeTagKey:
                     description: When enabled, it append the Tag name to the record.
                     type: boolean

--- a/docs/plugins/fluentbit/output/elasticsearch.md
+++ b/docs/plugins/fluentbit/output/elasticsearch.md
@@ -32,6 +32,7 @@ Elasticsearch is the es output plugin, allows to ingest your records into an Ela
 | tagKey | When Include_Tag_Key is enabled, this property defines the key name for the tag. | string |
 | generateID | When enabled, generate _id for outgoing records. This prevents duplicate records when retrying ES. | *bool |
 | idKey | If set, _id will be the value of the key from incoming record and Generate_ID option is ignored. | string |
+| writeOperation | Operation to use to write in bulk requests. | string |
 | replaceDots | When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3. | *bool |
 | traceOutput | When enabled print the elasticsearch API calls to stdout (for diag only) | *bool |
 | traceError | When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error | *bool |


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Add WriteOperation option to output plugin ElasticSearch. This option is supported by the fluentbit perse as seen in https://github.com/fluent/fluent-bit/blob/9d9ac68a2b45a4cedeafbf7c5aba513f494eced6/plugins/out_es/es_conf.c#L304 . 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?

User now can use option `writeOption` to adjust their ES bulk api call.
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```