### PR TITLE
Fix quotes for disable-component-controller argument string in fluent-operator deployment template.

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -102,7 +102,9 @@ spec:
           {{- with .Values.operator.extraArgs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          - --disable-component-controllers={{ .Values.operator.disableComponentControllers | quote }}
+          {{- with .Values.operator.disableComponentControllers }}
+          - {{ printf "%s=%s" "--disable-component-controllers" . | quote }}
+          {{- end }}
         volumeMounts:
         - name: env
           mountPath: /fluent-operator


### PR DESCRIPTION
This PR fixes quotes in fluent-operator dpeloyment template.
### Which issue(s) this PR fixes:

Fixes #1159

```release-note
None
```
