### PR TITLE
Fixes "build fluent operator" CI workflow

### DIFF
--- a/.github/workflows/build-fd-image.yaml
+++ b/.github/workflows/build-fd-image.yaml
@@ -384,7 +384,7 @@ jobs:
       - build-arm64-base-image-metadata
       - build-arm64-base
     with:
-      source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}"
+      source_image: "${{ needs.build-arm64-base-image-metadata.outputs.IMG_NAME }}:${{ needs.build-arm64-base-image-metadata.outputs.version }}"
       source_registry: ghcr.io
       target_image: "${{ needs.build-arm64-base-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
@@ -403,7 +403,7 @@ jobs:
       - prod-image-manifest
       - scan-image
     with:
-      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}"
+      source_image: "${{ needs.prod-image-manifest.outputs.IMG_NAME }}:${{ needs.prod-image-manifest.outputs.version }}"
       source_registry: ghcr.io
       target_image: "${{ needs.prod-image-manifest.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -152,7 +152,6 @@ jobs:
       source_registry: ghcr.io
       target_image: "${{ needs.build-image-metadata.outputs.DOCKER_IMG_NAME }}"
       target_registry: docker.io
-      platforms: "['linux/arm64', 'linux/amd64']"
       tags: ${{ needs.build-image-metadata.outputs.release_tags }}
     secrets:
       source_registry_username:  ${{ github.actor }}


### PR DESCRIPTION
#1259 removed the `platform` input from the `clone-docker-image-action` CI workflow but failed to remove it from being passed in the "build fluent operator" workflow which resulted in this error:

```
The workflow is not valid. .github/workflows/build-op-image.yaml (Line: 155, Col: 18): Invalid input, platforms is not defined in the referenced workflow
```

This PR also fixes a Dockerhub promotion issue for the fluentd-arm64-base images.