### PR TITLE
Support for patch release tags.

### DIFF
--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq tail 1)
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail 1)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
           else

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
-            # raw,latest
+            raw,latest
             type=raw,value=${{ env.IMAGE_TAG }}
             type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-'' -f2)")
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-'' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
             echo "Buliding patch release ${IMAGE_TAG}!"

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -54,6 +54,8 @@ jobs:
           fi
 
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        env:
+          VERSION: ${{env.VERSION }}
             
       - name: docker metadata for building
         id: image-metadata

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -118,6 +118,24 @@ jobs:
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
 
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
+            echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+            echo "Buliding patch release ${IMAGE_TAG}!"
+          else
+            echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
+            IMAGE_TAG="${{ env.VERSION }}"
+          fi
+  
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        env:
+          VERSION: ${{env.VERSION }}
+
       - name: docker metadata
         id: image-metadata
         uses: docker/metadata-action@v5
@@ -127,8 +145,8 @@ jobs:
             latest=false
             suffix=-debug
           tags: |
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -36,10 +36,8 @@ jobs:
         id: extract_version
         run: |
           VERSION=${{ github.event.inputs.docker_tag_version }}
-          VERSION_WITHOUT_V=${VERSION#v}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
-          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
 
       - name: Determine image version tag

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -41,6 +41,21 @@ jobs:
 
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
+
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
+            echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq tail 1)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+          else
+            echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
+            IMAGE_TAG="${{ env.VERSION }}"
+          fi
+
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
             
       - name: docker metadata for building
         id: image-metadata
@@ -49,8 +64,8 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
             raw,latest
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -38,6 +38,7 @@ jobs:
           VERSION=${{ github.event.inputs.docker_tag_version }}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
 
       - name: Determine image version tag

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-'' -f2)
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
             echo "Buliding patch release ${IMAGE_TAG}!"

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail 1)
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
           else

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -73,6 +73,7 @@ jobs:
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
 
       - name: docker tags for cloning
@@ -81,11 +82,12 @@ jobs:
         with:
           tags: |
             raw,latest
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
 
       - name: Set outputs
@@ -151,6 +153,7 @@ jobs:
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
 
       - name: docker tags for cloning
@@ -161,11 +164,12 @@ jobs:
             latest=false
             suffix=-debug
           tags: |
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
       
       - name: Set outputs

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -51,6 +51,7 @@ jobs:
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+            echo "Buliding patch release ${$IMAGE_TAG}!"
           else
             echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
             IMAGE_TAG="${{ env.VERSION }}"

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -36,9 +36,11 @@ jobs:
         id: extract_version
         run: |
           VERSION=${{ github.event.inputs.docker_tag_version }}
+          VERSION_WITHOUT_V=${VERSION#v}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
 
       - name: Determine image version tag
@@ -64,7 +66,7 @@ jobs:
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
-            raw,latest
+            # raw,latest
             type=raw,value=${{ env.IMAGE_TAG }}
             type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -115,13 +115,14 @@ jobs:
           VERSION_WITHOUT_V=${VERSION#v}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
 
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-debug; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -51,7 +51,7 @@ jobs:
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Buliding patch release ${IMAGE_TAG}!"
+            echo "Building patch release ${IMAGE_TAG}!"
           else
             echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
             IMAGE_TAG="${{ env.VERSION }}"
@@ -123,13 +123,13 @@ jobs:
         id: determine-tags
         run: |
           if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-debug; then
-            echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
+            echo "${{ env.VERSION }}-debug tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Buliding patch release ${IMAGE_TAG}!"
+            echo "Building patch release ${IMAGE_TAG}-debug!"
           else
-            echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
+            echo "${{ env.VERSION }}-debug tag does not exist, assuming we're building a new release!"
             IMAGE_TAG="${{ env.VERSION }}"
           fi
   

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -48,10 +48,10 @@ jobs:
         run: |
           if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1)
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-'' -f2)")
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Buliding patch release ${$IMAGE_TAG}!"
+            echo "Buliding patch release ${IMAGE_TAG}!"
           else
             echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
             IMAGE_TAG="${{ env.VERSION }}"

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect --no-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
             echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
@@ -115,7 +115,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect --no-tags --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+          if skopeo inspect --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
             echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
@@ -414,7 +414,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect --no-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -35,12 +35,34 @@ jobs:
         id: extract_version
         run: |
           VERSION=${{ github.event.inputs.docker_tag_version }}
