### PR TITLE
Set explicit fluent-bit name label selector

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-servicemonitor.yaml
+++ b/charts/fluent-operator/templates/fluentbit-servicemonitor.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
   selector:
     matchLabels:
-      {{- include "fluent-operator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: fluent-bit
       {{- with .Values.fluentbit.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
The fluent-bit service is created with a hardcoded label, https://github.com/fluent/fluent-operator/blob/master/charts/fluent-operator/templates/fluentbit-fluentBit.yaml#L9

This seems reasonable? So I added this to the ServiceMonitor selector as well, and removed the use of the fluent-operator labels.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1292

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```