### PR TITLE
fix: incorrect fields in syslog input plugin parameters

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/input/syslog.go
+++ b/apis/fluentbit/v1alpha2/plugins/input/syslog.go
@@ -51,10 +51,10 @@ func (s *Syslog) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	kvs := params.NewKVs()
 
 	if s.Mode != "" {
-		kvs.Insert("Mode", s.Path)
+		kvs.Insert("Mode", s.Mode)
 	}
 	if s.Listen != "" {
-		kvs.Insert("Listen", s.Path)
+		kvs.Insert("Listen", s.Listen)
 	}
 	if s.Port != nil {
 		kvs.Insert("Port", fmt.Sprint(*s.Port))
@@ -72,7 +72,7 @@ func (s *Syslog) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 		kvs.Insert("Buffer_Chunk_Size", s.BufferChunkSize)
 	}
 	if s.BufferMaxSize != "" {
-		kvs.Insert("Buffer_Max_Size", s.BufferChunkSize)
+		kvs.Insert("Buffer_Max_Size", s.BufferMaxSize)
 	}
 	if s.ReceiveBufferSize != "" {
 		kvs.Insert("Receive_Buffer_Size", s.ReceiveBufferSize)


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
It fixes a bug in the syslog input plugin, where some of the fields were incorrectly assigned to the kvs.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1083

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```