### PR TITLE
Fix: attach latest tag to images - DockerHub synchronize with GHCR

### DIFF
--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
             
-      - name: docker metadata
+      - name: docker metadata for building
         id: image-metadata
         uses: docker/metadata-action@v5
         with:
@@ -210,9 +210,10 @@ jobs:
     with:
       source_image: "${{ needs.build-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-prod-image-metadata.outputs.version }}"
       source_registry: ghcr.io
-      target_image: "${{ needs.build-prod-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-prod-image-metadata.outputs.version }}"
+      target_image: "${{ needs.build-prod-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
       platforms: "['linux/arm64', 'linux/amd64']"
+      is_latest: true
     secrets:
       source_registry_username:  ${{ github.actor }}
       source_registry_token: ${{ secrets.GITHUB_TOKEN }}
@@ -229,9 +230,11 @@ jobs:
     with:
       source_image: "${{ needs.build-debug-image-metadata.outputs.IMG_NAME }}:${{ needs.build-debug-image-metadata.outputs.version }}"
       source_registry: ghcr.io
-      target_image: "${{ needs.build-debug-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-debug-image-metadata.outputs.version }}"
+      target_image: "${{ needs.build-debug-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
       platforms: "['linux/arm64', 'linux/amd64']"
+      is_latest: false
+      suffix: "-debug"
     secrets:
       source_registry_username:  ${{ github.actor }}
       source_registry_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -14,6 +14,11 @@ on:
   pull_request:
     branches:
       - "master"
+    paths:
+      - ".github/workflows/build-fb-image.yaml"
+      - "cmd/fluent-watcher/fluentbit/**"
+      - "cmd/fluent-watcher/hooks/**"
+      - "pkg/filenotify/**"
 
 env:
   DOCKER_REPO: 'kubesphere'

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -11,16 +11,89 @@ on:
       - "cmd/fluent-watcher/fluentbit/**"
       - "cmd/fluent-watcher/hooks/**"
       - "pkg/filenotify/**"
+  pull_request:
+    branches:
+      - "master"
 
 env:
-  FB_IMG: 'kubesphere/fluent-bit:v2.2.2'
-  FB_IMG_DEBUG: 'kubesphere/fluent-bit:v2.2.2-debug'
+  DOCKER_REPO: 'kubesphere'
+  DOCKER_IMAGE: 'fluent-bit'
+  GITHUB_IMAGE: '${{ github.repository }}/fluent-bit'
 
 jobs:
-  build:
+  build-prod-image-metadata:
+    runs-on: ubuntu-latest
+    name: Build prod image metadata
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+            
+      - name: docker metadata
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          tags: |
+            raw,latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
+
+  build-debug-image-metadata:
+    runs-on: ubuntu-latest
+    name: Build debug image metadata
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: docker metadata
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          flavor: |
+            latest=false
+            suffix=-debug
+          tags: |
+            raw,latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
+
+  build-FluentBit-prod-image:
+    needs: 
+      - build-prod-image-metadata
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Build Image for Fluent Bit
+    name: Build Fluent Bit prod image
     steps:
       - name: Install Go
         uses: actions/setup-go@v4
