### PR TITLE
fix parsersfile default parsers.conf path

### DIFF
--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   service:
     parsersFiles:
-      - /fluent-bit/config/parsers.conf
+      - /fluent-bit/etc/parsers.conf
       - /fluent-bit/config/parsers_multiline.conf
     httpServer: true
   {{- if .Values.fluentbit.logLevel }}


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Fixed a bug, which would invalidate the default fluent-bit parsers conf
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1219

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```