### PR TITLE
bug: Allows to render net properties for outputs

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/net_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/net_types.go
@@ -50,7 +50,7 @@ func (t *Networking) Params(sl SecretLoader) (*params.KVs, error) {
 		kvs.Insert("net.dns.prefer_ipv4", fmt.Sprint(*t.DNSPreferIPv4))
 	}
 	if t.DNSResolver != nil {
-		kvs.Insert("net.dns.prefer_ipv4", *t.DNSResolver)
+		kvs.Insert("net.dns.resolver", *t.DNSResolver)
 	}
 	if t.Keepalive != nil {
 		kvs.Insert("net.keepalive", *t.Keepalive)

--- a/apis/fluentbit/v1alpha2/plugins/output/azure_blob_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/azure_blob_types.go
@@ -78,5 +78,12 @@ func (o *AzureBlob) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if o.Networking != nil {
+		net, err := o.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/elasticsearch_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/elasticsearch_types.go
@@ -231,6 +231,13 @@ func (es *Elasticsearch) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if es.Networking != nil {
+		net, err := es.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	if es.TotalLimitSize != "" {
 		kvs.Insert("storage.total_limit_size", es.TotalLimitSize)
 	}

--- a/apis/fluentbit/v1alpha2/plugins/output/forward_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/forward_types.go
@@ -100,5 +100,12 @@ func (f *Forward) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if f.Networking != nil {
+		net, err := f.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/gelf_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/gelf_types.go
@@ -83,5 +83,12 @@ func (g *Gelf) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if g.Networking != nil {
+		net, err := g.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/http_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/http_types.go
@@ -142,5 +142,12 @@ func (h *HTTP) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if h.Networking != nil {
+		net, err := h.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/influxdb_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/influxdb_types.go
@@ -118,5 +118,12 @@ func (o *InfluxDB) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if o.Networking != nil {
+		net, err := o.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/loki_types.go
@@ -137,5 +137,12 @@ func (l *Loki) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if l.Networking != nil {
+		net, err := l.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/open_search_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/open_search_types.go
@@ -222,6 +222,13 @@ func (o *OpenSearch) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if o.Networking != nil {
+		net, err := o.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	if o.TotalLimitSize != "" {
 		kvs.Insert("storage.total_limit_size", o.TotalLimitSize)
 	}

--- a/apis/fluentbit/v1alpha2/plugins/output/open_telemetry_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/open_telemetry_types.go
@@ -98,5 +98,12 @@ func (o *OpenTelemetry) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if o.Networking != nil {
+		net, err := o.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/prometheus_remote_write_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/prometheus_remote_write_types.go
@@ -97,5 +97,12 @@ func (p *PrometheusRemoteWrite) Params(sl plugins.SecretLoader) (*params.KVs, er
 		}
 		kvs.Merge(tls)
 	}
+	if p.Networking != nil {
+		net, err := p.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
@@ -151,5 +151,12 @@ func (o *Splunk) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if o.Networking != nil {
+		net, err := o.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/syslog_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/syslog_types.go
@@ -100,5 +100,12 @@ func (s *Syslog) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(tls)
 	}
+	if s.Networking != nil {
+		net, err := s.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/tcp_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/tcp_types.go
@@ -69,5 +69,12 @@ func (t *TCP) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 		}
 		kvs.Merge(net)
 	}
+	if t.Networking != nil {
+		net, err := t.Networking.Params(sl)
+		if err != nil {
+			return nil, err
+		}
+		kvs.Merge(net)
+	}
 	return kvs, nil
 }


### PR DESCRIPTION
### What this PR does / why we need it:

It renders attributes from `networking` field and fixes `DNSResolver`.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1297

### Does this PR introduced a user-facing change?

No

### Additional documentation, usage docs, etc.:
