### PR TITLE
Updates setup manifests to be compatible with v2.8.0

### DIFF
--- a/config/crd/bases/kustomization.yaml
+++ b/config/crd/bases/kustomization.yaml
@@ -6,11 +6,13 @@ resources:
 - fluentbit.fluent.io_fluentbits.yaml
 - fluentbit.fluent.io_clusterinputs.yaml
 - fluentbit.fluent.io_clusterfilters.yaml
+- fluentbit.fluent.io_clustermultilineparsers.yaml
 - fluentbit.fluent.io_clusteroutputs.yaml
 - fluentbit.fluent.io_clusterparsers.yaml
 - fluentbit.fluent.io_collectors.yaml
 - fluentbit.fluent.io_fluentbitconfigs.yaml
 - fluentbit.fluent.io_filters.yaml
+- fluentbit.fluent.io_multilineparsers.yaml
 - fluentbit.fluent.io_outputs.yaml
 - fluentbit.fluent.io_parsers.yaml
 - fluentd.fluent.io_fluentds.yaml

--- a/manifests/setup/fluent-operator-clusterRole.yaml
+++ b/manifests/setup/fluent-operator-clusterRole.yaml
@@ -57,11 +57,16 @@ rules:
       - clusteroutputs
       - clusteroutputs/finalizers
       - clusterparsers
+      - clusterparsers/finalizers
       - fluentbitconfigs
+      - fluentbitconfigs/finalizers
+      - multilineparsers
+      - multilineparsers/finalizers
+      - clustermultilineparsers
+      - clustermultilineparsers/finalizers
       - filters
       - outputs
       - parsers
-      - clusterparsers/finalizers
     verbs:
       - create
       - delete

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -3546,6 +3546,88 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
+  name: clustermultilineparsers.fluentbit.fluent.io
+spec:
+  group: fluentbit.fluent.io
+  names:
+    kind: ClusterMultilineParser
+    listKind: ClusterMultilineParserList
+    plural: clustermultilineparsers
+    shortNames:
+    - cfbmp
+    singular: clustermultilineparser
+  scope: Cluster
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterMultilineParser is the Schema for the cluster-level multiline
+          parser API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              flushTimeout:
+                default: 5000
+                description: Timeout in milliseconds to flush a non-terminated multiline
+                  buffer. Default is set to 5 seconds.
+                type: integer
+              keyContent:
+                description: For an incoming structured message, specify the key that
+                  contains the data that should be processed by the regular expression
+                  and possibly concatenated.
+                type: string
+              parser:
+                description: Name of a pre-defined parser that must be applied to
+                  the incoming content before applying the regex rule. If no parser
+                  is defined, it's assumed that's a raw text and not a structured
+                  message.
+                type: string
+              rules:
+                description: Configure a rule to match a multiline pattern. The rule
+                  has a specific format described below. Multiple rules can be defined.
+                items:
+                  properties:
+                    next:
+                      type: string
+                    regex:
+                      type: string
+                    start:
+                      type: string
+                  required:
+                  - next
+                  - regex
+                  - start
+                  type: object
+                type: array
+              type:
+                default: regex
+                description: Set the multiline mode, for now, we support the type
+                  regex.
+                enum:
+                - regex
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: clusteroutputs.fluentbit.fluent.io
 spec:
   group: fluentbit.fluent.io
@@ -28098,6 +28180,88 @@ spec:
     storage: true
     subresources:
       status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
