### PR TITLE
Fixes fluentd/fluent-bit image build CI workflows

### DIFF
--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -18,7 +18,38 @@ permissions:
   packages: write
 
 jobs:
+  determine-tags:
+    runs-on: ubuntu-latest
+    name: Determine image tags
+    outputs:
+      IMAGE_BASE_TAG: ${{ steps.determine-tags.outputs.IMAGE_BASE_TAG }}
+      IMAGE_MAJOR_MINOR: ${{ steps.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+
+    steps:
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          VERSION=${{ github.event.inputs.docker_tag_version }}
+          VERSION_WITHOUT_V=${VERSION#v}
+          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
+
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${VERSION}; then
+            echo "${VERSION} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${VERSION}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_BASE_TAG="${VERSION}-${NEW_PATCH_VERSION}"
+            echo "Building patch release ${IMAGE_BASE_TAG}!"
+          else
+            echo "${VERSION} tag does not exist, assuming we're building a new release!"
+            IMAGE_BASE_TAG="${VERSION}"
+          fi
+  
+          echo "IMAGE_BASE_TAG=$IMAGE_BASE_TAG" >> $GITHUB_OUTPUT
+          echo "IMAGE_MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_OUTPUT
+
   build-prod-image-metadata:
+    needs:
+      - determine-tags
     runs-on: ubuntu-latest
     name: Build prod image metadata
     outputs:
@@ -31,35 +62,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Extract version parts
-        id: extract_version
-        run: |
-          VERSION=${{ github.event.inputs.docker_tag_version }}
-          VERSION_WITHOUT_V=${VERSION#v}
-          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
-
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-
-      - name: Determine image version tag
-        id: determine-tags
-        run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
-            echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
-            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
-            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Building patch release ${IMAGE_TAG}!"
-          else
-            echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
-            IMAGE_TAG="${{ env.VERSION }}"
-          fi
-
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-        env:
-          VERSION: ${{env.VERSION }}
             
       - name: docker metadata for building
         id: image-metadata
@@ -68,13 +70,10 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
             raw,latest
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
       - name: docker tags for cloning
         id: image-tags
@@ -82,13 +81,10 @@ jobs:
         with:
           tags: |
             raw,latest
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
       - name: Set outputs
         id: set-outputs
@@ -97,6 +93,8 @@ jobs:
           echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
 
   build-debug-image-metadata:
+    needs:
+      - determine-tags
     runs-on: ubuntu-latest
     name: Build debug image metadata
     outputs:
@@ -110,35 +108,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Extract version parts
-        id: extract_version
-        run: |
-          VERSION=${{ github.event.inputs.docker_tag_version }}
-          VERSION_WITHOUT_V=${VERSION#v}
-          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
-
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-
-      - name: Determine image version tag
-        id: determine-tags
-        run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-debug; then
-            echo "${{ env.VERSION }}-debug tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
-            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
-            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Building patch release ${IMAGE_TAG}-debug!"
-          else
-            echo "${{ env.VERSION }}-debug tag does not exist, assuming we're building a new release!"
-            IMAGE_TAG="${{ env.VERSION }}"
-          fi
-  
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-        env:
-          VERSION: ${{env.VERSION }}
-
       - name: docker metadata
         id: image-metadata
         uses: docker/metadata-action@v5
@@ -148,13 +117,10 @@ jobs:
             latest=false
             suffix=-debug
           tags: |
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
       - name: docker tags for cloning
         id: image-tags
@@ -164,13 +130,10 @@ jobs:
             latest=false
             suffix=-debug
           tags: |
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
       
       - name: Set outputs
         id: set-outputs

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -293,7 +293,6 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.build-prod-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.build-prod-image-metadata.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}
@@ -313,7 +312,6 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.build-debug-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.build-debug-image-metadata.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -150,6 +150,9 @@ jobs:
         id: image-tags
         uses: docker/metadata-action@v5
         with:
+          flavor: |
+            latest=false
+            suffix=-arm64-base          
          tags: |
            type=raw,value=latest
            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -348,18 +348,18 @@ jobs:
           sources: |
             ghcr.io/${{ needs.build-amd64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-amd64-prod-image-metadata.outputs.version }}
 
-  scan-image:
-    needs: 
-      - prod-image-manifest
-    name: Scan Fluentd Image
-    uses: ./.github/workflows/scan-docker-image-action.yaml
-    with:
-      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
-      source_registry: ghcr.io
-      platforms: "['linux/arm64', 'linux/amd64']"
-    secrets:
-      registry_username: ${{ github.actor }}
-      registry_password: ${{ secrets.GITHUB_TOKEN }}
+  # scan-image:
+  #   needs: 
+  #     - prod-image-manifest
+  #   name: Scan Fluentd Image
+  #   uses: ./.github/workflows/scan-docker-image-action.yaml
+  #   with:
+  #     source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+  #     source_registry: ghcr.io
+  #     platforms: "['linux/arm64', 'linux/amd64']"
+  #   secrets:
+  #     registry_username: ${{ github.actor }}
+  #     registry_password: ${{ secrets.GITHUB_TOKEN }}
 
   release-arm64-base-image-to-docker-hub:
     if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -334,6 +334,7 @@ jobs:
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
+            type=raw,value=latest
             type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
             type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
             type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
@@ -347,6 +348,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           tags: |
+            type=raw,value=latest
             type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
             type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
             type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -82,39 +82,39 @@ jobs:
         run: |
           echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
 
-  # build-arm64-prod-image-metadata:
-  #   needs:
-  #     - determine-tags
-  #   runs-on: ubuntu-latest
-  #   name: Build prod image metadata for arm64
-  #   outputs:
-  #     IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
-  #     version: ${{ steps.image-metadata.outputs.version }}
-  #     tags: ${{ steps.image-metadata.outputs.tags }}
-  #     labels: ${{ steps.image-metadata.outputs.labels }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  build-arm64-prod-image-metadata:
+    needs:
+      - determine-tags
+    runs-on: ubuntu-latest
+    name: Build prod image metadata for arm64
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: docker metadata for arm64
-  #       id: image-metadata
-  #       uses: docker/metadata-action@v5
-  #       with:
-  #         images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
-  #         flavor: |
-  #           latest=false
-  #           suffix=-arm64
-  #         tags: |
-  #           raw,latest
-  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
-  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+      - name: docker metadata for arm64
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          flavor: |
+            latest=false
+            suffix=-arm64
+          tags: |
+            raw,latest
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
-  #     - name: Set outputs
-  #       id: set-outputs
-  #       run: |
-  #         echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
 
   build-arm64-base-image-metadata:
     needs:
@@ -250,61 +250,61 @@ jobs:
           tags: ${{ needs.build-arm64-base-image-metadata.outputs.tags }}
           labels: ${{ needs.build-arm64-base-image-metadata.outputs.labels }}
 
-  # build-arm64:
-  #   runs-on: ubuntu-latest
-  #   needs: 
-  #     - build-arm64-prod-image-metadata
-  #     - build-arm64-base-image-metadata
-  #     - build-arm64-base
-  #   timeout-minutes: 90 
-  #   name: Build arm64 Image for Fluentd
-  #   steps:
-  #     - name: Install Go
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         go-version: 1.21
+  build-arm64:
+    runs-on: ubuntu-latest
+    needs: 
+      - build-arm64-prod-image-metadata
+      - build-arm64-base-image-metadata
+      - build-arm64-base
+    timeout-minutes: 90 
+    name: Build arm64 Image for Fluentd
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
 
-  #     - uses: actions/cache@v4
-  #       with:
-  #         path: ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Docker Buildx
-  #       id: buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Build and Push arm64 base Image for Fluentd
-  #       uses: docker/build-push-action@v6
-  #       with:
-  #         context: .
-  #         file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.quick
-  #         push: true
-  #         platforms: linux/arm64
-  #         tags: ${{ needs.build-arm64-prod-image-metadata.outputs.tags }}
-  #         labels: ${{ needs.build-arm64-prod-image-metadata.outputs.labels }}
-  #         build-args: |
-  #           BASE_IMAGE_TAG=${{ needs.build-arm64-base-image-metadata.outputs.version }}
-  #           BASE_IMAGE=ghcr.io/${{needs.build-arm64-base-image-metadata.outputs.IMG_NAME}}
+      - name: Build and Push arm64 base Image for Fluentd
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.quick
+          push: true
+          platforms: linux/arm64
+          tags: ${{ needs.build-arm64-prod-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-arm64-prod-image-metadata.outputs.labels }}
+          build-args: |
+            BASE_IMAGE_TAG=${{ needs.build-arm64-base-image-metadata.outputs.version }}
+            BASE_IMAGE=ghcr.io/${{needs.build-arm64-base-image-metadata.outputs.IMG_NAME}}
 
   prod-image-manifest:
     needs: 
       - determine-tags
       - build-amd64-prod-image-metadata
-      #- build-arm64-prod-image-metadata
+      - build-arm64-prod-image-metadata
       - build-amd64
-      # - build-arm64
+      - build-arm64
     runs-on: ubuntu-latest
     name: Create image manifest
     outputs:
@@ -361,19 +361,20 @@ jobs:
           tags: ${{ steps.image-metadata.outputs.tags }}
           sources: |
             ghcr.io/${{ needs.build-amd64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-amd64-prod-image-metadata.outputs.version }}
+            ghcr.io/${{ needs.build-arm64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-prod-image-metadata.outputs.version }}
 
-  # scan-image:
-  #   needs: 
-  #     - prod-image-manifest
-  #   name: Scan Fluentd Image
-  #   uses: ./.github/workflows/scan-docker-image-action.yaml
-  #   with:
-  #     source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
-  #     source_registry: ghcr.io
-  #     platforms: "['linux/arm64', 'linux/amd64']"
-  #   secrets:
-  #     registry_username: ${{ github.actor }}
-  #     registry_password: ${{ secrets.GITHUB_TOKEN }}
+  scan-image:
+    needs: 
+      - prod-image-manifest
+    name: Scan Fluentd Image
+    uses: ./.github/workflows/scan-docker-image-action.yaml
+    with:
+      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+      source_registry: ghcr.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}
 
   release-arm64-base-image-to-docker-hub:
     if: ${{ github.event_name != 'pull_request' }}
@@ -401,7 +402,7 @@ jobs:
     uses: ./.github/workflows/clone-docker-image-action.yaml
     needs: 
       - prod-image-manifest
-      # - scan-image
+      - scan-image
     with:
       source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}"
       source_registry: ghcr.io

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -387,7 +387,7 @@ jobs:
     uses: ./.github/workflows/clone-docker-image-action.yaml
     needs: 
       - prod-image-manifest
-      - scan-image
+      # - scan-image
     with:
       source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}"
       source_registry: ghcr.io

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -366,18 +366,18 @@ jobs:
           sources: |
             ghcr.io/${{ needs.build-amd64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-amd64-prod-image-metadata.outputs.version }}
 
-  scan-image:
-    needs: 
-      - prod-image-manifest
-    name: Scan Fluentd Image
-    uses: ./.github/workflows/scan-docker-image-action.yaml
-    with:
-      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
-      source_registry: ghcr.io
-      platforms: "[''linux/amd64']" # "['linux/arm64', 'linux/amd64']"
-    secrets:
-      registry_username: ${{ github.actor }}
-      registry_password: ${{ secrets.GITHUB_TOKEN }}
+  # scan-image:
+  #   needs: 
+  #     - prod-image-manifest
+  #   name: Scan Fluentd Image
+  #   uses: ./.github/workflows/scan-docker-image-action.yaml
+  #   with:
+  #     source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+  #     source_registry: ghcr.io
+  #     platforms: "['linux/arm64', 'linux/amd64']"
+  #   secrets:
+  #     registry_username: ${{ github.actor }}
+  #     registry_password: ${{ secrets.GITHUB_TOKEN }}
 
   release-images-to-docker-hub:
     if: ${{ github.event_name != 'pull_request' }}
@@ -385,7 +385,7 @@ jobs:
     uses: ./.github/workflows/clone-docker-image-action.yaml
     needs: 
       - prod-image-manifest
-      - scan-image
+      # - scan-image
     with:
       source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}"
       source_registry: ghcr.io

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -348,22 +348,22 @@ jobs:
           sources: |
             ghcr.io/${{ needs.build-amd64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-amd64-prod-image-metadata.outputs.version }}
 