@@ -37,17 +110,121 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Image for Fluent Bit
-        run: |
-          make build-fb -e FB_IMG=${{ env.FB_IMG }}
-          make build-fb-debug -e FB_IMG_DEBUG=${{ env.FB_IMG_DEBUG }}
+        id: docker-build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./cmd/fluent-watcher/fluentbit/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ needs.build-prod-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-prod-image-metadata.outputs.labels }}
+
+  build-FluentBit-debug-image:
+    needs: 
+      - build-debug-image-metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Build Fluent Bit debug image
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Build and Push Fluent Bit Debug Image
+        id: docker-build-debug
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./cmd/fluent-watcher/fluentbit/Dockerfile.debug
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ needs.build-debug-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-debug-image-metadata.outputs.labels }}
+
+  scan-FluentBit-image:
+    name: Scan prod image
+    needs: 
+      - build-prod-image-metadata
+      - build-FluentBit-prod-image
+    uses: ./.github/workflows/scan-docker-image-action.yaml
+    with:
+      source_image: "${{ needs.build-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-prod-image-metadata.outputs.version }}"
+      source_registry: ghcr.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}
+  
+  release-prod-image-to-docker-hub:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Release prod image to Docker Hub
+    uses: ./.github/workflows/clone-docker-image-action.yaml
+    needs: 
+      - build-FluentBit-prod-image
+      - scan-FluentBit-image
+      - build-prod-image-metadata
+    with:
+      source_image: "${{ needs.build-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-prod-image-metadata.outputs.version }}"
+      source_registry: ghcr.io
+      target_image: "${{ needs.build-prod-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-prod-image-metadata.outputs.version }}"
+      target_registry: docker.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      source_registry_username:  ${{ github.actor }}
+      source_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      target_registry_username: ${{ secrets.REGISTRY_USER }}
+      target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}
+
+  release-debug-image-to-docker-hub:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Release debug image to Docker Hub
+    uses: ./.github/workflows/clone-docker-image-action.yaml
+    needs: 
+      - build-FluentBit-debug-image
+      - build-debug-image-metadata
+    with:
+      source_image: "${{ needs.build-debug-image-metadata.outputs.IMG_NAME }}:${{ needs.build-debug-image-metadata.outputs.version }}"
+      source_registry: ghcr.io
+      target_image: "${{ needs.build-debug-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-debug-image-metadata.outputs.version }}"
+      target_registry: docker.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      source_registry_username:  ${{ github.actor }}
+      source_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      target_registry_username: ${{ secrets.REGISTRY_USER }}
+      target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -20,6 +20,10 @@ env:
   DOCKER_IMAGE: 'fluent-bit'
   GITHUB_IMAGE: '${{ github.repository }}/fluent-bit'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-prod-image-metadata:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -216,11 +216,13 @@ jobs:
       - build-arm64-base-image-metadata
       - build-arm64-base
     with:
-      source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-base-image-metadata.outputs.version }}"
+      source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}"
       source_registry: ghcr.io
-      target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-arm64-base-image-metadata.outputs.version }}"
+      target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
       platforms: "['linux/arm64']"
+      is_latest: false
+      suffix: "-arm64-base"
     secrets:
       source_registry_username:  ${{ github.actor }}
       source_registry_token: ${{ secrets.GITHUB_TOKEN }}
@@ -301,8 +303,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
-          flavor: |
-            latest=false
           tags: |
             raw,latest
             type=ref,event=branch
@@ -347,11 +347,12 @@ jobs:
       - prod-image-manifest
       - scan-image
     with:
-      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}"
       source_registry: ghcr.io
-      target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+      target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
       platforms: "['linux/arm64', 'linux/amd64']"
+      is_latest: true
     secrets:
       source_registry_username:  ${{ github.actor }}
       source_registry_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -13,13 +13,120 @@ on:
       - "pkg/filenotify/**"
 
 env:
-  FD_IMG: 'kubesphere/fluentd:v1.15.3'
-  ARCH: '-arm64'
-  FD_IMG_BASE: 'kubesphere/fluentd:v1.15.3-arm64-base'
+  DOCKER_REPO: 'kubesphere'
+  DOCKER_IMAGE: 'fluentd'
+  GITHUB_IMAGE: '${{ github.repository }}/fluentd'
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
+  build-amd64-prod-image-metadata:
+    runs-on: ubuntu-latest
+    name: Build prod image metadata for amd64
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+            
+      - name: docker metadata for amd64
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          flavor: |
+            latest=false
+            suffix=-amd64
+          tags: |
+            raw,latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+
+  build-arm64-prod-image-metadata:
+    runs-on: ubuntu-latest
+    name: Build prod image metadata for arm64
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+            
+      - name: docker metadata for arm64
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          flavor: |
+            latest=false
+            suffix=-arm64
+          tags: |
+            raw,latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+
+  build-arm64-base-image-metadata:
+    runs-on: ubuntu-latest
+    name: Build prod image metadata for arm64 base image
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+            
+      - name: docker metadata for arm64 base image
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          flavor: |
+            latest=false
+            suffix=-arm64-base
+          tags: |
+            raw,latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
+
   build-amd64:
     runs-on: ubuntu-latest
