### PR TITLE
Fix fluent-bit image name.

### DIFF
--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -6,7 +6,7 @@ on:
       docker_tag_version:
         description: 'Fluent Bit image release version'
         required: true
-        default: '3.0.4'
+        default: '3.0.7'
 
 env:
   DOCKER_REPO: 'kubesphere'

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -74,8 +74,8 @@ fluentbit:
   enable: true
   serviceMonitor: false
   image:
-    repository: "ghcr.io/fluent/fluent-operator/fluentbit"
-    tag: "v3.0.7"
+    repository: "ghcr.io/fluent/fluent-operator/fluent-bit"
+    tag: "3.0.7"
   # fluentbit resources. If you do want to specify resources, adjust them as necessary
   # You can adjust it based on the log volume.
   resources:

--- a/config/samples/fluentbit_v1alpha2_fluentbit.yaml
+++ b/config/samples/fluentbit_v1alpha2_fluentbit.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluentbit:3.0.7
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.0.7
   imagePullPolicy: IfNotPresent
   positionDB:
     hostPath:

--- a/docs/best-practice/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
+++ b/docs/best-practice/forwarding-logs-via-http/deploy/fluentbit-fluentBit.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluentbit:3.0.7
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.0.7
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
+++ b/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluentbit:3.0.7
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.0.7
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/logging-stack/fluentbit-fluentBit.yaml
+++ b/manifests/logging-stack/fluentbit-fluentBit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluentbit:3.0.7
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.0.7
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/quick-start/fluentbit.yaml
+++ b/manifests/quick-start/fluentbit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluentbit:3.0.7
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.0.7
   fluentBitConfigName: fluent-bit-config
 
 ---

--- a/manifests/regex-parser/fluentbit-fluentBit.yaml
+++ b/manifests/regex-parser/fluentbit-fluentBit.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluentbit:3.0.7
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.0.7
   fluentBitConfigName: fluent-bit-config


### PR DESCRIPTION
### Which issue(s) this PR fixes:
There was a typo in the fluentbit image name.

`ghcr.io/fluent/fluent-operator/fluentbit:3.0.7` should be `ghcr.io/fluent/fluent-operator/fluent-bit:3.0.7` (missing the hyphen).