-  # scan-image:
-  #   needs: 
-  #     - prod-image-manifest
-  #   name: Scan Fluentd Image
-  #   uses: ./.github/workflows/scan-docker-image-action.yaml
-  #   with:
-  #     source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
-  #     source_registry: ghcr.io
-  #     platforms: "['linux/arm64', 'linux/amd64']"
-  #   secrets:
-  #     registry_username: ${{ github.actor }}
-  #     registry_password: ${{ secrets.GITHUB_TOKEN }}
+  scan-image:
+    needs: 
+      - prod-image-manifest
+    name: Scan Fluentd Image
+    uses: ./.github/workflows/scan-docker-image-action.yaml
+    with:
+      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
+      source_registry: ghcr.io
+      platforms: "['linux/arm64', 'linux/amd64']"
+    secrets:
+      registry_username: ${{ github.actor }}
+      registry_password: ${{ secrets.GITHUB_TOKEN }}
 
   release-arm64-base-image-to-docker-hub:
     if: ${{ github.event_name != 'pull_request' }}
-    name: Release images to Docker Hub
+    name: Release arm64-base images to Docker Hub
     uses: ./.github/workflows/clone-docker-image-action.yaml
     needs: 
       - build-arm64-base-image-metadata
@@ -373,7 +373,7 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "['linux/arm64']"
+      #platforms: "['linux/arm64']"
       tags: ${{ needs.build-arm64-base-image-metadata.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}
@@ -387,13 +387,13 @@ jobs:
     uses: ./.github/workflows/clone-docker-image-action.yaml
     needs: 
       - prod-image-manifest
-      # - scan-image
+      - scan-image
     with:
       source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}"
       source_registry: ghcr.io
       target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "['linux/amd64']" # "['linux/arm64', 'linux/amd64']"