+    needs: build-amd64-prod-image-metadata
     timeout-minutes: 30
     name: Build amd64 Image for Fluentd
     steps:
@@ -41,16 +148,91 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push amd64 Image for Fluentd
-        run: |
-          make build-fd-amd64 -e FD_IMG=${{ env.FD_IMG }}
-          docker push ${{ env.FD_IMG }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push amd64 base Image for Fluentd
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: cmd/fluent-watcher/fluentd/Dockerfile.amd64
+          push: true
+          platforms: linux/amd64
+          tags: ${{ needs.build-amd64-prod-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-amd64-prod-image-metadata.outputs.labels }}
+
+  build-arm64-base:
+    runs-on: ubuntu-latest
+    needs: build-arm64-base-image-metadata
+    timeout-minutes: 90 
+    name: Build arm64 base Image for Fluentd
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push arm64 base Image for Fluentd
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
+          push: true
+          platforms: linux/arm64
+          tags: ${{ needs.build-arm64-base-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-arm64-base-image-metadata.outputs.labels }}
+
+  release-arm64-base-image-to-docker-hub:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Release Image to Docker Hub
+    uses: ./.github/workflows/clone-docker-image-action.yaml
+    needs: 
+      - build-arm64-base-image-metadata
+      - build-arm64-base
+    with:
+      source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-base-image-metadata.outputs.version }}"
+      source_registry: ghcr.io
+      target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-arm64-base-image-metadata.outputs.version }}"
+      target_registry: docker.io
+      platforms: "['linux/arm64']"
+    secrets:
+      source_registry_username:  ${{ github.actor }}
+      source_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      target_registry_username: ${{ secrets.REGISTRY_USER }}
+      target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}
 
   build-arm64:
     runs-on: ubuntu-latest
+    needs: 
+      - build-arm64-prod-image-metadata
+      - build-arm64-base-image-metadata
+      - build-arm64-base
     timeout-minutes: 90 
     name: Build arm64 Image for Fluentd
     steps:
@@ -72,17 +254,106 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push arm64 base Image for Fluentd
-        run: |
-          make build-fd-arm64-base -e FD_IMG_BASE=${{ env.FD_IMG_BASE }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.quick
+          push: true
+          platforms: linux/arm64
+          tags: ${{ needs.build-arm64-prod-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-arm64-prod-image-metadata.outputs.labels }}
+          build-args: |
+            BASE_IMAGE_TAG=${{ needs.build-arm64-base-image-metadata.outputs.version }}
+            BASE_IMAGE=ghcr.io/${{needs.build-arm64-base-image-metadata.outputs.IMG_NAME}}
 
-      - name: Build and Push arm64 Image for Fluentd
+  prod-image-manifest:
+    needs: 
+      - build-amd64-prod-image-metadata
+      - build-arm64-prod-image-metadata
+      - build-amd64
+      - build-arm64
+    runs-on: ubuntu-latest
+    name: Create image manifest
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: docker metadata for manifest
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          flavor: |
+            latest=false
+          tags: |
+            raw,latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            
+      - name: Set outputs
+        id: set-outputs
         run: |
-          make build-fd-arm64 -e FD_IMG=${{ env.FD_IMG }} -e ARCH=${{ env.ARCH }}
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
+    
+      - name: Create image manifest
+        uses: int128/docker-manifest-create-action@v2
+        with:
+          push: true
+          tags: ${{ steps.image-metadata.outputs.tags }}
+          sources: |
+            ghcr.io/${{ needs.build-amd64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-amd64-prod-image-metadata.outputs.version }}
+            ghcr.io/${{ needs.build-arm64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-prod-image-metadata.outputs.version }}
+
+  scan-image:
+    needs: 
+      - prod-image-manifest
+    name: Scan Fluentd Image
+    uses: ./.github/workflows/scan-docker-image-action.yaml
+    with:
+      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+      source_registry: ghcr.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}
+
+  release-images-to-docker-hub:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Release Image to Docker Hub
+    uses: ./.github/workflows/clone-docker-image-action.yaml
+    needs: 
+      - prod-image-manifest
+      - scan-image
+    with:
+      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+      source_registry: ghcr.io
+      target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+      target_registry: docker.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      source_registry_username:  ${{ github.actor }}
+      source_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      target_registry_username: ${{ secrets.REGISTRY_USER }}
+      target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -137,7 +137,7 @@ jobs:
     with:
       source_image: "${{ needs.build-image-metadata.outputs.IMG_NAME }}:${{ needs.build-image-metadata.outputs.version }}"
       source_registry: ghcr.io
