### PR TITLE
LUA filter inline code support

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
@@ -3,7 +3,7 @@ package filter
 import (
 	"strconv"
 	"strings"
-    "regexp"
+	"regexp"
 
 	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/params"
@@ -21,7 +21,7 @@ type Lua struct {
 	// Lua function name that will be triggered to do filtering.
 	// It's assumed that the function is declared inside the Script defined above.
 	Call string `json:"call"`
-    // Inline LUA code instead of loading from a path via script.
+	// Inline LUA code instead of loading from a path via script.
 	Code string `json:"code"`
 	// If these keys are matched, the fields are converted to integer.
 	// If more than one key, delimit by space.
@@ -49,26 +49,26 @@ func (l *Lua) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 		return kvs, err
 	}
 
-    if l.Code != "" {
-        var singleLineLua string = ""
-        var lineTrim = ""
-        for _, line := range strings.Split(strings.TrimSuffix(l.Code, "\n"), "\n") {
-            lineTrim = strings.TrimSpace(line)
-            if lineTrim != "" {
-              operator, _ := regexp.MatchString("^function |^if |^for |^else|^elseif |^end|--[[]+", lineTrim)
-              if operator {
-                singleLineLua = singleLineLua + lineTrim + " "
-              } else {
-                singleLineLua = singleLineLua + lineTrim + "; "
-              }
-            }
-        }
-        kvs.Insert("code", singleLineLua)
-    }
+	if l.Code != "" {
+		var singleLineLua string = ""
+		var lineTrim = ""
+		for _, line := range strings.Split(strings.TrimSuffix(l.Code, "\n"), "\n") {
+			lineTrim = strings.TrimSpace(line)
+			if lineTrim != "" {
+				operator, _ := regexp.MatchString("^function |^if |^for |^else|^elseif |^end|--[[]+", lineTrim)
+				if operator {
+					singleLineLua = singleLineLua + lineTrim + " "
+				} else {
+					singleLineLua = singleLineLua + lineTrim + "; "
+				}
+			}
+		}
+		kvs.Insert("code", singleLineLua)
+	}
 
-    if l.Script.Key != "" {
-	    kvs.Insert("script", "/fluent-bit/config/"+l.Script.Key)
-    }
+	if l.Script.Key != "" {
+		kvs.Insert("script", "/fluent-bit/config/"+l.Script.Key)
+	}
 
 	kvs.Insert("call", l.Call)
 

--- a/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
@@ -3,6 +3,7 @@ package filter
 import (
 	"strconv"
 	"strings"
+    "regexp"
 
 	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/params"
@@ -20,6 +21,8 @@ type Lua struct {
 	// Lua function name that will be triggered to do filtering.
 	// It's assumed that the function is declared inside the Script defined above.
 	Call string `json:"call"`
+    // Inline LUA code instead of loading from a path via script.
+	Code string `json:"code"`
 	// If these keys are matched, the fields are converted to integer.
 	// If more than one key, delimit by space.
 	// Note that starting from Fluent Bit v1.6 integer data types are preserved
@@ -45,7 +48,28 @@ func (l *Lua) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	if err != nil {
 		return kvs, err
 	}
-	kvs.Insert("script", "/fluent-bit/config/"+l.Script.Key)
+
+    if l.Code != "" {
+        var singleLineLua string = ""
+        var lineTrim = ""
+        for _, line := range strings.Split(strings.TrimSuffix(l.Code, "\n"), "\n") {
+            lineTrim = strings.TrimSpace(line)
+            if lineTrim != "" {
+              operator, _ := regexp.MatchString("^function |^if |^for |^else|^elseif |^end|--[[]+", lineTrim)
+              if operator {
+                singleLineLua = singleLineLua + lineTrim + " "
+              } else {
+                singleLineLua = singleLineLua + lineTrim + "; "
+              }
+            }
+        }
+        kvs.Insert("code", singleLineLua)
+    }
+
+    if l.Script.Key != "" {
+	    kvs.Insert("script", "/fluent-bit/config/"+l.Script.Key)
+    }
+
 	kvs.Insert("call", l.Call)
 
 	if l.TypeIntKey != nil && len(l.TypeIntKey) > 0 {

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
@@ -289,6 +289,9 @@ spec:
                             do filtering. It's assumed that the function is declared
                             inside the Script defined above.
                           type: string
+                        code:
+                          description: Inline LUA code instead of loading from a path via script.
+                          type: string
                         protectedMode:
                           description: If enabled, Lua script will be executed in
                             protected mode. It prevents to crash when invalid Lua
@@ -341,7 +344,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.


### PR DESCRIPTION
Adds support for "code:" inline block in LUA namespace-wide filter.
See: https://docs.fluentbit.io/manual/pipeline/filters/lua
"code | Inline LUA code instead of loading from a path via script."

```release-note
None
```

```docs
Usage:

apiVersion: fluentbit.fluent.io/v1alpha2
kind: Filter
metadata:
  labels:
    fluentbit.fluent.io/enabled: "true"
  name: test
spec:
  match: "*"
  filters:
  - lua:
      call: converter
      protectedMode: true 
      code: |
        function converter(tag, timestamp, record)
            return 0, 0, 0
        end
```
