### PR TITLE
Add Profile field for Fluent bit S3 output

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/s3_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/s3_types.go
@@ -63,7 +63,9 @@ type S3 struct {
 	// Integer value to set the maximum number of retries allowed.
 	RetryLimit *int32 `json:"RetryLimit,omitempty"`
 	// Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.
-	ExternalId   string `json:"ExternalId,omitempty"`
+	ExternalId string `json:"ExternalId,omitempty"`
+	// Option to specify an AWS Profile for credentials.
+	Profile      string `json:Profile,omitempty`
 	*plugins.TLS `json:"tls,omitempty"`
 }
 
@@ -153,6 +155,9 @@ func (o *S3) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if o.ExternalId != "" {
 		kvs.Insert("external_id", o.ExternalId)
+	}
+	if o.Profile != "" {
+		kvs.Insert("profile", o.Profile)
 	}
 	if o.TLS != nil {
 		tls, err := o.TLS.Params(sl)

--- a/apis/fluentbit/v1alpha2/plugins/output/s3_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/s3_types.go
@@ -65,7 +65,7 @@ type S3 struct {
 	// Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.
 	ExternalId string `json:"ExternalId,omitempty"`
 	// Option to specify an AWS Profile for credentials.
-	Profile      string `json:Profile,omitempty`
+	Profile      string `json:"Profile,omitempty"`
 	*plugins.TLS `json:"tls,omitempty"`
 }
 

--- a/apis/fluentbit/v1alpha2/plugins/output/s3_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/s3_types_test.go
@@ -40,6 +40,7 @@ func TestOutput_S3_Params(t *testing.T) {
 		StorageClass:             "storage_class",
 		RetryLimit:               ptrAny(int32(1)),
 		ExternalId:               "external_id",
+		Profile:                  "my-profile",
 	}
 
 	expected := params.NewKVs()
@@ -69,6 +70,7 @@ func TestOutput_S3_Params(t *testing.T) {
 	expected.Insert("storage_class", "storage_class")
 	expected.Insert("retry_limit", "1")
 	expected.Insert("external_id", "external_id")
+	expected.Insert("profile", "my-profile")
 
 	kvs, err := s3.Params(sl)
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What this PR does / why we need it:
This adds support for the AWS credential `profile` field for the S3 Fluent Bit S3 ouput.  See [here](https://docs.fluentbit.io/manual/pipeline/outputs/s3).
### Which issue(s) this PR fixes:

Fixes #1126

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
The `Profile` field for the `S3` output is added, which translates to the `profile` field for the Fluent bit S3 output.
```