+  name: multilineparsers.fluentbit.fluent.io
+spec:
+  group: fluentbit.fluent.io
+  names:
+    kind: MultilineParser
+    listKind: MultilineParserList
+    plural: multilineparsers
+    shortNames:
+    - fbmp
+    singular: multilineparser
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: MultilineParser is the Schema of namespace-level multiline parser
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              flushTimeout:
+                default: 5000
+                description: Timeout in milliseconds to flush a non-terminated multiline
+                  buffer. Default is set to 5 seconds.
+                type: integer
+              keyContent:
+                description: For an incoming structured message, specify the key that
+                  contains the data that should be processed by the regular expression
+                  and possibly concatenated.
+                type: string
+              parser:
+                description: Name of a pre-defined parser that must be applied to
+                  the incoming content before applying the regex rule. If no parser
+                  is defined, it's assumed that's a raw text and not a structured
+                  message.
+                type: string
+              rules:
+                description: Configure a rule to match a multiline pattern. The rule
+                  has a specific format described below. Multiple rules can be defined.
+                items:
+                  properties:
+                    next:
+                      type: string
+                    regex:
+                      type: string
+                    start:
+                      type: string
+                  required:
+                  - next
+                  - regex
+                  - start
+                  type: object
+                type: array
+              type:
+                default: regex
+                description: Set the multiline mode, for now, we support the type
+                  regex.
+                enum:
+                - regex
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -3546,6 +3546,88 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
+  name: clustermultilineparsers.fluentbit.fluent.io
+spec:
+  group: fluentbit.fluent.io
+  names:
+    kind: ClusterMultilineParser
+    listKind: ClusterMultilineParserList
+    plural: clustermultilineparsers
+    shortNames:
+    - cfbmp
+    singular: clustermultilineparser
+  scope: Cluster
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterMultilineParser is the Schema for the cluster-level multiline
+          parser API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              flushTimeout:
+                default: 5000
+                description: Timeout in milliseconds to flush a non-terminated multiline
+                  buffer. Default is set to 5 seconds.
+                type: integer
+              keyContent:
+                description: For an incoming structured message, specify the key that
+                  contains the data that should be processed by the regular expression
+                  and possibly concatenated.
+                type: string
+              parser:
+                description: Name of a pre-defined parser that must be applied to
+                  the incoming content before applying the regex rule. If no parser
+                  is defined, it's assumed that's a raw text and not a structured
+                  message.
+                type: string
+              rules:
+                description: Configure a rule to match a multiline pattern. The rule
+                  has a specific format described below. Multiple rules can be defined.
+                items:
+                  properties:
+                    next:
+                      type: string
+                    regex:
+                      type: string
+                    start:
+                      type: string
+                  required:
+                  - next
+                  - regex
+                  - start
+                  type: object
+                type: array
+              type:
+                default: regex
+                description: Set the multiline mode, for now, we support the type
+                  regex.
+                enum:
+                - regex
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: clusteroutputs.fluentbit.fluent.io
 spec:
   group: fluentbit.fluent.io
@@ -28104,6 +28186,88 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
+  name: multilineparsers.fluentbit.fluent.io
+spec:
+  group: fluentbit.fluent.io
+  names:
+    kind: MultilineParser
+    listKind: MultilineParserList
+    plural: multilineparsers
+    shortNames:
+    - fbmp
+    singular: multilineparser
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: MultilineParser is the Schema of namespace-level multiline parser
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              flushTimeout:
+                default: 5000
+                description: Timeout in milliseconds to flush a non-terminated multiline
+                  buffer. Default is set to 5 seconds.
+                type: integer
+              keyContent:
+                description: For an incoming structured message, specify the key that
+                  contains the data that should be processed by the regular expression
+                  and possibly concatenated.
+                type: string
+              parser:
+                description: Name of a pre-defined parser that must be applied to
+                  the incoming content before applying the regex rule. If no parser
+                  is defined, it's assumed that's a raw text and not a structured
+                  message.
+                type: string
+              rules:
+                description: Configure a rule to match a multiline pattern. The rule
+                  has a specific format described below. Multiple rules can be defined.
+                items:
+                  properties:
+                    next:
+                      type: string
+                    regex:
+                      type: string
+                    start:
+                      type: string
+                  required:
+                  - next
+                  - regex
+                  - start
+                  type: object
+                type: array
+              type:
+                default: regex
+                description: Set the multiline mode, for now, we support the type
+                  regex.
+                enum:
+                - regex
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.3
   name: outputs.fluentbit.fluent.io
 spec:
   group: fluentbit.fluent.io
@@ -33391,11 +33555,16 @@ rules:
   - clusteroutputs
   - clusteroutputs/finalizers
   - clusterparsers
+  - clusterparsers/finalizers
   - fluentbitconfigs
+  - fluentbitconfigs/finalizers
+  - multilineparsers
+  - multilineparsers/finalizers
+  - clustermultilineparsers
+  - clustermultilineparsers/finalizers
   - filters
   - outputs
   - parsers
-  - clusterparsers/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

v2.8.0 includes changes to the _ClusterRole_ and adds a couple new CRDs.  The Helm Chart was updated to include these changes, but the changes were never synced over to the setup manifests.

This means that the `setup.yaml` included with the v2.8.0 is essentially broken.

### Which issue(s) this PR fixes:
No issue created.

### Does this PR introduced a user-facing change?
No.

### Additional documentation, usage docs, etc.:
We somehow need to automate these changes in the future. 