### PR TITLE
make lua scripts `code` and `script` optional

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
@@ -1,9 +1,9 @@
 package filter
 
 import (
+	"regexp"
 	"strconv"
 	"strings"
-	"regexp"
 
 	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v2/apis/fluentbit/v1alpha2/plugins/params"
@@ -17,12 +17,12 @@ import (
 type Lua struct {
 	plugins.CommonParams `json:",inline"`
 	// Path to the Lua script that will be used.
-	Script v1.ConfigMapKeySelector `json:"script"`
+	Script v1.ConfigMapKeySelector `json:"script,omitempty"`
 	// Lua function name that will be triggered to do filtering.
 	// It's assumed that the function is declared inside the Script defined above.
 	Call string `json:"call"`
 	// Inline LUA code instead of loading from a path via script.
-	Code string `json:"code"`
+	Code string `json:"code,omitempty"`
 	// If these keys are matched, the fields are converted to integer.
 	// If more than one key, delimit by space.
 	// Note that starting from Fluent Bit v1.6 integer data types are preserved

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfilters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfilters.yaml
@@ -345,8 +345,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
@@ -345,8 +345,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.

--- a/config/crd/bases/fluentbit.fluent.io_clusterfilters.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterfilters.yaml
@@ -345,8 +345,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.

--- a/config/crd/bases/fluentbit.fluent.io_filters.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_filters.yaml
@@ -345,8 +345,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -343,8 +343,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.
@@ -11438,8 +11436,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -343,8 +343,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.
@@ -11438,8 +11436,6 @@ spec:
                           type: array
                       required:
                       - call
-                      - code
-                      - script
                       type: object
                     modify:
                       description: Modify defines Modify Filter configuration.


### PR DESCRIPTION

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes #1128 

### Does this PR introduced a user-facing change?

None

```release-note
make lua scripts `code` and `script` optional
```

### Additional documentation, usage docs, etc.:

```