### PR TITLE
fix: missing inputs and clusterInputs CRDs in setup.yaml (#1144)

### DIFF
--- a/config/crd/bases/kustomization.yaml
+++ b/config/crd/bases/kustomization.yaml
@@ -17,6 +17,8 @@ resources:
 - fluentd.fluent.io_clusterfluentdconfigs.yaml
 - fluentd.fluent.io_fluentdconfigs.yaml
 - fluentd.fluent.io_filters.yaml
+- fluentd.fluent.io_clusterinputs.yaml
+- fluentd.fluent.io_inputs.yaml
 - fluentd.fluent.io_clusterfilters.yaml
 - fluentd.fluent.io_outputs.yaml
 - fluentd.fluent.io_clusteroutputs.yaml

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -2643,6 +2643,909 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
+  name: clusterinputs.fluentd.fluent.io
+spec:
+  group: fluentd.fluent.io
+  names:
+    kind: ClusterInput
+    listKind: ClusterInputList
+    plural: clusterinputs
+    shortNames:
+    - cfdi
+    singular: clusterinput
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInput is the Schema for the clusterinputs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInputSpec defines the desired state of ClusterInput
+            properties:
+              inputs:
+                items:
+                  description: Input defines all available input plugins and their
+                    parameters
+                  properties:
+                    customPlugin:
+                      description: Custom plugin type
+                      properties:
+                        config:
+                          type: string
+                      required:
+                      - config
+                      type: object
+                    forward:
+                      description: in_forward plugin
+                      properties:
+                        addTagPrefix:
+                          description: Adds the prefix to the incoming event's tag.
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        chunkSizeLimit:
+                          description: The size limit of the received chunk. If the
+                            chunk size is larger than this value, the received chunk
+                            is dropped.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        chunkSizeWarnLimit:
+                          description: The warning size limit of the received chunk.
+                            If the chunk size is larger than this value, a warning
+                            message will be sent.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        client:
+                          description: The security section of client plugin
+                          properties:
+                            host:
+                              description: The IP address or hostname of the client.
+                                This is exclusive with Network.
+                              type: string
+                            network:
+                              description: The network address specification. This
+                                is exclusive with Host.
+                              type: string
+                            sharedKey:
+                              description: The shared key per client.
+                              type: string
+                            users:
+                              description: The array of usernames.
+                              type: string
+                          type: object
+                        denyKeepalive:
+                          description: The connections will be disconnected right
+                            after receiving a message, if true.
+                          type: boolean
+                        lingerTimeout:
+                          description: The timeout used to set the linger option.
+                          type: integer
+                        port:
+                          description: The port to listen to, default is 24224.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        resolveHostname:
+                          description: Tries to resolve hostname from IP addresses
+                            or not.
+                          type: boolean
+                        security:
+                          description: The security section of forward plugin
+                          properties:
+                            allowAnonymousSource:
+                              description: Allows the anonymous source. <client> sections
+                                are required, if disabled.
+                              type: string
+                            selfHostname:
+                              description: The hostname.
+                              type: string
+                            sharedKey:
+                              description: The shared key for authentication.
+                              type: string
+                            user:
+                              description: Defines user section directly.
+                              properties:
+                                password:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                                username:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                              type: object
+                            userAuth:
+                              description: If true, user-based authentication is used.
+                              type: string
+                          type: object
+                        sendKeepalivePacket:
+                          description: Enables the TCP keepalive for sockets.
+                          type: boolean
+                        skipInvalidEvent:
+                          description: Skips the invalid incoming event.
+                          type: boolean
+                        sourceAddressKey:
+                          description: The field name of the client's source address.
+                            If set, the client's address will be set to its key.
+                          type: string
+                        sourceHostnameKey:
+                          description: The field name of the client's hostname. If
+                            set, the client's hostname will be set to its key.
+                          type: string
+                        tag:
+                          description: in_forward uses incoming event's tag by default
+                            (See Protocol Section). If the tag parameter is set, its
+                            value is used instead.
+                          type: string
+                        transport:
+                          description: The transport section of forward plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                        user:
+                          description: The security section of user plugin
+                          properties:
+                            password:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                            username:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    http:
+                      description: in_http plugin
+                      properties:
+                        addHttpHeaders:
+                          description: Adds HTTP_ prefix headers to the record.
+                          type: boolean
+                        addRemoteAddr:
+                          description: 'Adds REMOTE_ADDR field to the record. The
+                            value of REMOTE_ADDR is the client''s address. i.e: X-Forwarded-For:
+                            host1, host2'
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        bodySizeLimit:
+                          description: The size limit of the POSTed element.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        corsAllOrigins:
+                          description: Whitelist domains for CORS.
+                          type: string
+                        corsAllowCredentials:
+                          description: Add Access-Control-Allow-Credentials header.
+                            It's needed when a request's credentials mode is include
+                          type: string
+                        keepaliveTimeout:
+                          description: The timeout limit for keeping the connection
+                            alive.
+                          pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                          type: string
+                        parse:
+                          description: The parse section of http plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        port:
+                          description: The port to listen to, default is 9880.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        respondsWithEmptyImg:
+                          description: Responds with an empty GIF image of 1x1 pixel
+                            (rather than an empty string).
+                          type: boolean
+                        transport:
+                          description: The transport section of http plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                      type: object
+                    id:
+                      description: The @id parameter specifies a unique name for the
+                        configuration.
+                      type: string
+                    label:
+                      description: The @label parameter is to route the input events
+                        to <label> sections.
+                      type: string
+                    logLevel:
+                      description: The @log_level parameter specifies the plugin-specific
+                        logging level
+                      type: string
+                    monitorAgent:
+                      description: monitor_agent plugin
+                      properties:
+                        bind:
+                          description: The bind address to listen to.
+                          type: string
+                        emitInterval:
+                          description: The interval time between event emits. This
+                            will be used when "tag" is configured.
+                          format: int64
+                          type: integer
+                        includeConfig:
+                          description: You can set this option to false to remove
+                            the config field from the response.
+                          type: boolean
+                        includeRetry:
+                          description: You can set this option to false to remove
+                            the retry field from the response.
+                          type: boolean
+                        port:
+                          description: The port to listen to.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: If you set this parameter, this plugin emits
+                            metrics as records.
+                          type: string
+                      type: object
+                    sample:
+                      description: in_sample plugin
+                      properties:
+                        autoIncrementKey:
+                          description: If specified, each generated event has an auto-incremented
+                            key field.
+                          type: string
+                        rate:
+                          description: It configures how many events to generate per
+                            second.
+                          format: int64
+                          type: integer
+                        sample:
+                          description: The sample data to be generated. It should
+                            be either an array of JSON hashes or a single JSON hash.
+                            If it is an array of JSON hashes, the hashes in the array
+                            are cycled through in order.
+                          type: string
+                        size:
+                          description: The number of events in the event stream of
+                            each emit.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: The tag of the event. The value is the tag
+                            assigned to the generated events.
+                          type: string
+                      type: object
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ClusterInputStatus defines the observed state of ClusterInput
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: clusteroutputs.fluentbit.fluent.io
 spec:
   group: fluentbit.fluent.io
@@ -26261,6 +27164,909 @@ spec:
               state:
                 description: The state of this fluentd
                 type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  name: inputs.fluentd.fluent.io
+spec:
+  group: fluentd.fluent.io
+  names:
+    kind: Input
+    listKind: InputList
+    plural: inputs
+    shortNames:
+    - fdi
+    singular: input
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Input is the Schema for the inputs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InputSpec defines the desired state of Input
+            properties:
+              inputs:
+                items:
+                  description: Input defines all available input plugins and their
+                    parameters
+                  properties:
+                    customPlugin:
+                      description: Custom plugin type
+                      properties:
+                        config:
+                          type: string
+                      required:
+                      - config
+                      type: object
+                    forward:
+                      description: in_forward plugin
+                      properties:
+                        addTagPrefix:
+                          description: Adds the prefix to the incoming event's tag.
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        chunkSizeLimit:
+                          description: The size limit of the received chunk. If the
+                            chunk size is larger than this value, the received chunk
+                            is dropped.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        chunkSizeWarnLimit:
+                          description: The warning size limit of the received chunk.
+                            If the chunk size is larger than this value, a warning
+                            message will be sent.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        client:
+                          description: The security section of client plugin
+                          properties:
+                            host:
+                              description: The IP address or hostname of the client.
+                                This is exclusive with Network.
+                              type: string
+                            network:
+                              description: The network address specification. This
+                                is exclusive with Host.
+                              type: string
+                            sharedKey:
+                              description: The shared key per client.
+                              type: string
+                            users:
+                              description: The array of usernames.
+                              type: string
+                          type: object
+                        denyKeepalive:
+                          description: The connections will be disconnected right
+                            after receiving a message, if true.
+                          type: boolean
+                        lingerTimeout:
+                          description: The timeout used to set the linger option.
+                          type: integer
+                        port:
+                          description: The port to listen to, default is 24224.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        resolveHostname:
+                          description: Tries to resolve hostname from IP addresses
+                            or not.
+                          type: boolean
+                        security:
+                          description: The security section of forward plugin
+                          properties:
+                            allowAnonymousSource:
+                              description: Allows the anonymous source. <client> sections
+                                are required, if disabled.
+                              type: string
+                            selfHostname:
+                              description: The hostname.
+                              type: string
+                            sharedKey:
+                              description: The shared key for authentication.
+                              type: string
+                            user:
+                              description: Defines user section directly.
+                              properties:
+                                password:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                                username:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                              type: object
+                            userAuth:
+                              description: If true, user-based authentication is used.
+                              type: string
+                          type: object
+                        sendKeepalivePacket:
+                          description: Enables the TCP keepalive for sockets.
+                          type: boolean
+                        skipInvalidEvent:
+                          description: Skips the invalid incoming event.
+                          type: boolean
+                        sourceAddressKey:
+                          description: The field name of the client's source address.
+                            If set, the client's address will be set to its key.
+                          type: string
+                        sourceHostnameKey:
+                          description: The field name of the client's hostname. If
+                            set, the client's hostname will be set to its key.
+                          type: string
+                        tag:
+                          description: in_forward uses incoming event's tag by default
+                            (See Protocol Section). If the tag parameter is set, its
+                            value is used instead.
+                          type: string
+                        transport:
+                          description: The transport section of forward plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                        user:
+                          description: The security section of user plugin
+                          properties:
+                            password:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                            username:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    http:
+                      description: in_http plugin
+                      properties:
+                        addHttpHeaders:
+                          description: Adds HTTP_ prefix headers to the record.
+                          type: boolean
+                        addRemoteAddr:
+                          description: 'Adds REMOTE_ADDR field to the record. The
+                            value of REMOTE_ADDR is the client''s address. i.e: X-Forwarded-For:
+                            host1, host2'
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        bodySizeLimit:
+                          description: The size limit of the POSTed element.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        corsAllOrigins:
+                          description: Whitelist domains for CORS.
+                          type: string
+                        corsAllowCredentials:
+                          description: Add Access-Control-Allow-Credentials header.
+                            It's needed when a request's credentials mode is include
+                          type: string
+                        keepaliveTimeout:
+                          description: The timeout limit for keeping the connection
+                            alive.
+                          pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                          type: string
+                        parse:
+                          description: The parse section of http plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        port:
+                          description: The port to listen to, default is 9880.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        respondsWithEmptyImg:
+                          description: Responds with an empty GIF image of 1x1 pixel
+                            (rather than an empty string).
+                          type: boolean
+                        transport:
+                          description: The transport section of http plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                      type: object
+                    id:
+                      description: The @id parameter specifies a unique name for the
+                        configuration.
+                      type: string
+                    label:
+                      description: The @label parameter is to route the input events
+                        to <label> sections.
+                      type: string
+                    logLevel:
+                      description: The @log_level parameter specifies the plugin-specific
+                        logging level
+                      type: string
+                    monitorAgent:
+                      description: monitor_agent plugin
+                      properties:
+                        bind:
+                          description: The bind address to listen to.
+                          type: string
+                        emitInterval:
+                          description: The interval time between event emits. This
+                            will be used when "tag" is configured.
+                          format: int64
+                          type: integer
+                        includeConfig:
+                          description: You can set this option to false to remove
+                            the config field from the response.
+                          type: boolean
+                        includeRetry:
+                          description: You can set this option to false to remove
+                            the retry field from the response.
+                          type: boolean
+                        port:
+                          description: The port to listen to.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: If you set this parameter, this plugin emits
+                            metrics as records.
+                          type: string
+                      type: object
+                    sample:
+                      description: in_sample plugin
+                      properties:
+                        autoIncrementKey:
+                          description: If specified, each generated event has an auto-incremented
+                            key field.
+                          type: string
+                        rate:
+                          description: It configures how many events to generate per
+                            second.
+                          format: int64
+                          type: integer
+                        sample:
+                          description: The sample data to be generated. It should
+                            be either an array of JSON hashes or a single JSON hash.
+                            If it is an array of JSON hashes, the hashes in the array
+                            are cycled through in order.
+                          type: string
+                        size:
+                          description: The number of events in the event stream of
+                            each emit.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: The tag of the event. The value is the tag
+                            assigned to the generated events.
+                          type: string
+                      type: object
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: InputStatus defines the observed state of Input
             type: object
         type: object
     served: true

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -2643,6 +2643,909 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
+  name: clusterinputs.fluentd.fluent.io
+spec:
+  group: fluentd.fluent.io
+  names:
+    kind: ClusterInput
+    listKind: ClusterInputList
+    plural: clusterinputs
+    shortNames:
+    - cfdi
+    singular: clusterinput
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterInput is the Schema for the clusterinputs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterInputSpec defines the desired state of ClusterInput
+            properties:
+              inputs:
+                items:
+                  description: Input defines all available input plugins and their
+                    parameters
+                  properties:
+                    customPlugin:
+                      description: Custom plugin type
+                      properties:
+                        config:
+                          type: string
+                      required:
+                      - config
+                      type: object
+                    forward:
+                      description: in_forward plugin
+                      properties:
+                        addTagPrefix:
+                          description: Adds the prefix to the incoming event's tag.
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        chunkSizeLimit:
+                          description: The size limit of the received chunk. If the
+                            chunk size is larger than this value, the received chunk
+                            is dropped.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        chunkSizeWarnLimit:
+                          description: The warning size limit of the received chunk.
+                            If the chunk size is larger than this value, a warning
+                            message will be sent.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        client:
+                          description: The security section of client plugin
+                          properties:
+                            host:
+                              description: The IP address or hostname of the client.
+                                This is exclusive with Network.
+                              type: string
+                            network:
+                              description: The network address specification. This
+                                is exclusive with Host.
+                              type: string
+                            sharedKey:
+                              description: The shared key per client.
+                              type: string
+                            users:
+                              description: The array of usernames.
+                              type: string
+                          type: object
+                        denyKeepalive:
+                          description: The connections will be disconnected right
+                            after receiving a message, if true.
+                          type: boolean
+                        lingerTimeout:
+                          description: The timeout used to set the linger option.
+                          type: integer
+                        port:
+                          description: The port to listen to, default is 24224.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        resolveHostname:
+                          description: Tries to resolve hostname from IP addresses
+                            or not.
+                          type: boolean
+                        security:
+                          description: The security section of forward plugin
+                          properties:
+                            allowAnonymousSource:
+                              description: Allows the anonymous source. <client> sections
+                                are required, if disabled.
+                              type: string
+                            selfHostname:
+                              description: The hostname.
+                              type: string
+                            sharedKey:
+                              description: The shared key for authentication.
+                              type: string
+                            user:
+                              description: Defines user section directly.
+                              properties:
+                                password:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                                username:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                              type: object
+                            userAuth:
+                              description: If true, user-based authentication is used.
+                              type: string
+                          type: object
+                        sendKeepalivePacket:
+                          description: Enables the TCP keepalive for sockets.
+                          type: boolean
+                        skipInvalidEvent:
+                          description: Skips the invalid incoming event.
+                          type: boolean
+                        sourceAddressKey:
+                          description: The field name of the client's source address.
+                            If set, the client's address will be set to its key.
+                          type: string
+                        sourceHostnameKey:
+                          description: The field name of the client's hostname. If
+                            set, the client's hostname will be set to its key.
+                          type: string
+                        tag:
+                          description: in_forward uses incoming event's tag by default
+                            (See Protocol Section). If the tag parameter is set, its
+                            value is used instead.
+                          type: string
+                        transport:
+                          description: The transport section of forward plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                        user:
+                          description: The security section of user plugin
+                          properties:
+                            password:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                            username:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    http:
+                      description: in_http plugin
+                      properties:
+                        addHttpHeaders:
+                          description: Adds HTTP_ prefix headers to the record.
+                          type: boolean
+                        addRemoteAddr:
+                          description: 'Adds REMOTE_ADDR field to the record. The
+                            value of REMOTE_ADDR is the client''s address. i.e: X-Forwarded-For:
+                            host1, host2'
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        bodySizeLimit:
+                          description: The size limit of the POSTed element.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        corsAllOrigins:
+                          description: Whitelist domains for CORS.
+                          type: string
+                        corsAllowCredentials:
+                          description: Add Access-Control-Allow-Credentials header.
+                            It's needed when a request's credentials mode is include
+                          type: string
+                        keepaliveTimeout:
+                          description: The timeout limit for keeping the connection
+                            alive.
+                          pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                          type: string
+                        parse:
+                          description: The parse section of http plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        port:
+                          description: The port to listen to, default is 9880.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        respondsWithEmptyImg:
+                          description: Responds with an empty GIF image of 1x1 pixel
+                            (rather than an empty string).
+                          type: boolean
+                        transport:
+                          description: The transport section of http plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                      type: object
+                    id:
+                      description: The @id parameter specifies a unique name for the
+                        configuration.
+                      type: string
+                    label:
+                      description: The @label parameter is to route the input events
+                        to <label> sections.
+                      type: string
+                    logLevel:
+                      description: The @log_level parameter specifies the plugin-specific
+                        logging level
+                      type: string
+                    monitorAgent:
+                      description: monitor_agent plugin
+                      properties:
+                        bind:
+                          description: The bind address to listen to.
+                          type: string
+                        emitInterval:
+                          description: The interval time between event emits. This
+                            will be used when "tag" is configured.
+                          format: int64
+                          type: integer
+                        includeConfig:
+                          description: You can set this option to false to remove
+                            the config field from the response.
+                          type: boolean
+                        includeRetry:
+                          description: You can set this option to false to remove
+                            the retry field from the response.
+                          type: boolean
+                        port:
+                          description: The port to listen to.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: If you set this parameter, this plugin emits
+                            metrics as records.
+                          type: string
+                      type: object
+                    sample:
+                      description: in_sample plugin
+                      properties:
+                        autoIncrementKey:
+                          description: If specified, each generated event has an auto-incremented
+                            key field.
+                          type: string
+                        rate:
+                          description: It configures how many events to generate per
+                            second.
+                          format: int64
+                          type: integer
+                        sample:
+                          description: The sample data to be generated. It should
+                            be either an array of JSON hashes or a single JSON hash.
+                            If it is an array of JSON hashes, the hashes in the array
+                            are cycled through in order.
+                          type: string
+                        size:
+                          description: The number of events in the event stream of
+                            each emit.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: The tag of the event. The value is the tag
+                            assigned to the generated events.
+                          type: string
+                      type: object
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ClusterInputStatus defines the observed state of ClusterInput
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: clusteroutputs.fluentbit.fluent.io
 spec:
   group: fluentbit.fluent.io
@@ -26261,6 +27164,909 @@ spec:
               state:
                 description: The state of this fluentd
                 type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  name: inputs.fluentd.fluent.io
+spec:
+  group: fluentd.fluent.io
+  names:
+    kind: Input
+    listKind: InputList
+    plural: inputs
+    shortNames:
+    - fdi
+    singular: input
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Input is the Schema for the inputs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InputSpec defines the desired state of Input
+            properties:
+              inputs:
+                items:
+                  description: Input defines all available input plugins and their
+                    parameters
+                  properties:
+                    customPlugin:
+                      description: Custom plugin type
+                      properties:
+                        config:
+                          type: string
+                      required:
+                      - config
+                      type: object
+                    forward:
+                      description: in_forward plugin
+                      properties:
+                        addTagPrefix:
+                          description: Adds the prefix to the incoming event's tag.
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        chunkSizeLimit:
+                          description: The size limit of the received chunk. If the
+                            chunk size is larger than this value, the received chunk
+                            is dropped.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        chunkSizeWarnLimit:
+                          description: The warning size limit of the received chunk.
+                            If the chunk size is larger than this value, a warning
+                            message will be sent.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        client:
+                          description: The security section of client plugin
+                          properties:
+                            host:
+                              description: The IP address or hostname of the client.
+                                This is exclusive with Network.
+                              type: string
+                            network:
+                              description: The network address specification. This
+                                is exclusive with Host.
+                              type: string
+                            sharedKey:
+                              description: The shared key per client.
+                              type: string
+                            users:
+                              description: The array of usernames.
+                              type: string
+                          type: object
+                        denyKeepalive:
+                          description: The connections will be disconnected right
+                            after receiving a message, if true.
+                          type: boolean
+                        lingerTimeout:
+                          description: The timeout used to set the linger option.
+                          type: integer
+                        port:
+                          description: The port to listen to, default is 24224.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        resolveHostname:
+                          description: Tries to resolve hostname from IP addresses
+                            or not.
+                          type: boolean
+                        security:
+                          description: The security section of forward plugin
+                          properties:
+                            allowAnonymousSource:
+                              description: Allows the anonymous source. <client> sections
+                                are required, if disabled.
+                              type: string
+                            selfHostname:
+                              description: The hostname.
+                              type: string
+                            sharedKey:
+                              description: The shared key for authentication.
+                              type: string
+                            user:
+                              description: Defines user section directly.
+                              properties:
+                                password:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                                username:
+                                  description: Secret defines the key of a value.
+                                  properties:
+                                    valueFrom:
+                                      description: ValueSource defines how to find
+                                        a value's key.
+                                      properties:
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  type: object
+                              type: object
+                            userAuth:
+                              description: If true, user-based authentication is used.
+                              type: string
+                          type: object
+                        sendKeepalivePacket:
+                          description: Enables the TCP keepalive for sockets.
+                          type: boolean
+                        skipInvalidEvent:
+                          description: Skips the invalid incoming event.
+                          type: boolean
+                        sourceAddressKey:
+                          description: The field name of the client's source address.
+                            If set, the client's address will be set to its key.
+                          type: string
+                        sourceHostnameKey:
+                          description: The field name of the client's hostname. If
+                            set, the client's hostname will be set to its key.
+                          type: string
+                        tag:
+                          description: in_forward uses incoming event's tag by default
+                            (See Protocol Section). If the tag parameter is set, its
+                            value is used instead.
+                          type: string
+                        transport:
+                          description: The transport section of forward plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                        user:
+                          description: The security section of user plugin
+                          properties:
+                            password:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                            username:
+                              description: Secret defines the key of a value.
+                              properties:
+                                valueFrom:
+                                  description: ValueSource defines how to find a value's
+                                    key.
+                                  properties:
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    http:
+                      description: in_http plugin
+                      properties:
+                        addHttpHeaders:
+                          description: Adds HTTP_ prefix headers to the record.
+                          type: boolean
+                        addRemoteAddr:
+                          description: 'Adds REMOTE_ADDR field to the record. The
+                            value of REMOTE_ADDR is the client''s address. i.e: X-Forwarded-For:
+                            host1, host2'
+                          type: string
+                        bind:
+                          description: The port to listen to, default is "0.0.0.0"
+                          type: string
+                        bodySizeLimit:
+                          description: The size limit of the POSTed element.
+                          pattern: ^\d+(KB|MB|GB|TB)$
+                          type: string
+                        corsAllOrigins:
+                          description: Whitelist domains for CORS.
+                          type: string
+                        corsAllowCredentials:
+                          description: Add Access-Control-Allow-Credentials header.
+                            It's needed when a request's credentials mode is include
+                          type: string
+                        keepaliveTimeout:
+                          description: The timeout limit for keeping the connection
+                            alive.
+                          pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                          type: string
+                        parse:
+                          description: The parse section of http plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        port:
+                          description: The port to listen to, default is 9880.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        respondsWithEmptyImg:
+                          description: Responds with an empty GIF image of 1x1 pixel
+                            (rather than an empty string).
+                          type: boolean
+                        transport:
+                          description: The transport section of http plugin
+                          properties:
+                            caCertPath:
+                              description: for Cert generated
+                              type: string
+                            caPath:
+                              description: for Cert signed by public CA
+                              type: string
+                            caPrivateKeyPassphrase:
+                              type: string
+                            caPrivateKeyPath:
+                              type: string
+                            certPath:
+                              type: string
+                            certVerifier:
+                              description: other parameters
+                              type: string
+                            ciphers:
+                              type: string
+                            clientCertAuth:
+                              type: boolean
+                            insecure:
+                              type: boolean
+                            privateKeyPassphrase:
+                              type: string
+                            privateKeyPath:
+                              type: string
+                            protocol:
+                              description: 'The protocal name of this plugin, i.e:
+                                tls'
+                              type: string
+                            version:
+                              type: string
+                          type: object
+                      type: object
+                    id:
+                      description: The @id parameter specifies a unique name for the
+                        configuration.
+                      type: string
+                    label:
+                      description: The @label parameter is to route the input events
+                        to <label> sections.
+                      type: string
+                    logLevel:
+                      description: The @log_level parameter specifies the plugin-specific
+                        logging level
+                      type: string
+                    monitorAgent:
+                      description: monitor_agent plugin
+                      properties:
+                        bind:
+                          description: The bind address to listen to.
+                          type: string
+                        emitInterval:
+                          description: The interval time between event emits. This
+                            will be used when "tag" is configured.
+                          format: int64
+                          type: integer
+                        includeConfig:
+                          description: You can set this option to false to remove
+                            the config field from the response.
+                          type: boolean
+                        includeRetry:
+                          description: You can set this option to false to remove
+                            the retry field from the response.
+                          type: boolean
+                        port:
+                          description: The port to listen to.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: If you set this parameter, this plugin emits
+                            metrics as records.
+                          type: string
+                      type: object
+                    sample:
+                      description: in_sample plugin
+                      properties:
+                        autoIncrementKey:
+                          description: If specified, each generated event has an auto-incremented
+                            key field.
+                          type: string
+                        rate:
+                          description: It configures how many events to generate per
+                            second.
+                          format: int64
+                          type: integer
+                        sample:
+                          description: The sample data to be generated. It should
+                            be either an array of JSON hashes or a single JSON hash.
+                            If it is an array of JSON hashes, the hashes in the array
+                            are cycled through in order.
+                          type: string
+                        size:
+                          description: The number of events in the event stream of
+                            each emit.
+                          format: int64
+                          type: integer
+                        tag:
+                          description: The tag of the event. The value is the tag
+                            assigned to the generated events.
+                          type: string
+                      type: object
+                    tail:
+                      description: in_tail plugin
+                      properties:
+                        emitUnmatchedLines:
+                          description: Emits unmatched lines when <parse> format is
+                            not matched for incoming logs.
+                          type: boolean
+                        enableStatWatcher:
+                          description: Enables the additional inotify-based watcher.
+                            Setting this parameter to false will disable the inotify
+                            events and use only timer watcher for file tailing. This
+                            option is mainly for avoiding the stuck issue with inotify.
+                          type: boolean
+                        enableWatchTimer:
+                          description: Enables the additional watch timer. Setting
+                            this parameter to false will significantly reduce CPU
+                            and I/O consumption when tailing a large number of files
+                            on systems with inotify support. The default is true which
+                            results in an additional 1 second timer being used.
+                          type: boolean
+                        encoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        excludePath:
+                          description: The paths excluded from the watcher list.
+                          items:
+                            type: string
+                          type: array
+                        followInodes:
+                          description: Avoid to read rotated files duplicately. You
+                            should set true when you use * or strftime format in path.
+                          type: boolean
+                        fromEncoding:
+                          description: Specifies the encoding of reading lines. By
+                            default, in_tail emits string value as ASCII-8BIT encoding.
+                            If encoding is specified, in_tail changes string to encoding.
+                            If encoding and fromEncoding both are specified, in_tail
+                            tries to encode string from fromEncoding to encoding.
+                          type: string
+                        group:
+                          description: The in_tail plugin can assign each log file
+                            to a group, based on user defined rules. The limit parameter
+                            controls the total number of lines collected for a group
+                            within a rate_period time interval.
+                          properties:
+                            pattern:
+                              description: Specifies the regular expression for extracting
+                                metadata (namespace, podname) from log file path.
+                                Default value of the pattern regexp extracts information
+                                about namespace, podname, docker_id, container of
+                                the log (K8s specific).
+                              type: string
+                            ratePeriod:
+                              description: Time period in which the group line limit
+                                is applied. in_tail resets the counter after every
+                                rate_period interval.
+                              format: int32
+                              type: integer
+                            rule:
+                              description: Grouping rules for log files.
+                              properties:
+                                limit:
+                                  description: Maximum number of lines allowed from
+                                    a group in rate_period time interval. The default
+                                    value of -1 doesn't throttle log files of that
+                                    group.
+                                  format: int32
+                                  type: integer
+                                match:
+                                  additionalProperties:
+                                    type: string
+                                  description: match parameter is used to check if
+                                    a file belongs to a particular group based on
+                                    hash keys (named captures from pattern) and hash
+                                    values (regexp in string)
+                                  type: object
+                              type: object
+                          required:
+                          - rule
+                          type: object
+                        ignoreRepeatedPermissionError:
+                          description: If you have to exclude the non-permission files
+                            from the watch list, set this parameter to true. It suppresses
+                            the repeated permission error logs.
+                          type: boolean
+                        limitRecentlyModified:
+                          description: Limits the watching files that the modification
+                            time is within the specified time range when using * in
+                            path.
+                          format: int32
+                          type: integer
+                        maxLineSize:
+                          description: The maximum length of a line. Longer lines
+                            than it will be just skipped.
+                          format: int32
+                          type: integer
+                        multilineFlushInterval:
+                          description: The interval of flushing the buffer for multiline
+                            format.
+                          format: int32
+                          type: integer
+                        openOnEveryUpdate:
+                          description: Opens and closes the file on every update instead
+                            of leaving it open until it gets rotated.
+                          type: boolean
+                        parse:
+                          description: Parse defines various parameters for the parse
+                            plugin
+                          properties:
+                            customPatternPath:
+                              description: Path to the file that includes custom grok
+                                patterns.
+                              type: string
+                            estimateCurrentEvent:
+                              description: If true, use Fluent::Eventnow(current time)
+                                as a timestamp when time_key is specified.
+                              type: boolean
+                            expression:
+                              description: Specifies the regular expression for matching
+                                logs. Regular expression also supports i and m suffix.
+                              type: string
+                            grok:
+                              description: Grok Sections
+                              items:
+                                properties:
+                                  keepTimeKey:
+                                    description: If true, keep time field in the record.
+                                    type: boolean
+                                  name:
+                                    description: The name of this grok section.
+                                    type: string
+                                  pattern:
+                                    description: The pattern of grok. Required parameter.
+                                    type: string
+                                  timeFormat:
+                                    description: Process value using specified format.
+                                      This is available only when time_type is string
+                                    type: string
+                                  timeKey:
+                                    description: Specify time field for event time.
+                                      If the event doesn't have this field, current
+                                      time is used.
+                                    type: string
+                                  timeZone:
+                                    description: Use specified timezone. one can parse/format
+                                      the time value in the specified timezone.
+                                    type: string
+                                type: object
+                              type: array
+                            grokFailureKey:
+                              description: The key has grok failure reason.
+                              type: string
+                            grokPattern:
+                              description: The pattern of grok.
+                              type: string
+                            grokPatternSeries:
+                              description: Specify grok pattern series set.
+                              type: string
+                            id:
+                              description: The @id parameter specifies a unique name
+                                for the configuration.
+                              type: string
+                            keepTimeKey:
+                              description: If true, keep time field in th record.
+                              type: boolean
+                            localtime:
+                              description: If true, uses local time.
+                              type: boolean
+                            logLevel:
+                              description: The @log_level parameter specifies the
+                                plugin-specific logging level
+                              type: string
+                            multiLineStartRegexp:
+                              description: The regexp to match beginning of multiline.
+                                This is only for "multiline_grok".
+                              type: string
+                            timeFormat:
+                              description: Process value according to the specified
+                                format. This is available only when time_type is string
+                              type: string
+                            timeFormatFallbacks:
+                              description: Uses the specified time format as a fallback
+                                in the specified order. You can parse undetermined
+                                time format by using time_format_fallbacks. This options
+                                is enabled when time_type is mixed.
+                              type: string
+                            timeKey:
+                              description: Specify time field for event time. If the
+                                event doesn't have this field, current time is used.
+                              type: string
+                            timeType:
+                              description: parses/formats value according to this
+                                type, default is string
+                              enum:
+                              - float
+                              - unixtime
+                              - string
+                              - mixed
+                              type: string
+                            timeout:
+                              description: Specify timeout for parse processing.
+                              pattern: ^\d+(\.[0-9]{0,2})?(s|m|h|d)?$
+                              type: string
+                            timezone:
+                              description: Uses the specified timezone.
+                              type: string
+                            type:
+                              description: The @type parameter specifies the type
+                                of the plugin.
+                              enum:
+                              - regexp
+                              - apache2
+                              - apache_error
+                              - nginx
+                              - syslog
+                              - csv
+                              - tsv
+                              - ltsv
+                              - json
+                              - multiline
+                              - none
+                              - grok
+                              - multiline_grok
+                              type: string
+                            types:
+                              description: 'Specify types for converting field into
+                                another, i.e: types user_id:integer,paid:bool,paid_usd_amount:float'
+                              type: string
+                            utc:
+                              description: If true, uses UTC.
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                        path:
+                          description: The path(s) to read. Multiple paths can be
+                            specified, separated by comma ','.
+                          type: string
+                        pathKey:
+                          description: Adds the watching file path to the path_key
+                            field.
+                          type: string
+                        pathTimezone:
+                          description: This parameter is for strftime formatted path
+                            like /path/to/%Y/%m/%d/.
+                          type: string
+                        posFile:
+                          description: (recommended) Fluentd will record the position
+                            it last read from this file. pos_file handles multiple
+                            positions in one file so no need to have multiple pos_file
+                            parameters per source. Don't share pos_file between in_tail
+                            configurations. It causes unexpected behavior e.g. corrupt
+                            pos_file content.
+                          type: string
+                        posFileCompactionInterval:
+                          description: The interval of doing compaction of pos file.
+                          format: int32
+                          type: integer
+                        readBytesLimitPerSecond:
+                          description: The number of reading bytes per second to read
+                            with I/O operation. This value should be equal or greater
+                            than 8192.
+                          format: int32
+                          type: integer
+                        readFromHead:
+                          description: Starts to read the logs from the head of the
+                            file or the last read position recorded in pos_file, not
+                            tail.
+                          type: boolean
+                        readLinesLimit:
+                          description: The number of lines to read with each I/O operation.
+                          format: int32
+                          type: integer
+                        refreshInterval:
+                          description: The interval to refresh the list of watch files.
+                            This is used when the path includes *.
+                          format: int32
+                          type: integer
+                        rotateWait:
+                          description: in_tail actually does a bit more than tail
+                            -F itself. When rotating a file, some data may still need
+                            to be written to the old file as opposed to the new one.
+                            in_tail takes care of this by keeping a reference to the
+                            old file (even after it has been rotated) for some time
+                            before transitioning completely to the new file. This
+                            helps prevent data designated for the old file from getting
+                            lost. By default, this time interval is 5 seconds. The
+                            rotate_wait parameter accepts a single integer representing
+                            the number of seconds you want this time interval to be.
+                          format: int32
+                          type: integer
+                        skipRefreshOnStartup:
+                          description: Skips the refresh of the watch list on startup.
+                            This reduces the startup time when * is used in path.
+                          type: boolean
+                        tag:
+                          description: The tag of the event.
+                          type: string
+                      required:
+                      - parse
+                      - path
+                      - tag
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            description: InputStatus defines the observed state of Input
             type: object
         type: object
     served: true


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1144 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```