### PR TITLE
HostNetwork DNS Policy

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -12,6 +12,8 @@ spec:
 {{- end }}
 {{- if .Values.fluentbit.dnsPolicy }}
   dnsPolicy: {{ .Values.fluentbit.dnsPolicy }}
+{{- else if .Values.fluentbit.hostNetwork }}
+  dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
   image: {{ .Values.fluentbit.image.repository }}:{{ .Values.fluentbit.image.tag }}
   {{- if .Values.fluentbit.imagePullSecrets }}


### PR DESCRIPTION
- when hostNetwork is true and dnsPolicy is not filled in, default to `ClusterFirstWithHostNet`

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
It changes the default behavior when hostNetwork is true and dnsPolicy is not filled in to use `ClusterFirstWithHostNet`. 
[Pod's DNS Policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
None

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```