+      # platforms: "['linux/amd64']" # "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.prod-image-manifest.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -393,7 +393,7 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "['linux/arm64']" # "['linux/arm64', 'linux/amd64']"
+      platforms: "['linux/amd64']" # "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.prod-image-manifest.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -374,7 +374,7 @@ jobs:
     with:
       source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
       source_registry: ghcr.io
-      platforms: "['linux/arm64', 'linux/amd64']"
+      platforms: "[''linux/amd64']" # "['linux/arm64', 'linux/amd64']"
     secrets:
       registry_username: ${{ github.actor }}
       registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -116,41 +116,41 @@ jobs:
   #       run: |
   #         echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
 
-  # build-arm64-base-image-metadata:
-  #   needs:
-  #     - determine-tags
-  #   runs-on: ubuntu-latest
-  #   name: Build prod image metadata for arm64 base image
-  #   outputs:
-  #     IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
-  #     DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
-  #     version: ${{ steps.image-metadata.outputs.version }}
-  #     tags: ${{ steps.image-metadata.outputs.tags }}
-  #     labels: ${{ steps.image-metadata.outputs.labels }}
-  #     release_tags: ${{ steps.image-tags.outputs.tags }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  build-arm64-base-image-metadata:
+    needs:
+      - determine-tags
+    runs-on: ubuntu-latest
+    name: Build prod image metadata for arm64 base image
+    outputs:
+      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+      DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
+      version: ${{ steps.image-metadata.outputs.version }}
+      tags: ${{ steps.image-metadata.outputs.tags }}
+      labels: ${{ steps.image-metadata.outputs.labels }}
+      release_tags: ${{ steps.image-tags.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
          
-  #     - name: docker metadata for arm64 base image
-  #       id: image-metadata
-  #       uses: docker/metadata-action@v5
-  #       with:
-  #         images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
-  #         flavor: |
-  #           latest=false
-  #           suffix=-arm64-base
-  #         tags: |
-  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
-  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+      - name: docker metadata for arm64 base image
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+          flavor: |
+            latest=false
+            suffix=-arm64-base
+          tags: |
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
-  #     - name: Set outputs
-  #       id: set-outputs
-  #       run: |
-  #         echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
-  #         echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
+      - name: Set outputs
+        id: set-outputs
+        run: |
+          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+          echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
 
   build-amd64:
     runs-on: ubuntu-latest
@@ -173,7 +173,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Login to Docker Hub
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -194,67 +194,47 @@ jobs:
           tags: ${{ needs.build-amd64-prod-image-metadata.outputs.tags }}
           labels: ${{ needs.build-amd64-prod-image-metadata.outputs.labels }}
 
-  # build-arm64-base:
-  #   runs-on: ubuntu-latest
-  #   needs: build-arm64-base-image-metadata
-  #   timeout-minutes: 90 
-  #   name: Build arm64 base Image for Fluentd
-  #   steps:
-  #     - name: Install Go
-  #       uses: actions/setup-go@v5
-  #       with:
-  #         go-version: 1.21
+  build-arm64-base:
+    runs-on: ubuntu-latest
+    needs: build-arm64-base-image-metadata
+    timeout-minutes: 90 
+    name: Build arm64 base Image for Fluentd
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
 
-  #     - uses: actions/cache@v4
-  #       with:
-  #         path: ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Set up Docker Buildx
-  #       id: buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Build and Push arm64 base Image for Fluentd
-  #       uses: docker/build-push-action@v6
-  #       with:
-  #         context: .
-  #         file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
-  #         push: true
-  #         platforms: linux/arm64
-  #         tags: ${{ needs.build-arm64-base-image-metadata.outputs.tags }}
-  #         labels: ${{ needs.build-arm64-base-image-metadata.outputs.labels }}
-
-  # release-arm64-base-image-to-docker-hub:
-  #   if: ${{ github.event_name != 'pull_request' }}
-  #   name: Release Image to Docker Hub
-  #   uses: ./.github/workflows/clone-docker-image-action.yaml
-  #   needs: 
-  #     - build-arm64-base-image-metadata
-  #     - build-arm64-base
-  #   with:
-  #     source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}"
-  #     source_registry: ghcr.io
-  #     target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
-  #     target_registry: docker.io
-  #     platforms: "['linux/arm64']"
-  #     tags: ${{ needs.build-arm64-base-image-metadata.outputs.release_tags }}
-  #   secrets:
-  #     source_registry_username:  ${{ github.actor }}
-  #     source_registry_token: ${{ secrets.GITHUB_TOKEN }}
-  #     target_registry_username: ${{ secrets.REGISTRY_USER }}
-  #     target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build and Push arm64 base Image for Fluentd
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
+          push: true
+          platforms: linux/arm64
+          tags: ${{ needs.build-arm64-base-image-metadata.outputs.tags }}
+          labels: ${{ needs.build-arm64-base-image-metadata.outputs.labels }}
 
   # build-arm64:
   #   runs-on: ubuntu-latest
@@ -381,9 +361,29 @@ jobs:
   #     registry_username: ${{ github.actor }}
   #     registry_password: ${{ secrets.GITHUB_TOKEN }}
 
+  release-arm64-base-image-to-docker-hub:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Release arm64-base image to Docker Hub
+    uses: ./.github/workflows/clone-docker-image-action.yaml
+    needs: 
+      - build-arm64-base-image-metadata
+      - build-arm64-base
+    with:
+      source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}"
+      source_registry: ghcr.io
+      target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
+      target_registry: docker.io
+      platforms: "['linux/arm64']"
+      tags: ${{ needs.build-arm64-base-image-metadata.outputs.release_tags }}
+    secrets:
+      source_registry_username:  ${{ github.actor }}
+      source_registry_token: ${{ secrets.GITHUB_TOKEN }}
+      target_registry_username: ${{ secrets.REGISTRY_USER }}
+      target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}
+
   release-images-to-docker-hub:
     if: ${{ github.event_name != 'pull_request' }}
