### PR TITLE
BUG: re-add accidently removed flag.Parse

### DIFF
--- a/cmd/fluent-watcher/fluentbit/main.go
+++ b/cmd/fluent-watcher/fluentbit/main.go
@@ -72,6 +72,8 @@ func main() {
 		level.Warn(logger).Log("--flb-timeout is deprecated. Consider setting the terminationGracePeriod field on the `(Cluster)FluentBit` instance.")
 	}
 
+	flag.Parse()
+
 	// First, launch the fluent-bit process.
 	args := []string{"--enable-hot-reload", "-c", configPath}
 	if externalPluginPath != "" {


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

In the commit at https://github.com/fluent/fluent-operator/commit/d8e206004898e6e86f1bcbfeaf192916f9fb6293 I saw that someone accidentally removed the flag.Parse line, which caused fluent-watcher to ignore any CLI flag values, so I added it back

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes re

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```