### PR TITLE
UAdding instructions on how to set run operator for developement

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,11 @@ If you want to learn more about Fluent-Operator, please refer to the [misc](docs
 
 ### Running
 
+Make sure you have a KUBECONFIG file loaded for your local developement kubernetes cluster. 
+
 1. Install CRDs: `make install`
-2. Run: `make run`
+2. `export NAMESPACE=something` to set the namespace for the operator 
+3. Run: `make run`
 
 ## Contributing
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

From the documentation it's not clear that the "NAMESPACE" environment variable needs to be set for the operator to work locally 

### Which issue(s) this PR fixes:

Makes it more clear on how to run the operator for developement

Fixes #1215

### Does this PR introduced a user-facing change?

None