### PR TITLE
feat: add 'sslVerify' to opensearch output

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/output/opensearch.go
+++ b/apis/fluentd/v1alpha1/plugins/output/opensearch.go
@@ -26,4 +26,6 @@ type Opensearch struct {
 	User *plugins.Secret `json:"user,omitempty"`
 	// Optional, The login credentials to connect to Opensearch
 	Password *plugins.Secret `json:"password,omitempty"`
+	// Optional, Force certificate validation
+	SslVerify *bool `json:"sslVerify,omitempty"`
 }

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -611,6 +611,10 @@ func (o *Output) opensearchPlugin(parent *params.PluginStore, loader plugins.Sec
 		parent.InsertPairs("logstash_prefix", fmt.Sprint(*o.Opensearch.LogstashPrefix))
 	}
 
+	if o.Opensearch.SslVerify != nil {
+		parent.InsertPairs("ssl_verify", fmt.Sprint(*o.Opensearch.SslVerify))
+	}
+
 	return parent, nil
 }
 

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -2146,6 +2146,9 @@ spec:
                           description: 'Specify https if your Opensearch endpoint
                             supports SSL (default: http).'
                           type: string
+                        sslVerify:
+                          description: Optional, Force certificate validation
+                          type: boolean
                         user:
                           description: Optional, The login credentials to connect
                             to Opensearch

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -2146,6 +2146,9 @@ spec:
                           description: 'Specify https if your Opensearch endpoint
                             supports SSL (default: http).'
                           type: string
+                        sslVerify:
+                          description: Optional, Force certificate validation
+                          type: boolean
                         user:
                           description: Optional, The login credentials to connect
                             to Opensearch

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -2146,6 +2146,9 @@ spec:
                           description: 'Specify https if your Opensearch endpoint
                             supports SSL (default: http).'
                           type: string
+                        sslVerify:
+                          description: Optional, Force certificate validation
+                          type: boolean
                         user:
                           description: Optional, The login credentials to connect
                             to Opensearch

--- a/docs/plugins/fluentd/output/opensearch.md
+++ b/docs/plugins/fluentd/output/opensearch.md
@@ -15,3 +15,4 @@ Opensearch defines the parameters for out_opensearch plugin
 | logstashPrefix | LogstashPrefix defines the logstash prefix index name to write events when logstash_format is true (default: logstash). | *string |
 | user | Optional, The login credentials to connect to Opensearch | *[plugins.Secret](../secret.md) |
 | password | Optional, The login credentials to connect to Opensearch | *[plugins.Secret](../secret.md) |
+| sslVerify | Optional, Force certificate validation | *bool |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -9949,6 +9949,9 @@ spec:
                           description: 'Specify https if your Opensearch endpoint
                             supports SSL (default: http).'
                           type: string
+                        sslVerify:
+                          description: Optional, Force certificate validation
+                          type: boolean
                         user:
                           description: Optional, The login credentials to connect
                             to Opensearch

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -9949,6 +9949,9 @@ spec:
                           description: 'Specify https if your Opensearch endpoint
                             supports SSL (default: http).'
                           type: string
+                        sslVerify:
+                          description: Optional, Force certificate validation
+                          type: boolean
                         user:
                           description: Optional, The login credentials to connect
                             to Opensearch
@@ -36039,6 +36042,9 @@ spec:
                           description: 'Specify https if your Opensearch endpoint
                             supports SSL (default: http).'
                           type: string
+                        sslVerify:
+                          description: Optional, Force certificate validation
+                          type: boolean
                         user:
                           description: Optional, The login credentials to connect
                             to Opensearch


### PR DESCRIPTION
### What this PR does / why we need it:
This is to allow fluentd opensearch output plugin to use https without verify ssl, just like es output plugin.

### Which issue(s) this PR fixes:
Fixes #568

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
No additional documentation, I have update the existing opensearch output documentation