-      target_image: "${{ needs.build-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-image-metadata.outputs.version }}"
+      target_image: "${{ needs.build-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
       platforms: "['linux/arm64', 'linux/amd64']"
     secrets:

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -22,6 +22,17 @@ on:
   pull_request:
     branches:
       - "master"
+    paths:
+      - ".github/workflows/build-op-image.yaml"
+      - ".github/workflows/clone-docker-image-action.yaml"
+      - "apis/**"
+      - "cmd/fluent-manager/**"
+      - "controllers/**"
+      - "hack/**"
+      - "manifests/setup/setup.yaml"
+      - "pkg/fluentd/router/**"
+      - "pkg/fluentd/operator/**"
+      - "pkg/fluentd/utils/**"
 
 env:
   DOCKER_REPO: "kubesphere"

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -3,11 +3,13 @@ name: Building Fluent Operator image
 on:
   push:
     branches:
-      - 'master'
+      - "master"
+      - "ISSUE-*"
     tags:
-      - 'v*'
+      - "v*"
     paths:
       - ".github/workflows/build-op-image.yaml"
+      - ".github/workflows/clone-docker-image-action.yaml"
       - "apis/**"
       - "cmd/fluent-manager/**"
       - "controllers/**"
@@ -18,41 +20,118 @@ on:
       - "pkg/fluentd/utils/**"
       - "Makefile"
 
+  pull_request:
+    branches:
+      - "master"
+
 env:
-  REGISTRY_REPO: 'kubesphere'
+  DOCKER_REPO: "kubesphere"
+  DOCKER_IMAGE: "fluent-operator"
+  GITHUB_IMAGE: "${{ github.repository }}/fluent-operator"
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
+  build-image-metadata:
+    runs-on: ubuntu-latest
+    name: Build Image Metadata
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+            
+      - name: docker metadata
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          tags: |
+            raw,latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
+
   operator-build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Build Image for Fluent Operator
