### PR TITLE
fix(fluentd): add securityContext and podSecurityContext in values.yaml

### DIFF
--- a/charts/fluent-operator/templates/fluentd-fluentd.yaml
+++ b/charts/fluent-operator/templates/fluentd-fluentd.yaml
@@ -28,6 +28,14 @@ spec:
   envVars:
   {{- toYaml .Values.fluentd.envVars | nindent 4 }}
   {{- end }}
+  {{- if .Values.fluentd.securityContext }}
+  containerSecurityContext:
+  {{ toYaml .Values.fluentd.securityContext | nindent 4 }}
+  {{- end }}
+  {{- if .Values.fluentd.podSecurityContext }}
+  securityContext:
+  {{ toYaml .Values.fluentd.podSecurityContext | nindent 4 }}
+  {{- end }}
   {{- if .Values.fluentd.schedulerName }}
   schedulerName: {{ .Values.fluentd.schedulerName }}
   {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -403,6 +403,10 @@ fluentd:
   #    value: "bar"
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # Pod security context for Fluentd pod. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext: {}
+  # Container security context for Fluentd container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext: {}
   imagePullSecrets: []
   # - name: "image-pull-secret"
   logLevel: ""


### PR DESCRIPTION
### What this PR does / why we need it:
- Tiny PR to add the same `securityContext` and `podSecurityContext` options to fluentd values which we already have for fluent-bit

### Which issue(s) this PR fixes:
Fixes #952 

### Does this PR introduced a user-facing change?
```release-note
- Add `securityContext` and `podSecurityContext` options to fluentd helm chart values.
```