### PR TITLE
Passing variables to es output config is fixed

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
@@ -36,6 +36,8 @@ spec:
     logstashFormat: {{ .Values.fluentbit.output.es.logstashFormat | default true }}
     logstashPrefix: {{ .Values.fluentbit.output.es.logstashPrefix | default "ks-logstash-log" | quote }}
     replaceDots: {{ .Values.fluentbit.output.es.replaceDots | default false }}
+    writeOperation: {{ .Values.fluentbit.output.es.writeOperation | default "create" | quote }}
+    traceError: {{ .Values.fluentbit.output.es.traceError | default false }}
     generateID: true
     timeKey: "@timestamp"
 {{- if .Values.fluentbit.output.es.enableTLS }}


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
It passes variables from values.yaml to Elasticsearch ClusterOutput. traceError and writeOperation were omitted.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
None

### Additional documentation, usage docs, etc.