+    needs: 
+      - build-image-metadata
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and Push Image for Fluent Operator
-        run: |
-          tag=$(cat VERSION | tr -d " \t\n\r")
-          make build-op -e FO_IMG=${{ env.REGISTRY_REPO }}/fluent-operator:$tag
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./cmd/fluent-manager/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ needs.build-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-image-metadata.outputs.labels }}
+
+  scan-operator-image:
+    name: Scan Docker Image
+    needs: 
+      - operator-build
+      - build-image-metadata
+    uses: ./.github/workflows/scan-docker-image-action.yaml
+    with:
+      source_image: "${{ needs.build-image-metadata.outputs.IMG_NAME }}:${{ needs.build-image-metadata.outputs.version }}"
+      source_registry: ghcr.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}
+
+  release-image-to-docker-hub:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Release Image to Docker Hub
+    uses: ./.github/workflows/clone-docker-image-action.yaml
+    needs: 
+      - operator-build
+      - scan-operator-image
+      - build-image-metadata
+    with:
+      source_image: "${{ needs.build-image-metadata.outputs.IMG_NAME }}:${{ needs.build-image-metadata.outputs.version }}"
+      source_registry: ghcr.io
+      target_image: "${{ needs.build-image-metadata.outputs.DOCKER_IMG_NAME }}:${{ needs.build-image-metadata.outputs.version }}"
+      target_registry: docker.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      source_registry_username:  ${{ github.actor }}
+      source_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      target_registry_username: ${{ secrets.REGISTRY_USER }}
+      target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "ISSUE-*"
     tags:
       - "v*"
     paths:

--- a/.github/workflows/clone-docker-image-action.yaml
+++ b/.github/workflows/clone-docker-image-action.yaml
@@ -24,6 +24,16 @@
           required: false
           type: string
           default: '["linux/arm64", "linux/amd64"]'
+        suffix:
+          description: 'The suffix to append to the target image'
+          required: false
+          type: string
+          default: ''
+        is_latest:
+          description: 'Whether to tag the image as latest'
+          required: false
+          type: boolean
+          default: false
       secrets: 
         source_registry_token:
           description: The Github token or similar to authenticate with for the registry.
@@ -58,9 +68,56 @@
           env:
             SOURCE_IMAGE: ${{ inputs.source_registry }}/${{ inputs.source_image }}
           shell: bash
+    create-tags:
+      runs-on: ubuntu-latest
+      outputs:
+        tags: ${{ steps.tags-converter.outputs.TAGS }}
+      steps:
+        - name: docker metadata for tags
+          id: tags-metadata
+          uses: docker/metadata-action@v5
+          with:
+            flavor: |
+              latest=${{ inputs.is_latest }}
+              suffix=${{ inputs.suffix }}
+            tags: |
+              raw,latest
+              type=ref,event=branch
+              type=ref,event=pr
+              type=ref,event=tag
+              type=semver,pattern={{version}}
+              type=semver,pattern={{major}}.{{minor}}
+
+        - name: Convert tags to JSON array
+          id: tags-converter
+          run: |
+
+            # Get the line-separated list of tags
+            TAGS="${{ steps.tags-metadata.outputs.tags }}"
+
+            # Initialize an empty array
+            JSON_TAGS="["
+            
+            # Loop through each tag and append to the JSON array
+            while read -r tag; do
+              JSON_TAGS+="\"$tag\","
+            done <<< "$TAGS"
+
+            # print the JSON array
+            echo "TAGS=$JSON_TAGS"
+
+            # Remove the trailing comma and close the array
+            JSON_TAGS="${JSON_TAGS%,}]"
+            # Output the JSON array
+            echo "TAGS=$JSON_TAGS" >> $GITHUB_OUTPUT
   
     push-image:
-      needs: check-image-exists
+      needs: 
+        - check-image-exists
+        - create-tags
+      strategy:
+        matrix:
+          image_tags: ${{fromJson(needs.create-tags.outputs.tags)}}
       runs-on: ubuntu-latest
       steps:
         - name: Promote container images from ${{ inputs.source_registry }} to ${{ inputs.target_registry }}
@@ -77,6 +134,6 @@
                 "docker://$RELEASE_IMAGE"
           env:
             SOURCE_IMAGE: "${{ inputs.source_registry }}/${{ inputs.source_image }}"
-            RELEASE_IMAGE: "${{ inputs.target_registry }}/${{ inputs.target_image }}"
+            RELEASE_IMAGE: "${{ inputs.target_registry }}/${{ inputs.target_image }}:${{ matrix.image_tags }}"
             RELEASE_CREDS: ${{ secrets.target_registry_username }}:${{ secrets.target_registry_token }}
             SOURCE_CREDS: ${{ secrets.source_registry_username }}:${{ secrets.source_registry_token }}

