### PR TITLE
Bump fluentbit to 3.1.2.

### DIFF
--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -6,7 +6,7 @@ on:
       docker_tag_version:
         description: 'Fluent Bit image release version'
         required: true
-        default: '3.1.0'
+        default: '3.1.2'
 
 env:
   DOCKER_REPO: 'kubesphere'

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -83,7 +83,7 @@ fluentbit:
     metricRelabelings: []
   image:
     repository: "ghcr.io/fluent/fluent-operator/fluent-bit"
-    tag: "3.1.0"
+    tag: "3.1.2"
   # fluentbit resources. If you do want to specify resources, adjust them as necessary
   # You can adjust it based on the log volume.
   resources:

--- a/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
+++ b/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.0
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.2
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/logging-stack/fluentbit-fluentBit.yaml
+++ b/manifests/logging-stack/fluentbit-fluentBit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.0
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.2
   positionDB:
     hostPath:
       path: /var/lib/fluent-bit/

--- a/manifests/quick-start/fluentbit.yaml
+++ b/manifests/quick-start/fluentbit.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.0
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.2
   fluentBitConfigName: fluent-bit-config
 
 ---

--- a/manifests/regex-parser/fluentbit-fluentBit.yaml
+++ b/manifests/regex-parser/fluentbit-fluentBit.yaml
@@ -6,5 +6,5 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.0
+  image: ghcr.io/fluent/fluent-operator/fluent-bit:3.1.2
   fluentBitConfigName: fluent-bit-config


### PR DESCRIPTION
Fluentbit 3.1.0 has a known [bug](https://github.com/fluent/fluent-bit/issues/9072) around the `record_modifier` plugin that was fixed in 3.1.2.

I already merged https://github.com/fluent/fluent-operator/pull/1238 and built new images.  This PR just updates the Helm chart and other templates to use 3.1.2 by default.