-    name: Release Image to Docker Hub
+    name: Release images to Docker Hub
     uses: ./.github/workflows/clone-docker-image-action.yaml
     needs: 
       - prod-image-manifest

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -363,7 +363,7 @@ jobs:
 
   release-arm64-base-image-to-docker-hub:
     if: ${{ github.event_name != 'pull_request' }}
-    name: Release arm64-base image to Docker Hub
+    name: Release images to Docker Hub
     uses: ./.github/workflows/clone-docker-image-action.yaml
     needs: 
       - build-arm64-base-image-metadata

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -153,12 +153,12 @@ jobs:
           flavor: |
             latest=false
             suffix=-arm64-base          
-         tags: |
-           type=raw,value=latest
-           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
-           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
       - name: Set outputs
         id: set-outputs

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -38,7 +38,7 @@ jobs:
             LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${VERSION}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
             NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
             IMAGE_BASE_TAG="${VERSION}-${NEW_PATCH_VERSION}"
-            echo "Building patch release ${IMAGE_TAG}!"
+            echo "Building patch release ${IMAGE_BASE_TAG}!"
           else
             echo "${VERSION} tag does not exist, assuming we're building a new release!"
             IMAGE_BASE_TAG="${VERSION}"
@@ -101,7 +101,7 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix=-"amd64"
+            suffix="-amd64"
           tags: |
             raw,latest
             type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -115,6 +115,8 @@ jobs:
           echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
 
   build-arm64-prod-image-metadata:
+    needs:
+      - determine-tags
     runs-on: ubuntu-latest
     name: Build prod image metadata for arm64
     outputs:
@@ -126,38 +128,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Extract version parts
-        id: extract_version
-        run: |
-          VERSION=${{ github.event.inputs.docker_tag_version }}
-          VERSION_SUFFIX="arm64"
-          VERSION_WITHOUT_V=${VERSION#v}
-          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
-
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
-          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-
-      - name: Determine image version tag
-        id: determine-tags
-        run: |
-          if skopeo inspect --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
-            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
-            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
-            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
-          else
-            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
-            IMAGE_TAG="${{ env.VERSION }}"
-          fi
-  
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-        env:
-          VERSION: ${{ env.VERSION }}
-          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}      
-
       - name: docker metadata for arm64
         id: image-metadata
         uses: docker/metadata-action@v5
@@ -165,17 +135,13 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix=-${{ env.VERSION_SUFFIX }}
+            suffix=-arm64
           tags: |
             raw,latest
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
-          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
       - name: Set outputs
         id: set-outputs