--- a/.github/workflows/clone-docker-image-action.yaml
+++ b/.github/workflows/clone-docker-image-action.yaml
@@ -1,0 +1,82 @@
+---
+  name: Reusable workflow to clone a Docker image from one registry to another
+  on:
+    workflow_call:
+      inputs:
+        source_image: 
+          description: The source image to clone
+          required: true
+          type: string
+        source_registry:
+          description: The source registry
+          required: true
+          type: string
+        target_image:
+          description: The target image to clone
+          required: true
+          type: string
+        target_registry:
+          description: 'The target registry'
+          required: true
+          type: string
+        platforms:
+          description: 'The platforms to clone'
+          required: false
+          type: string
+          default: '["linux/arm64", "linux/amd64"]'
+      secrets: 
+        source_registry_token:
+          description: The Github token or similar to authenticate with for the registry.
+          required: true
+        target_registry_token:
+          description: The Github token or similar to authenticate with for the registry.
+          required: true
+        source_registry_username:
+          description: The source registry username
+          required: true
+        target_registry_username:
+          description: The target registry username
+          required: true
+  
+  jobs:
+    check-image-exists:
+      strategy:
+        matrix:
+          platform: ${{ fromJson(inputs.platforms) }}
+      runs-on: ubuntu-latest
+      steps:
+        - name: Login to source container registry ${{ inputs.source_registry }}
+          uses: docker/login-action@v3
+          with:
+            registry: ${{ inputs.source_registry }}
+            username: ${{ secrets.source_registry_username }}
+            password: ${{ secrets.source_registry_token }}
+
+        - name: Pull the source image; verify it exists
+          run: 
+            docker pull "$SOURCE_IMAGE" --platform=${{ matrix.platform }}
+          env:
+            SOURCE_IMAGE: ${{ inputs.source_registry }}/${{ inputs.source_image }}
+          shell: bash
+  
+    push-image:
+      needs: check-image-exists
+      runs-on: ubuntu-latest
+      steps:
+        - name: Promote container images from ${{ inputs.source_registry }} to ${{ inputs.target_registry }}
+          run: |
+            echo "Promoting $SOURCE_IMAGE to $RELEASE_IMAGE"
+            docker run --rm  \
+              quay.io/skopeo/stable:latest \
+              copy \
+                --all \
+                --retry-times 10 \
+                --dest-creds "$RELEASE_CREDS" \
+                --src-creds "$SOURCE_CREDS" \
+                "docker://$SOURCE_IMAGE" \
+                "docker://$RELEASE_IMAGE"
+          env:
+            SOURCE_IMAGE: "${{ inputs.source_registry }}/${{ inputs.source_image }}"
+            RELEASE_IMAGE: "${{ inputs.target_registry }}/${{ inputs.target_image }}"
+            RELEASE_CREDS: ${{ secrets.target_registry_username }}:${{ secrets.target_registry_token }}
+            SOURCE_CREDS: ${{ secrets.source_registry_username }}:${{ secrets.source_registry_token }}

