### PR TITLE
adds servicemonitor

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-servicemonitor.yaml
+++ b/charts/fluent-operator/templates/fluentbit-servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.enable -}}
+{{- if .Values.fluentbit.serviceMonitor -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fluent-bit
+  labels:
+    app.kubernetes.io/name: fluent-bit
+spec:
+  endpoints:
+    - port: metrics
+      path: /api/v2/metrics/prometheus
+      interval: 30s
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fluent-bit
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -72,6 +72,7 @@ fluentbit:
   # Installs a sub chart carrying the CRDs for the fluent-bit controller. The sub chart is enabled by default.
   crdsEnable: true
   enable: true
+  serviceMonitor: false
   image:
     repository: "kubesphere/fluent-bit"
     tag: "v2.2.2"


### PR DESCRIPTION
Prometheus servicemonitor logging collector support.
Servicemonitor disabled by default not to cause issues with existing installations.

```release-note
None
```

```docs
Usage (in values.yaml):

fluentbit:
    serviceMonitor: true
```

ps. sorry for dup (