+          VERSION_SUFFIX="amd64"
           VERSION_WITHOUT_V=${VERSION#v}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-            
+
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+            echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
+          else
+            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
+            IMAGE_TAG="${{ env.VERSION }}"
+          fi
+  
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        env:
+          VERSION: ${{env.VERSION }}
+          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
+          
       - name: docker metadata for amd64
         id: image-metadata
         uses: docker/metadata-action@v5
@@ -48,15 +70,17 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix=-amd64
+            suffix=-${{ env.VERSION_SUFFIX }}
           tags: |
             raw,latest
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
 
       - name: Set outputs
         id: set-outputs
@@ -79,12 +103,34 @@ jobs:
         id: extract_version
         run: |
           VERSION=${{ github.event.inputs.docker_tag_version }}
+          VERSION_SUFFIX="arm64"
           VERSION_WITHOUT_V=${VERSION#v}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-            
+
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+            echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
+          else
+            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
+            IMAGE_TAG="${{ env.VERSION }}"
+          fi
+  
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        env:
+          VERSION: ${{ env.VERSION }}
+          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}      
+
       - name: docker metadata for arm64
         id: image-metadata
         uses: docker/metadata-action@v5
@@ -92,15 +138,17 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix=-arm64
+            suffix=-${{ env.VERSION_SUFFIX }}
           tags: |
             raw,latest
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
 
       - name: Set outputs
         id: set-outputs
@@ -125,9 +173,12 @@ jobs:
         id: extract_version
         run: |
           VERSION=${{ github.event.inputs.docker_tag_version }}
+          VERSION_SUFFIX="arm64-base"
           VERSION_WITHOUT_V=${VERSION#v}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
             
@@ -138,28 +189,16 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix=-arm64-base
+            suffix=-${{ env.VERSION_SUFFIX }}
           tags: |
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
-      - name: docker metadata for arm64 base image
-        id: image-tags
-        uses: docker/metadata-action@v5
-        with:
-          flavor: |
-            latest=false
-            suffix=-arm64-base
-          tags: |
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
 
       - name: Set outputs
         id: set-outputs

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -181,7 +181,26 @@ jobs:
           echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-            
+
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+            echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
+          else
+            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
+            IMAGE_TAG="${{ env.VERSION }}"
+          fi
+    
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        env:
+          VERSION: ${{ env.VERSION }}
+          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}            
+          
       - name: docker metadata for arm64 base image
         id: image-metadata
         uses: docker/metadata-action@v5

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -185,7 +185,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect --no-tags --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+          if skopeo inspect --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
             echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -407,20 +407,40 @@ jobs:
           VERSION_WITHOUT_V=${VERSION#v}
           MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
           echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
 
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
+            echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+            echo "Building patch release ${IMAGE_TAG}!"
+          else
+            echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
+            IMAGE_TAG="${{ env.VERSION }}"
+          fi
+    
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+        env:
+          VERSION: ${{ env.VERSION }}
+          
       - name: docker metadata for manifest
         id: image-metadata
         uses: docker/metadata-action@v5
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
       
       - name: docker tags for cloning
@@ -428,11 +448,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           tags: |
-            type=raw,value=${{ github.event.inputs.docker_tag_version }}
-            type=raw,value=v${{ github.event.inputs.docker_tag_version }}
+            type=raw,value=${{ env.IMAGE_TAG }}
+            type=raw,value=v${{ env.IMAGE_TAG }}
             type=raw,value=${{ env.MAJOR_MINOR }}
             type=raw,value=v${{ env.MAJOR_MINOR }}
         env:
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
             
       - name: Set outputs

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+          if skopeo inspect --no-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
             echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
@@ -115,7 +115,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+          if skopeo inspect --no-tags --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
             echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
@@ -185,7 +185,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+          if skopeo inspect --no-tags --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
             echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
@@ -414,7 +414,7 @@ jobs:
       - name: Determine image version tag
         id: determine-tags
         run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
+          if skopeo inspect --no-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
             echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))

--- a/cmd/fluent-watcher/README.md
+++ b/cmd/fluent-watcher/README.md
@@ -1,0 +1,19 @@
+# fluent-watcher
+
+This directory contains `Dockerfiles` for the custom build of both `fluentd` and `fluent-bit` that `fluent-operator` uses.
+
+These custom builds include a wrapper that watches for configuration changes and reloads/restarts the `fluentd` and `fluent-bit` processes.  These images are required for running the fluent-operator.
+
+## Versioning
+
+These images track upstream versions/tags.  For example, Fluent Operator's `ghcr.io/fluent/fluent-operator/fluent-bit:3.1.12` image is based off of the upstream `fluentd/fluent-bit:3.1.12` image.
+
+Occasionally, changes to Fluent Operator's customizations need to be introduced into the images out of band of upstream version changes.  When this happens, we add a "patch version" to the tag.  For example, the `ghcr.io/fluent/fluent-operator/fluent-bit:3.1.12-1` image remains based off of the upstream `fluent/fluent-bit:3.1.2` image but contains a Fluent Operator-specific patch (`-1`).
+
+We strive to never overwrite existing image tags (eg, `ghcr.io/fluent/fluent-operator/fluent-bit:3.1.12`) with customizations and/or patches.
+
+## Building
+
+As a maintainer, to build the `ghcr.io/fluent/fluent-operator/fluent-bit` and `ghcr.io/fluent/fluent-operator/fluentd` images, you can run the "Build Fluent Bit image" or "Build Fluentd image" Github Action workflows in the "Actions" tab of this repository.
+
+Always specify the upstream Fluent Bit version (eg, `3.1.2`, `3.1.3`, etc) when running this workflow.  If the CI workflow detects that an image tag already exists for the version specified, it will assume that a patch release needs to be built and will automatically add a patch version to the image tag (eg, `3.1.2-1`, `3.1.2-2`, etc).


### PR DESCRIPTION
### What this PR does / why we need it:
Introduces the ability to release "patch" builds (eg, `fluent-bit:3.1.2-2`) of fluent-bit/fluentd.  This allows us to release changes to our custom builds without overwriting tags that track upstream versions (eg, `fluent-bit:3.1.2`).

### Which issue(s) this PR fixes:
Fixes #1241

These workflows were tested successfully in my fork of the repo.

### Does this PR introduced a user-facing change?
N/A