### PR TITLE
Fix service monitor label selector scope

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-servicemonitor.yaml
+++ b/charts/fluent-operator/templates/fluentbit-servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     matchLabels:
       {{- include "fluent-operator.selectorLabels" . | nindent 6 }}
       {{- with .Values.fluentbit.labels }}
-      {{- toYaml .Values.fluentbit.labels | nindent 6}}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

This block in the service monitor fails to correctly use the `with` context:

```
  selector:
    matchLabels:
      {{- include "fluent-operator.selectorLabels" . | nindent 6 }}
      {{- with .Values.fluentbit.labels }}
      {{- toYaml .Values.fluentbit.labels | nindent 6}}
      {{- end }}
```

As a result, populating `.Values.fluentbit.labels` results in:

`Helm install failed for release monitoring/fluent-operator with chart fluent-operator@3.0.0: template: fluent-operator/templates/fluentbit-servicemonitor.yaml:34:24: executing "fluent-operator/templates/fluentbit-servicemonitor.yaml" at <.Values.fluentbit.labels>: nil pointer evaluating interface {}.fluentbit`

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None, can create an issue if necessary

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed the helm template where the service monitor incorrectly refers to variables in a "with" block
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```