### PR TITLE
Fix 1090: Path issues

### DIFF
--- a/cmd/fluent-watcher/fluentd/main.go
+++ b/cmd/fluent-watcher/fluentd/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	defaultBinPath      = "/usr/bin/fluentd"
+	defaultBinPath      = "/usr/local/bundle/bin/fluentd"
 	defaultCfgPath      = "/fluentd/etc/fluent.conf"
 	defaultWatchDir     = "/fluentd/etc"
 	defaultPluginPath   = "/fluentd/plugins"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1090 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixes docker run path for fluentd
```

> docker run kubesphere/fluentd:v1.15.3-arm64  

is running the following
<img width="812" alt="image" src="https://github.com/fluent/fluent-operator/assets/39090092/efe90dda-a127-4f0d-845f-31c27e4b27a1">

This changes fixes the path issue for fluentd
<img width="1495" alt="image" src="https://github.com/fluent/fluent-operator/assets/39090092/a3b54347-f993-49d1-8b80-9a75a3ade203">


### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```