### PR TITLE
helm template fluentbit output es support logstashPrefixKey

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-elasticsearch.yaml
@@ -34,7 +34,12 @@ spec:
 {{ toYaml .Values.fluentbit.output.es.httpPassword | indent 6 }}
 {{- end }}
     logstashFormat: {{ .Values.fluentbit.output.es.logstashFormat | default true }}
-    logstashPrefix: {{ .Values.fluentbit.output.es.logstashPrefix | default "ks-logstash-log" | quote }}
+{{- if .Values.fluentbit.output.es.logstashPrefix }}
+    logstashPrefix: {{ .Values.fluentbit.output.es.logstashPrefix | quote }}
+{{- end }}
+{{- if .Values.fluentbit.output.es.logstashPrefixKey }}
+    logstashPrefixKey: {{ .Values.fluentbit.output.es.logstashPrefixKey | quote }}
+{{- end }}
     replaceDots: {{ .Values.fluentbit.output.es.replaceDots | default false }}
     writeOperation: {{ .Values.fluentbit.output.es.writeOperation | default "create" | quote }}
     traceError: {{ .Values.fluentbit.output.es.traceError | default false }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -220,6 +220,7 @@ fluentbit:
       logstashPrefix: ks-logstash-log
       bufferSize: 20MB
       traceError: true
+    #      logstashPrefixKey: ks-logstash-log
     #      suppressTypeName: "On"
     #      path: ""
     #      bufferSize: "4KB"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

helm template output es support logstashPrefixKey

### Which issue(s) this PR fixes:

Fixes  #1118 

### Does this PR introduced a user-facing change?

None

### Additional documentation, usage docs, etc.:

- [Usage]: 

```docs
  output:
    es:
      enable: true
      host: 10.8.xx.xx
      port: 9200
      logstashPrefixKey: ks-logstash-log
      buffer:
        enable: false
        type: file
        path: /buffers/es

```