### PR TITLE
Fix fluentd path issues.

### DIFF
--- a/cmd/fluent-watcher/fluentd/main.go
+++ b/cmd/fluent-watcher/fluentd/main.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -19,7 +20,8 @@ import (
 )
 
 const (
-	defaultBinPath      = "/usr/local/bundle/bin/fluentd"
+	defaultBinPath      = "/usr/bin/fluentd"
+	defaultArm64BinPath = "/usr/local/bundle/bin/fluentd"
 	defaultCfgPath      = "/fluentd/etc/fluent.conf"
 	defaultWatchDir     = "/fluentd/etc"
 	defaultPluginPath   = "/fluentd/plugins"
@@ -48,7 +50,16 @@ var pollInterval time.Duration
 
 func main() {
 
-	flag.StringVar(&binPath, "b", defaultBinPath, "The fluentd binary path.")
+	logger = log.NewLogfmtLogger(os.Stdout)
+
+	_ = level.Info(logger).Log("msg", "Current architecture", "arch", runtime.GOARCH)
+
+	switch runtime.GOARCH {
+	case "arm64":
+		flag.StringVar(&binPath, "b", defaultArm64BinPath, "The fluentd binary path for arm64.")
+	default:
+		flag.StringVar(&binPath, "b", defaultBinPath, "The fluentd binary path for amd64.")
+	}
 	flag.StringVar(&configPath, "c", defaultCfgPath, "The config file path.")
 	flag.StringVar(&pluginPath, "p", defaultPluginPath, "The config file path.")
 	flag.BoolVar(&exitOnFailure, "exit-on-failure", false, "If fluentd exits with failure, also exit the watcher.")


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
There has been an issue with fluentd coming up in docker images. Previous changes were handling only arch, as usr/local/bundle/bin/fluentd. But,

For amd64 it is"/usr/bin/fluentd"
For arm64 it is "/usr/local/bundle/bin/fluentd".

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1187

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```