### PR TITLE
feat(helm): Respect helm release namespace setting

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fluent-operator
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator

--- a/charts/fluent-operator/templates/fluentbit-containerd-config.yaml
+++ b/charts/fluent-operator/templates/fluentbit-containerd-config.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fluent-bit-containerd-config
+  namespace: {{ .Release.Namespace | quote }}
 data:
   containerd.lua: |
     function containerd( tag, timestamp, record)

--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -4,6 +4,7 @@ apiVersion: fluentbit.fluent.io/v1alpha2
 kind: FluentBit
 metadata:
   name: fluent-bit
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:

--- a/charts/fluent-operator/templates/fluentbit-fluentbit-edge.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentbit-edge.yaml
@@ -3,7 +3,7 @@ apiVersion: fluentbit.fluent.io/v1alpha2
 kind: FluentBit
 metadata:
   name: fluentbit-edge
-  namespace: fluent
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:

--- a/charts/fluent-operator/templates/fluentbit-lua-config.yaml
+++ b/charts/fluent-operator/templates/fluentbit-lua-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fluent-bit-lua
+  namespace: {{ .Release.Namespace | quote }}
 data:
   systemd.lua: |
     function add_time(tag, timestamp, record)

--- a/charts/fluent-operator/templates/fluentbit-output-loki.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-loki.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $k |quote }}
+  namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
   value: {{ $v | b64enc | quote }}

--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -4,6 +4,7 @@ apiVersion: fluentd.fluent.io/v1alpha1
 kind: Fluentd
 metadata:
   name: {{ .Values.fluentd.name }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: fluentd
 spec:


### PR DESCRIPTION
Whenever a helm chart is rendered you can pass it a namespace.
Usually a chart then adds the namespace to the namespaced resources
it is rendering.

This change establishes that behaviour in the fluent-operator chart.

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it

Helm charts tend to respect the namespace that the user passes in to the helm command.

The fluent-operator didn't render a namespace field for the namespaced resources.

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note

```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

