### PR TITLE
feat(disableLogVolumes): expose disableLogVolumes in helm chart

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -87,5 +87,8 @@ spec:
   serviceAccountAnnotations:
 {{ toYaml .Values.fluentbit.serviceAccountAnnotations | indent 4 }}
   {{- end }}
+{{- if .Values.fluentbit.disableLogVolumes }}
+  disableLogVolumes: {{ .Values.fluentbit.disableLogVolumes }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -337,6 +337,9 @@ fluentbit:
       # Change the port to the port of a cloud-side Prometheus-compatible server that can receive Prometheus remote write data
       port: "<cloud-prometheus-service-port>"
 
+  # removes the hostPath mounts for varlibcontainers, varlogs and systemd.
+  disableLogVolumes: false
+
 fluentd:
   # Installs a sub chart carrying the CRDs for the fluentd controller. The sub chart is enabled by default.
   crdsEnable: true


### PR DESCRIPTION
### What this PR does / why we need it: allows setting DisableLogVolumes via helm chart

### Does this PR introduced a user-facing change?
No
```release-note
feat(disableLogVolumes): expose disableLogVolumes in helm chart
```