### PR TITLE
feat: update references of kubesphere/fluent-bit to all use v2.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION?=$(shell cat VERSION | tr -d " \t\n\r")
 # Image URL to use all building/pushing image targets
-FB_IMG ?= kubesphere/fluent-bit:v2.2.2
-FB_IMG_DEBUG ?= kubesphere/fluent-bit:v2.2.2-debug
+FB_IMG ?= kubesphere/fluent-bit:v2.8.0
+FB_IMG_DEBUG ?= kubesphere/fluent-bit:v2.8.0-debug
 FD_IMG ?= kubesphere/fluentd:v1.15.3
 FO_IMG ?= kubesphere/fluent-operator:$(VERSION)
 FD_IMG_BASE ?= kubesphere/fluentd:v1.15.3-arm64-base

--- a/config/samples/fluentbit_v1alpha2_fluentbit.yaml
+++ b/config/samples/fluentbit_v1alpha2_fluentbit.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v1.8.3
+  image: kubesphere/fluent-bit:v2.8.0
   imagePullPolicy: IfNotPresent
   positionDB:
     hostPath:

--- a/docs/best-practice/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
+++ b/docs/best-practice/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v1.8.3
+  image: kubesphere/fluent-bit:v2.8.0
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
+++ b/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v2.2.2
+  image: kubesphere/fluent-bit:v2.8.0
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/logging-stack/fluentbit-fluentBit.yaml
+++ b/manifests/logging-stack/fluentbit-fluentBit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v2.2.2
+  image: kubesphere/fluent-bit:v2.8.0
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/quick-start/fluentbit.yaml
+++ b/manifests/quick-start/fluentbit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v2.2.2
+  image: kubesphere/fluent-bit:v2.8.0
   fluentBitConfigName: fluent-bit-config
 
 ---

--- a/manifests/regex-parser/fluentbit-fluentBit.yaml
+++ b/manifests/regex-parser/fluentbit-fluentBit.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: kubesphere/fluent-bit:v2.2.2
+  image: kubesphere/fluent-bit:v2.8.0
   fluentBitConfigName: fluent-bit-config


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

There were references to 2.2.2 and 1.8.3 this PR brings everything up to date with the most recent release of 2.8.0

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Updated  image tag  of kubesphere/fluent-bit to use v2.8.0
```