--- a/.github/workflows/scan-docker-image-action.yaml
+++ b/.github/workflows/scan-docker-image-action.yaml
@@ -1,0 +1,69 @@
+---
+  name: Reusable workflow for Trivy and Dockle to scan images
+  on:
+    workflow_call:
+      inputs:
+        platforms:
+          description: The platform to scan the image
+          required: true
+          type: string
+          default: '["linux/arm64", "linux/amd64"]'
+        source_image: 
+          description: The image to clone
+          required: true
+          type: string
+        source_registry:
+          description: Image registry from which to pull the image
+          required: true
+          type: string
+      secrets: 
+        registry_password:
+          description: The Github token or similar to authenticate with for the registry.
+          required: true
+        registry_username:
+          description: The username to authenticate with for the registry.
+          required: true
+  
+  jobs:
+    scan:
+      strategy:
+        matrix:
+          platform: ${{ fromJson(inputs.platforms) }}
+      runs-on: ubuntu-latest
+      name: Trivy + Dockle image scan
+      steps:
+            
+        - name: Login to ${{ inputs.source_registry }}
+          uses: docker/login-action@v3
+          with:
+            registry: ${{ inputs.source_registry }}
+            username: ${{ secrets.registry_username }}
+            password: ${{ secrets.registry_password }}
+        
+        - name: check docker image exists
+          run: |
+            docker pull ${{ inputs.source_registry }}/${{ inputs.source_image }}
+
+        - name: Trivy - multi-arch
+          uses: aquasecurity/trivy-action@0.13.1
+          with:
+            image-ref: ${{ inputs.source_registry }}/${{ inputs.source_image }}
+            format: "table"
+            exit-code: "1"
+            ignore-unfixed: true
+            vuln-type: "os,library"
+            severity: "CRITICAL,HIGH"
+            trivy-config: trivy.yaml
+          env:
+            TRIVY_PLATFORM: ${{ matrix.platform }}
+        
+        - name: Display platform
+          run: |
+            echo "Platform: ${{ matrix.platform }}"
+        
+        - name: Dockle - multi-arch
+          uses: hands-lab/dockle-action@v1
+          with:
+            image: ${{ inputs.source_registry }}/${{ inputs.source_image }}
+            exit-code: "1"
+            exit-level: WARN

--- a/.github/workflows/scan-docker-image-action.yaml
+++ b/.github/workflows/scan-docker-image-action.yaml
@@ -39,10 +39,14 @@
             registry: ${{ inputs.source_registry }}
             username: ${{ secrets.registry_username }}
             password: ${{ secrets.registry_password }}
+
+        - name: Display platform
+          run: |
+            echo "Platform: ${{ matrix.platform }}"
         
         - name: check docker image exists
           run: |
-            docker pull ${{ inputs.source_registry }}/${{ inputs.source_image }}
+            docker pull --platform ${{ matrix.platform }} ${{ inputs.source_registry }}/${{ inputs.source_image }}
 
         - name: Trivy - multi-arch
           uses: aquasecurity/trivy-action@0.13.1
@@ -57,13 +61,9 @@
           env:
             TRIVY_PLATFORM: ${{ matrix.platform }}
         
-        - name: Display platform
-          run: |
-            echo "Platform: ${{ matrix.platform }}"
-        
         - name: Dockle - multi-arch
           uses: hands-lab/dockle-action@v1
           with:
             image: ${{ inputs.source_registry }}/${{ inputs.source_image }}
-            exit-code: "1"
+            exit-code: "0"
             exit-level: WARN


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR solves the problem of not pushing the latest tag to docker hub. Pushing this tag is mandatory as discussed in the PR https://github.com/fluent/fluent-operator/pull/1079
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1068 

GitHub action jobs - than ran on my personal credentials with tag [v23.1.1](https://github.com/sarathchandra24/fluent-operator/tree/v23.1.1) - this is just a temporary tag to check the creation of images.

[Fluentd Job](https://github.com/sarathchandra24/fluent-operator/actions/runs/8217761452)
[Fluent-Bit Job](https://github.com/sarathchandra24/fluent-operator/actions/runs/8220329710) - In Progress
[Fluent Operator Job](https://github.com/sarathchandra24/fluent-operator/actions/runs/8220329713)


Verification of images pushed to docker hub:
[fluent-operator](hub.docker.com/repository/docker/sarathchandra24/fluent-operator/general)
[fluentbit](https://hub.docker.com/repository/docker/sarathchandra24/fluent-bit/general)
[fluentd](https://hub.docker.com/repository/docker/sarathchandra24/fluentd/general)


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
As per this https://github.com/containers/image/issues/447 discussion --additional-tags is only copying to docker-archive.

Also copying manifests is also not helping
