### PR TITLE
fix fluent-operator clusterrole in manifests directory

### DIFF
--- a/manifests/setup/fluent-operator-clusterRole.yaml
+++ b/manifests/setup/fluent-operator-clusterRole.yaml
@@ -47,15 +47,21 @@ rules:
     resources:
       - collectors
       - fluentbits
+      - fluentbits/finalizers
       - clusterfluentbitconfigs
+      - clusterfluentbitconfigs/finalizers
       - clusterfilters
+      - clusterfilters/finalizers
       - clusterinputs
+      - clusterinputs/finalizers
       - clusteroutputs
+      - clusteroutputs/finalizers
       - clusterparsers
       - fluentbitconfigs
       - filters
       - outputs
       - parsers
+      - clusterparsers/finalizers
     verbs:
       - create
       - delete
@@ -77,6 +83,8 @@ rules:
       - filters
       - clusteroutputs
       - outputs
+      - inputs
+      - clusterinputs
     verbs:
       - create
       - delete

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -31145,15 +31145,21 @@ rules:
   resources:
   - collectors
   - fluentbits
+  - fluentbits/finalizers
   - clusterfluentbitconfigs
+  - clusterfluentbitconfigs/finalizers
   - clusterfilters
+  - clusterfilters/finalizers
   - clusterinputs
+  - clusterinputs/finalizers
   - clusteroutputs
+  - clusteroutputs/finalizers
   - clusterparsers
   - fluentbitconfigs
   - filters
   - outputs
   - parsers
+  - clusterparsers/finalizers
   verbs:
   - create
   - delete
@@ -31175,6 +31181,8 @@ rules:
   - filters
   - clusteroutputs
   - outputs
+  - inputs
+  - clusterinputs
   verbs:
   - create
   - delete


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
There is a diff between the helm and the kustomize deployments in the fluent-operator clusterrole.

Seems the following two commits only modified the helm chart but not the kustmozie based deployment manifests:
* https://github.com/fluent/fluent-operator/commit/12afff1bef7fb2ae76e138cf081886563b31305d
* https://github.com/fluent/fluent-operator/commit/0607757aee2fbecbca732cb2a99c20697ddb0446

### Which issue(s) this PR fixes:
I did not open an issue for this.

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: update RBAC clusterrole in kustomize deployment to reflect recent changes in the helm chart
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```