### PR TITLE
Add bearer token auth for loki

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
@@ -576,6 +576,11 @@ func (in *Loki) DeepCopyInto(out *Loki) {
 		*out = new(plugins.Secret)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.BearerToken != nil {
+		in, out := &in.BearerToken, &out.BearerToken
+		*out = new(plugins.Secret)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.TenantID != nil {
 		in, out := &in.TenantID, &out.TenantID
 		*out = new(plugins.Secret)

--- a/apis/fluentd/v1alpha1/plugins/output/loki.go
+++ b/apis/fluentd/v1alpha1/plugins/output/loki.go
@@ -13,6 +13,9 @@ type Loki struct {
 	// Password for user defined in HTTP_User
 	// Set HTTP basic authentication password
 	HTTPPasswd *plugins.Secret `json:"httpPassword,omitempty"`
+	// Set path to file with bearer authentication token
+	// Can be used as alterntative to HTTP basic authentication
+	BearerTokenFile *string `json:"bearerTokenFile,omitempty"`
 	// Tenant ID used by default to push logs to Loki.
 	// If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent.
 	TenantID *plugins.Secret `json:"tenantID,omitempty"`

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -714,6 +714,9 @@ func (o *Output) lokiPlugin(parent *params.PluginStore, loader plugins.SecretLoa
 		}
 		parent.InsertPairs("password", passwd)
 	}
+	if o.Loki.BearerTokenFile != nil {
+		parent.InsertPairs("bearer_token_file", fmt.Sprint(*o.Loki.BearerTokenFile))
+	}
 	if o.Loki.TenantID != nil {
 		id, err := loader.LoadSecret(*o.Loki.TenantID)
 		if err != nil {

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1979,6 +1979,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -2249,6 +2280,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -1979,6 +1979,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -2249,6 +2280,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -1914,6 +1914,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -1914,6 +1914,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.

--- a/charts/fluent-operator/templates/fluentbit-output-loki.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-loki.yaml
@@ -5,14 +5,15 @@
 
 {{ with .Values.fluentbit.output.loki -}}
 {{/* 
-When http{User,Password} or tenantID is a string, make a secret for them
+When http{User,Password}, bearerToken, or tenantID is a string, make a secret for them
 When these keys are objects, they specify a secret to use generated elsewhere, assumed to exist in the k8s cluster 
 */}}
 {{ $userSecret := "loki-http-auth" -}}
 {{ $passSecret := "loki-http-pass" -}}
+{{ $bearerTokenSecret := "loki-bearer-token" -}}
 {{ $tenantIDSecret := "loki-tenant-id" -}}
 
-{{ range $k, $v := dict $userSecret .httpUser $passSecret .httpPassword $tenantIDSecret .tenantID -}}
+{{ range $k, $v := dict $userSecret .httpUser $passSecret .httpPassword $tenantIDSecret .tenantID $bearerTokenSecret .bearerToken -}}
 {{ if kindIs "string" $v -}}
 ---
 apiVersion: v1
@@ -78,6 +79,19 @@ spec:
           optional: false
       {{- else }}
 {{ .httpPassword | toYaml | indent 6 }}
+      {{- end }}
+    {{- end }}
+
+    {{- if .bearerToken }}
+    bearerToken: 
+      {{- if kindIs "string" .bearerToken }}
+      valueFrom:
+        secretKeyRef:
+          key: 'value'
+          name: {{ $bearerTokenSecret }}
+          optional: false
+      {{- else }}
+{{ .bearerToken | toYaml | indent 6 }}
       {{- end }}
     {{- end }}
 

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -278,7 +278,7 @@ fluentbit:
     # See https://docs.fluentbit.io/manual/pipeline/outputs/loki
     loki:
       # Switch for generation of fluentbit loki ClusterOutput (and loki basic auth http user and pass secrets if required)
-      enable: false   # Bool
+      enable: false # Bool
       host: 127.0.0.1 # String
       port: 3100      # Int
       # Either, give http{User,Password},tenantID string values specifying them directly
@@ -305,6 +305,15 @@ fluentbit:
       #      name: tenantsecret
       #      optional: true
       #
+      # To use bearer token auth instead of http basic auth
+      #bearerToken: ey....
+      # or with existing secret
+      #bearerToken:
+      #  valueFrom:
+      #    secretKeyRef:
+      #      key: value
+      #      name: bearerTokenSecret
+      #      optional: true
       #labels: []      # String list of <name>=<value>
       #labelKeys: []   # String list of <key>
       #removeKeys: []  # String list of <key>

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1979,6 +1979,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -2249,6 +2280,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -1979,6 +1979,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -2249,6 +2280,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -1914,6 +1914,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -1914,6 +1914,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.

--- a/docs/plugins/fluentbit/output/loki.md
+++ b/docs/plugins/fluentbit/output/loki.md
@@ -7,8 +7,10 @@ The loki output plugin, allows to ingest your records into a Loki service. <br /
 | ----- | ----------- | ------ |
 | host | Loki hostname or IP address. | string |
 | port | Loki TCP port | *int32 |
+| uri | Specify a custom HTTP URI. It must start with forward slash. | string |
 | httpUser | Set HTTP basic authentication user name. | *[plugins.Secret](../secret.md) |
 | httpPassword | Password for user defined in HTTP_User Set HTTP basic authentication password | *[plugins.Secret](../secret.md) |
+| bearerToken | Set bearer token authentication token value. Can be used as alterntative to HTTP basic authentication | *[plugins.Secret](../secret.md) |
 | tenantID | Tenant ID used by default to push logs to Loki. If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent. | *[plugins.Secret](../secret.md) |
 | labels | Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs. In addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property). | []string |
 | labelKeys | Optional list of record keys that will be placed as stream labels. This configuration property is for records key only. | []string |

--- a/docs/plugins/fluentd/output/loki.md
+++ b/docs/plugins/fluentd/output/loki.md
@@ -8,6 +8,7 @@ The loki output plugin, allows to ingest your records into a Loki service.
 | url | Loki URL. | *string |
 | httpUser | Set HTTP basic authentication user name. | *[plugins.Secret](../secret.md) |
 | httpPassword | Password for user defined in HTTP_User Set HTTP basic authentication password | *[plugins.Secret](../secret.md) |
+| bearerTokenFile | Set path to file with bearer authentication token Can be used as alterntative to HTTP basic authentication | *string |
 | tenantID | Tenant ID used by default to push logs to Loki. If omitted or empty it assumes Loki is running in single-tenant mode and no X-Scope-OrgID header is sent. | *[plugins.Secret](../secret.md) |
 | labels | Stream labels for API request. It can be multiple comma separated of strings specifying  key=value pairs. In addition to fixed parameters, it also allows to add custom record keys (similar to label_keys property). | []string |
 | labelKeys | Optional list of record keys that will be placed as stream labels. This configuration property is for records key only. | []string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -9752,6 +9752,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.
@@ -35880,6 +35885,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5701,6 +5701,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -5971,6 +6002,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object
@@ -31794,6 +31829,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -32064,6 +32130,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -9752,6 +9752,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.
@@ -35880,6 +35885,11 @@ spec:
                     loki:
                       description: out_loki plugin
                       properties:
+                        bearerTokenFile:
+                          description: |-
+                            Set path to file with bearer authentication token
+                            Can be used as alterntative to HTTP basic authentication
+                          type: string
                         dropSingleKey:
                           description: If a record only has 1 key, then just set the
                             log line to the value and discard the key.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5701,6 +5701,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -5971,6 +6002,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object
@@ -31794,6 +31829,37 @@ spec:
                     - "on"
                     - "off"
                     type: string
+                  bearerToken:
+                    description: |-
+                      Set bearer token authentication token value.
+                      Can be used as alterntative to HTTP basic authentication
+                    properties:
+                      valueFrom:
+                        description: ValueSource defines how to find a value's key.
+                        properties:
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    type: object
                   dropSingleKey:
                     description: If set to true and after extracting labels only a
                       single key remains, the log line sent to Loki will be the value
@@ -32064,6 +32130,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  uri:
+                    description: Specify a custom HTTP URI. It must start with forward
+                      slash.
+                    type: string
                 required:
                 - host
                 type: object


### PR DESCRIPTION
### What this PR does / why we need it:

I was searching for an alternative of the openshift-logging-operator. None of the available operators supported bearer token authentication for the Loki output. Since bearer authentication is very useful together wiith Loki and the openshift oauth proxy I decided to make this contribution. 

### Which issue(s) this PR fixes:

Fixes #1221 (Not my ticket, by coincidence someone else seems to be missing this feature)

### Does this PR introduced a user-facing change?

```release-note
 * [Fluent-Bit] Additional Parameter "bearerToken" for (Cluster) Output of type Loki
 * [Fluent-Bit] Additional Parameter "uri" for (Cluster) Output of type Loki
 * [Fluentd] Additional Parameter "bearerTokenFile" for ClusterOutput of type Loki
```

### Additional documentation, usage docs, etc.:

```docs
- [Usage]: https://docs.fluentbit.io/manual/pipeline/outputs/loki
- [Other doc] https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/loki.md
- [Usage] https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentd/output/loki.md
- [Other doc] https://docs.fluentbit.io/manual/pipeline/outputs/loki
```