### PR TITLE
feat: add rbacRules to values.yaml with events watching as fixed permissions

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -90,6 +90,16 @@ spec:
   serviceAccountAnnotations:
 {{ toYaml .Values.fluentbit.serviceAccountAnnotations | indent 4 }}
   {{- end }}
+  rbacRules:
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - list
+  {{- if .Values.fluentbit.rbacRules }}
+{{ toYaml .Values.fluentbit.rbacRules | nindent 4 }}
+  {{- end }}
 {{- if .Values.fluentbit.disableLogVolumes }}
   disableLogVolumes: {{ .Values.fluentbit.disableLogVolumes }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -121,6 +121,9 @@ fluentbit:
   securityContext: {}
   # List of volumes that can be mounted by containers belonging to the pod.
   additionalVolumes: []
+  # Additional rbac rules which will be applied to the fluent-bit clusterrole. Ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding
+  # NOTE: As fluent-bit is managed by the fluent-operator, fluent-bit can only be granted permissions the operator also has 
+  rbacRules: {}
   # Pod volumes to mount into the container's filesystem.
   additionalVolumesMounts: []
   # affinity configuration for Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
### What this PR does / why we need it:
- Added rbacRules to watch kubernetes events to FluentBit template.
- This way people don't have to modify the CR themselves; it is more user-friendly.
- Added the possibility for custom rbacRules in the operators `values.yaml`. 
- This adds more flexibility to the operator chart

### Which issue(s) this PR fixes:
- Fixes issue #923 
- Builds on [this PR](https://github.com/fluent/fluent-operator/pull/1209) 

### Does this PR introduced a user-facing change?
```release-note
1. Added `rbacRules` option in operators' `values.yaml`
2. No additional action is required from user
```