### PR TITLE
Update references to fluentd:1.17.0 image

### DIFF
--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -6,7 +6,7 @@ on:
       docker_tag_version:
         description: 'Fluentd image release version'
         required: true
-        default: '1.15.3'
+        default: '1.17.0'
 
 env:
   DOCKER_REPO: 'kubesphere'

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ VERSION?=$(shell cat VERSION | tr -d " \t\n\r")
 # Image URL to use all building/pushing image targets
 FB_IMG ?= kubesphere/fluent-bit:v3.0.4
 FB_IMG_DEBUG ?= kubesphere/fluent-bit:v3.0.4-debug
-FD_IMG ?= kubesphere/fluentd:v1.15.3
+FD_IMG ?= ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
 FO_IMG ?= kubesphere/fluent-operator:$(VERSION)
-FD_IMG_BASE ?= kubesphere/fluentd:v1.15.3-arm64-base
+FD_IMG_BASE ?= ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-arm64-base
 
 ARCH ?= arm64
 

--- a/apis/fluentd/v1alpha1/tests/tools.go
+++ b/apis/fluentd/v1alpha1/tests/tools.go
@@ -55,7 +55,7 @@ spec:
       size: 10
       autoIncrementKey: "id"
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector:
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"
@@ -80,7 +80,7 @@ spec:
       includeConfig: true
       includeRetry: true
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector:
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"
@@ -132,7 +132,7 @@ spec:
       - /var/log/foo.log
       - /var/log/bar
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -371,8 +371,8 @@ fluentd:
   mode: "collector"
   port: 24224
   image:
-    repository: "kubesphere/fluentd"
-    tag: "v1.15.3"
+    repository: "ghcr.io/fluent/fluent-operator/fluentd"
+    tag: "v1.17.0"
   # Numbers of the Fluentd instance
   # Applicable when the mode is "collector", and will be ignored when the mode is "agent"
   replicas: 1

--- a/manifests/fluentd/fluentd-cluster-cfg-output-buffer-example.yaml
+++ b/manifests/fluentd/fluentd-cluster-cfg-output-buffer-example.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 3
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-cluster-cfg-output-es.yaml
+++ b/manifests/fluentd/fluentd-cluster-cfg-output-es.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-cluster-cfg-output-kafka.yaml
+++ b/manifests/fluentd/fluentd-cluster-cfg-output-kafka.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-mixed-cfgs-multi-tenant-output.yaml
+++ b/manifests/fluentd/fluentd-mixed-cfgs-multi-tenant-output.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-mixed-cfgs-output-es.yaml
+++ b/manifests/fluentd/fluentd-mixed-cfgs-output-es.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-namespaced-cfg-output-es.yaml
+++ b/manifests/fluentd/fluentd-namespaced-cfg-output-es.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: kubesphere/fluentd:v1.15.3
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

https://github.com/fluent/fluent-operator/pull/1198 recently started building a new fluentd:1.17.0 image, but there are several references to the old v1.15.3 images that need to be updated.