@@ -183,6 +149,8 @@ jobs:
           echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
 
   build-arm64-base-image-metadata:
+    needs:
+      - determine-tags
     runs-on: ubuntu-latest
     name: Build prod image metadata for arm64 base image
     outputs:
@@ -195,39 +163,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Extract version parts
-        id: extract_version
-        run: |
-          VERSION=${{ github.event.inputs.docker_tag_version }}
-          VERSION_SUFFIX="arm64-base"
-          VERSION_WITHOUT_V=${VERSION#v}
-          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
-
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
-          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-
-      - name: Determine image version tag
-        id: determine-tags
-        run: |
-          if skopeo inspect --override-arch arm64 docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
-            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
-            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
-            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
-          else
-            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
-            IMAGE_TAG="${{ env.VERSION }}"
-          fi
-    
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-        env:
-          VERSION: ${{ env.VERSION }}
-          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}            
-          
+         
       - name: docker metadata for arm64 base image
         id: image-metadata
         uses: docker/metadata-action@v5
@@ -235,16 +171,12 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix=-${{ env.VERSION_SUFFIX }}
+            suffix=-arm64-base
           tags: |
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
-          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
       - name: Set outputs
         id: set-outputs
@@ -406,6 +338,7 @@ jobs:
 
   prod-image-manifest:
     needs: 
+      - determine-tags
       - build-amd64-prod-image-metadata
       - build-arm64-prod-image-metadata
       - build-amd64
@@ -426,46 +359,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Extract version parts
-        id: extract_version
-        run: |
-          VERSION=${{ github.event.inputs.docker_tag_version }}
-          VERSION_WITHOUT_V=${VERSION#v}
-          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
-
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-
-      - name: Determine image version tag
-        id: determine-tags
-        run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}; then
-            echo "${{ env.VERSION }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
-            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
-            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Building patch release ${IMAGE_TAG}!"
-          else
-            echo "${{ env.VERSION }} tag does not exist, assuming we're building a new release!"
-            IMAGE_TAG="${{ env.VERSION }}"
-          fi
-    
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-        env:
-          VERSION: ${{ env.VERSION }}
-          
+              
       - name: docker metadata for manifest
         id: image-metadata
         uses: docker/metadata-action@v5
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
           MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
@@ -475,13 +379,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           tags: |
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
             
       - name: Set outputs
         id: set-outputs

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -365,7 +365,6 @@ jobs:
           tags: ${{ steps.image-metadata.outputs.tags }}
           sources: |
             ghcr.io/${{ needs.build-amd64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-amd64-prod-image-metadata.outputs.version }}
-            # ghcr.io/${{ needs.build-arm64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-prod-image-metadata.outputs.version }}
 
   scan-image:
     needs: 

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -18,7 +18,38 @@ permissions:
   packages: write
 
 jobs:
