### PR TITLE
Allow fluent-operator to watch Kubernetes events

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -15,7 +15,7 @@ description: A Helm chart for Kubernetes
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -31,6 +31,7 @@ rules:
       - events
     verbs:
       - list
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -54,6 +54,7 @@ type FluentBitReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;list;get;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;list;get;watch;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
+// +kubebuilder:rbac:groups=core,resources=events,verbs=list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/manifests/setup/fluent-operator-clusterRole.yaml
+++ b/manifests/setup/fluent-operator-clusterRole.yaml
@@ -30,7 +30,8 @@ rules:
     resources:
       - events
     verbs:
-      - list      
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -39196,6 +39196,7 @@ rules:
   - events
   verbs:
   - list
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

This pull request adds a missing RBAC verb to enable the proper functioning of the Kubernetes events input.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1276 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```