### PR TITLE
configure emitter parameters from filter rewriteTag

### DIFF
--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
@@ -649,6 +649,18 @@ spec:
                             component of the pipeline, you can use this property to
                             configure an optional name for it.
                           type: string
+                        emitterStorageType:
+                          description: Specify the emitter buffering mechanism to use. It can be
+                            memory or filesystem
+                          enum:
+                          - filesystem
+                          - memory
+                          type: string
+                        emitterMemBufLimit:
+                          description: Set a limit of memory that Emitter plugin can use when
+                            appending data to the Engine. If the limit is reach, it will
+                            be paused; when the data is flushed it resumes.
+                          type: string
                         retryLimit:
                           description: 'RetryLimit describes how many times fluent-bit
                             should retry to send data to a specific output. If set


### PR DESCRIPTION
Ability to set emitter parameters from filter rewriteTag.
In addition to clusterfilter-only https://github.com/fluent/fluent-operator/pull/1069

```release-note
None
```

```docs
apiVersion: fluentbit.fluent.io/v1alpha2
kind: Filter
metadata:
  labels:
    fluentbit.fluent.io/enabled: "true"
  name: filter
  namespace: namespace
spec:
  match: kube.*
  filters:
  - rewriteTag:
      emitterName: rewrite
      emitterStorageType: filesystem
      emitterMemBufLimit: 8MB
      rules:
      - $flow_tag msg $TAG[0].msg false
```