+  determine-tags:
+    runs-on: ubuntu-latest
+    name: Determine image tags
+    outputs:
+      IMAGE_BASE_TAG: ${{ steps.determine-tags.outputs.IMAGE_BASE_TAG }}
+      IMAGE_MAJOR_MINOR: ${{ steps.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+
+    steps:
+      - name: Determine image version tag
+        id: determine-tags
+        run: |
+          VERSION=${{ github.event.inputs.docker_tag_version }}
+          VERSION_WITHOUT_V=${VERSION#v}
+          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
+
+          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${VERSION}; then
+            echo "${VERSION} tag already exists, assuming we're building a patch release!"
+            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${VERSION}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+            IMAGE_BASE_TAG="${VERSION}-${NEW_PATCH_VERSION}"
+            echo "Building patch release ${IMAGE_TAG}!"
+          else
+            echo "${VERSION} tag does not exist, assuming we're building a new release!"
+            IMAGE_BASE_TAG="${VERSION}"
+          fi
+  
+          echo "IMAGE_BASE_TAG=$IMAGE_BASE_TAG" >> $GITHUB_OUTPUT
+          echo "IMAGE_MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_OUTPUT
+
   build-amd64-prod-image-metadata:
+    needs:
+      - determine-tags
     runs-on: ubuntu-latest
     name: Build prod image metadata for amd64
     outputs:
@@ -31,37 +62,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Extract version parts
-        id: extract_version
-        run: |
-          VERSION=${{ github.event.inputs.docker_tag_version }}
-          VERSION_SUFFIX="amd64"
-          VERSION_WITHOUT_V=${VERSION#v}
-          MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
+      # - name: Extract version parts
+      #   id: extract_version
+      #   run: |
+      #     VERSION=${{ github.event.inputs.docker_tag_version }}
+      #     VERSION_SUFFIX="amd64"
+      #     VERSION_WITHOUT_V=${VERSION#v}
+      #     MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
 
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
-          echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
-          echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
+      #     echo "VERSION=$VERSION" >> $GITHUB_ENV
+      #     echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
+      #     echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
+      #     echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
 
-      - name: Determine image version tag
-        id: determine-tags
-        run: |
-          if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
-            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
-            LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
-            NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
-            IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-            echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
-          else
-            echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
-            IMAGE_TAG="${{ env.VERSION }}"
-          fi
+      # - name: Determine image version tag
+      #   id: determine-tags
+      #   run: |
+      #     if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
+      #       echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
+      #       LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
+      #       NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
+      #       IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
+      #       echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
+      #     else
+      #       echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
+      #       IMAGE_TAG="${{ env.VERSION }}"
+      #     fi
   
-          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-        env:
-          VERSION: ${{env.VERSION }}
-          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
+      #     echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+      #   env:
+      #     VERSION: ${{env.VERSION }}
+      #     VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
           
       - name: docker metadata for amd64
         id: image-metadata
@@ -70,17 +101,13 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix=-${{ env.VERSION_SUFFIX }}
+            suffix=-"amd64"
           tags: |
             raw,latest
-            type=raw,value=${{ env.IMAGE_TAG }}
-            type=raw,value=v${{ env.IMAGE_TAG }}
-            type=raw,value=${{ env.MAJOR_MINOR }}
-            type=raw,value=v${{ env.MAJOR_MINOR }}
-        env:
-          IMAGE_TAG: ${{ env.IMAGE_TAG }}
-          MAJOR_MINOR: ${{ env.MAJOR_MINOR }}
-          VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
       - name: Set outputs
         id: set-outputs

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -101,7 +101,7 @@ jobs:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
             latest=false
-            suffix="-amd64"
+            suffix=-amd64
           tags: |
             raw,latest
             type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -388,7 +388,6 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      #platforms: "['linux/arm64']"
       tags: ${{ needs.build-arm64-base-image-metadata.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}
@@ -408,7 +407,6 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      # platforms: "['linux/amd64']" # "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.prod-image-manifest.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -61,39 +61,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      # - name: Extract version parts
-      #   id: extract_version
-      #   run: |
-      #     VERSION=${{ github.event.inputs.docker_tag_version }}
-      #     VERSION_SUFFIX="amd64"
-      #     VERSION_WITHOUT_V=${VERSION#v}
-      #     MAJOR_MINOR=$(echo $VERSION_WITHOUT_V | cut -d. -f1-2)
-
-      #     echo "VERSION=$VERSION" >> $GITHUB_ENV
-      #     echo "VERSION_SUFFIX=$VERSION_SUFFIX" >> $GITHUB_ENV
-      #     echo "VERSION_WITHOUT_V=$VERSION_WITHOUT_V" >> $GITHUB_ENV
-      #     echo "MAJOR_MINOR=$MAJOR_MINOR" >> $GITHUB_ENV
-
-      # - name: Determine image version tag
-      #   id: determine-tags
-      #   run: |
-      #     if skopeo inspect docker://ghcr.io/${{ env.GITHUB_IMAGE }}:${{ env.VERSION }}-${{ env.VERSION_SUFFIX }}; then
-      #       echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag already exists, assuming we're building a patch release!"
-      #       LATEST_PATCH_VERSION=$(skopeo list-tags docker://ghcr.io/${{ env.GITHUB_IMAGE }} | grep -E "${{ env.VERSION }}-[0-9]+" | sort | uniq | tail -1 | tr -d \" | cut -d'-' -f2)
-      #       NEW_PATCH_VERSION=$((LATEST_PATCH_VERSION + 1))
-      #       IMAGE_TAG="${{ env.VERSION }}-${NEW_PATCH_VERSION}"
-      #       echo "Building patch release ${IMAGE_TAG}-${{ env.VERSION_SUFFIX }}!"
-      #     else
-      #       echo "${{ env.VERSION }}-${{ env.VERSION_SUFFIX }} tag does not exist, assuming we're building a new release!"
-      #       IMAGE_TAG="${{ env.VERSION }}"
-      #     fi
-  
-      #     echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-      #   env:
-      #     VERSION: ${{env.VERSION }}
-      #     VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
-          
+        
       - name: docker metadata for amd64
         id: image-metadata
         uses: docker/metadata-action@v5
@@ -114,75 +82,75 @@ jobs:
         run: |
           echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
 
-  build-arm64-prod-image-metadata:
-    needs:
-      - determine-tags
-    runs-on: ubuntu-latest
-    name: Build prod image metadata for arm64
-    outputs:
-      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
-      version: ${{ steps.image-metadata.outputs.version }}
-      tags: ${{ steps.image-metadata.outputs.tags }}
-      labels: ${{ steps.image-metadata.outputs.labels }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # build-arm64-prod-image-metadata:
+  #   needs:
+  #     - determine-tags
+  #   runs-on: ubuntu-latest
+  #   name: Build prod image metadata for arm64
+  #   outputs:
+  #     IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+  #     version: ${{ steps.image-metadata.outputs.version }}
+  #     tags: ${{ steps.image-metadata.outputs.tags }}
+  #     labels: ${{ steps.image-metadata.outputs.labels }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: docker metadata for arm64
-        id: image-metadata
-        uses: docker/metadata-action@v5
-        with:
-          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
-          flavor: |
-            latest=false
-            suffix=-arm64
-          tags: |
-            raw,latest
-            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
-            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+  #     - name: docker metadata for arm64
+  #       id: image-metadata
+  #       uses: docker/metadata-action@v5
+  #       with:
+  #         images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+  #         flavor: |
+  #           latest=false
+  #           suffix=-arm64
+  #         tags: |
+  #           raw,latest
+  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
-      - name: Set outputs
-        id: set-outputs
-        run: |
-          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+  #     - name: Set outputs
+  #       id: set-outputs
+  #       run: |
+  #         echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
 
-  build-arm64-base-image-metadata:
-    needs:
-      - determine-tags
-    runs-on: ubuntu-latest
-    name: Build prod image metadata for arm64 base image
-    outputs:
-      IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
-      DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
-      version: ${{ steps.image-metadata.outputs.version }}
-      tags: ${{ steps.image-metadata.outputs.tags }}
-      labels: ${{ steps.image-metadata.outputs.labels }}
-      release_tags: ${{ steps.image-tags.outputs.tags }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # build-arm64-base-image-metadata:
+  #   needs:
+  #     - determine-tags
+  #   runs-on: ubuntu-latest
+  #   name: Build prod image metadata for arm64 base image
+  #   outputs:
+  #     IMG_NAME: ${{ steps.set-outputs.outputs.IMAGE_NAME }}
+  #     DOCKER_IMG_NAME: ${{ steps.set-outputs.outputs.DOCKER_IMG_NAME }}
+  #     version: ${{ steps.image-metadata.outputs.version }}
+  #     tags: ${{ steps.image-metadata.outputs.tags }}
+  #     labels: ${{ steps.image-metadata.outputs.labels }}
+  #     release_tags: ${{ steps.image-tags.outputs.tags }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
          
-      - name: docker metadata for arm64 base image
-        id: image-metadata
-        uses: docker/metadata-action@v5
-        with:
-          images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
-          flavor: |
-            latest=false
-            suffix=-arm64-base
-          tags: |
-            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
-            type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
-            type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+  #     - name: docker metadata for arm64 base image
+  #       id: image-metadata
+  #       uses: docker/metadata-action@v5
+  #       with:
+  #         images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
+  #         flavor: |
+  #           latest=false
+  #           suffix=-arm64-base
+  #         tags: |
+  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+  #           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+  #           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
-      - name: Set outputs
-        id: set-outputs
-        run: |
-          echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
-          echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
+  #     - name: Set outputs
+  #       id: set-outputs
+  #       run: |
+  #         echo "IMAGE_NAME=${{ env.GITHUB_IMAGE }}" >> $GITHUB_OUTPUT
+  #         echo "DOCKER_IMG_NAME=${{env.DOCKER_REPO}}/${{ env.DOCKER_IMAGE }}" >> $GITHUB_OUTPUT
 
   build-amd64:
     runs-on: ubuntu-latest
@@ -226,123 +194,123 @@ jobs:
           tags: ${{ needs.build-amd64-prod-image-metadata.outputs.tags }}
           labels: ${{ needs.build-amd64-prod-image-metadata.outputs.labels }}
 
-  build-arm64-base:
-    runs-on: ubuntu-latest
-    needs: build-arm64-base-image-metadata
-    timeout-minutes: 90 
-    name: Build arm64 base Image for Fluentd
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21
+  # build-arm64-base:
+  #   runs-on: ubuntu-latest
+  #   needs: build-arm64-base-image-metadata
+  #   timeout-minutes: 90 
+  #   name: Build arm64 base Image for Fluentd
+  #   steps:
+  #     - name: Install Go
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version: 1.21
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #     - uses: actions/cache@v4
+  #       with:
+  #         path: ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       id: buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Build and Push arm64 base Image for Fluentd
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
-          push: true
-          platforms: linux/arm64
-          tags: ${{ needs.build-arm64-base-image-metadata.outputs.tags }}
-          labels: ${{ needs.build-arm64-base-image-metadata.outputs.labels }}
+  #     - name: Build and Push arm64 base Image for Fluentd
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         context: .
+  #         file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
+  #         push: true
+  #         platforms: linux/arm64
+  #         tags: ${{ needs.build-arm64-base-image-metadata.outputs.tags }}
+  #         labels: ${{ needs.build-arm64-base-image-metadata.outputs.labels }}
 
-  release-arm64-base-image-to-docker-hub:
-    if: ${{ github.event_name != 'pull_request' }}
-    name: Release Image to Docker Hub
-    uses: ./.github/workflows/clone-docker-image-action.yaml
-    needs: 
-      - build-arm64-base-image-metadata
-      - build-arm64-base
-    with:
-      source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}"
-      source_registry: ghcr.io
-      target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
-      target_registry: docker.io
-      platforms: "['linux/arm64']"
-      tags: ${{ needs.build-arm64-base-image-metadata.outputs.release_tags }}
-    secrets:
-      source_registry_username:  ${{ github.actor }}
-      source_registry_token: ${{ secrets.GITHUB_TOKEN }}
-      target_registry_username: ${{ secrets.REGISTRY_USER }}
-      target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}
+  # release-arm64-base-image-to-docker-hub:
+  #   if: ${{ github.event_name != 'pull_request' }}
+  #   name: Release Image to Docker Hub
+  #   uses: ./.github/workflows/clone-docker-image-action.yaml
+  #   needs: 
+  #     - build-arm64-base-image-metadata
+  #     - build-arm64-base
+  #   with:
+  #     source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}"
+  #     source_registry: ghcr.io
+  #     target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
+  #     target_registry: docker.io
+  #     platforms: "['linux/arm64']"
+  #     tags: ${{ needs.build-arm64-base-image-metadata.outputs.release_tags }}
+  #   secrets:
+  #     source_registry_username:  ${{ github.actor }}
+  #     source_registry_token: ${{ secrets.GITHUB_TOKEN }}
+  #     target_registry_username: ${{ secrets.REGISTRY_USER }}
+  #     target_registry_token: ${{ secrets.REGISTRY_PASSWORD }}
 
-  build-arm64:
-    runs-on: ubuntu-latest
-    needs: 
-      - build-arm64-prod-image-metadata
-      - build-arm64-base-image-metadata
-      - build-arm64-base
-    timeout-minutes: 90 
-    name: Build arm64 Image for Fluentd
-    steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21
+  # build-arm64:
+  #   runs-on: ubuntu-latest
+  #   needs: 
+  #     - build-arm64-prod-image-metadata
+  #     - build-arm64-base-image-metadata
+  #     - build-arm64-base
+  #   timeout-minutes: 90 
+  #   name: Build arm64 Image for Fluentd
+  #   steps:
+  #     - name: Install Go
+  #       uses: actions/setup-go@v5
+  #       with:
+  #         go-version: 1.21
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #     - uses: actions/cache@v4
+  #       with:
+  #         path: ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       id: buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Build and Push arm64 base Image for Fluentd
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.quick
-          push: true
-          platforms: linux/arm64
-          tags: ${{ needs.build-arm64-prod-image-metadata.outputs.tags }}
-          labels: ${{ needs.build-arm64-prod-image-metadata.outputs.labels }}
-          build-args: |
-            BASE_IMAGE_TAG=${{ needs.build-arm64-base-image-metadata.outputs.version }}
-            BASE_IMAGE=ghcr.io/${{needs.build-arm64-base-image-metadata.outputs.IMG_NAME}}
+  #     - name: Build and Push arm64 base Image for Fluentd
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         context: .
+  #         file: cmd/fluent-watcher/fluentd/Dockerfile.arm64.quick
+  #         push: true
+  #         platforms: linux/arm64
+  #         tags: ${{ needs.build-arm64-prod-image-metadata.outputs.tags }}
+  #         labels: ${{ needs.build-arm64-prod-image-metadata.outputs.labels }}
+  #         build-args: |
+  #           BASE_IMAGE_TAG=${{ needs.build-arm64-base-image-metadata.outputs.version }}
+  #           BASE_IMAGE=ghcr.io/${{needs.build-arm64-base-image-metadata.outputs.IMG_NAME}}
 
   prod-image-manifest:
     needs: 
       - determine-tags
       - build-amd64-prod-image-metadata
-      - build-arm64-prod-image-metadata
+      #- build-arm64-prod-image-metadata
       - build-amd64
-      - build-arm64
+      # - build-arm64
     runs-on: ubuntu-latest
     name: Create image manifest
     outputs:
@@ -397,7 +365,7 @@ jobs:
           tags: ${{ steps.image-metadata.outputs.tags }}
           sources: |
             ghcr.io/${{ needs.build-amd64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-amd64-prod-image-metadata.outputs.version }}
-            ghcr.io/${{ needs.build-arm64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-prod-image-metadata.outputs.version }}
+            # ghcr.io/${{ needs.build-arm64-prod-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-prod-image-metadata.outputs.version }}
 
   scan-image:
     needs: 
@@ -424,7 +392,7 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "['linux/arm64', 'linux/amd64']"
+      platforms: "[''linux/amd64']" # "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.prod-image-manifest.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -391,7 +391,7 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "[''linux/amd64']" # "['linux/arm64', 'linux/amd64']"
+      platforms: "['linux/arm64']" # "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.prod-image-manifest.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}

--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -146,6 +146,17 @@ jobs:
             type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
             type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
 
+      - name: docker metadata for arm64 base image
+        id: image-tags
+        uses: docker/metadata-action@v5
+        with:
+         tags: |
+           type=raw,value=latest
+           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_BASE_TAG }}
+           type=raw,value=${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+           type=raw,value=v${{ needs.determine-tags.outputs.IMAGE_MAJOR_MINOR }}
+
       - name: Set outputs
         id: set-outputs
         run: |

--- a/.github/workflows/clone-docker-image-action.yaml
+++ b/.github/workflows/clone-docker-image-action.yaml
@@ -60,7 +60,7 @@
           run: 
             docker pull "$SOURCE_IMAGE" --platform=${{ matrix.platform }}
           env:
-            SOURCE_IMAGE: ${{ inputs.source_registry }}/${{ inputs.source_image }}
+            SOURCE_IMAGE: ${{ inputs.source_registry }}/${{ inputs.source_image }}:${{ inputs.tags }}
           shell: bash
     create-tags:
       runs-on: ubuntu-latest

--- a/.github/workflows/clone-docker-image-action.yaml
+++ b/.github/workflows/clone-docker-image-action.yaml
@@ -43,25 +43,6 @@
           required: true
   
   jobs:
-    check-image-exists:
-      strategy:
-        matrix:
-          platform: ${{ fromJson(inputs.platforms) }}
-      runs-on: ubuntu-latest
-      steps:
-        - name: Login to source container registry ${{ inputs.source_registry }}
-          uses: docker/login-action@v3
-          with:
-            registry: ${{ inputs.source_registry }}
-            username: ${{ secrets.source_registry_username }}
-            password: ${{ secrets.source_registry_token }}
-
-        - name: Pull the source image; verify it exists
-          run: 
-            docker pull "$SOURCE_IMAGE" --platform=${{ matrix.platform }}
-          env:
-            SOURCE_IMAGE: ${{ inputs.source_registry }}/${{ inputs.source_image }}:${{ inputs.tags }}
-          shell: bash
     create-tags:
       runs-on: ubuntu-latest
       outputs:
@@ -98,7 +79,6 @@
   
     push-image:
       needs: 
-        - check-image-exists
         - create-tags
       strategy:
         matrix:

--- a/.github/workflows/clone-docker-image-action.yaml
+++ b/.github/workflows/clone-docker-image-action.yaml
@@ -19,11 +19,11 @@
           description: 'The target registry'
           required: true
           type: string
-        platforms:
-          description: 'The platforms to clone'
-          required: false
-          type: string
-          default: '["linux/arm64", "linux/amd64"]'
+        # platforms:
+        #   description: 'The platforms to clone'
+        #   required: false
+        #   type: string
+        #   default: '["linux/arm64", "linux/amd64"]'
         tags:
           description: 'The tags to apply to the target image'
           required: false


### PR DESCRIPTION
### What this PR does / why we need it:
#1246 implemented changes that allow us to release "patch" releases of our fluent-bit and fluentd images,  but it had a few bugs which are addressed in this PR.

Primarily, the logic that promotes and copies images to Dockerhub was broken for various reasons.  This PR centralizes the management of patch tags (eg, `3.1.0-0`) and removes some unnecessary checks/complexity.  This ensures that there is consistent versioning across all tags/patch releases.