### PR TITLE
Support storage.total_limit_size in syslog plugin

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/syslog_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/syslog_types.go
@@ -45,6 +45,8 @@ type Syslog struct {
 	*plugins.TLS `json:"tls,omitempty"`
 	// Include fluentbit networking options for this output-plugin
 	*plugins.Networking `json:"networking,omitempty"`
+	// Limit the maximum number of Chunks in the filesystem for the current output logical destination.
+	TotalLimitSize string `json:"totalLimitSize,omitempty"`
 }
 
 func (_ *Syslog) Name() string {
@@ -106,6 +108,9 @@ func (s *Syslog) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 			return nil, err
 		}
 		kvs.Merge(net)
+	}
+	if s.TotalLimitSize != "" {
+		kvs.Insert("storage.total_limit_size", s.TotalLimitSize)
 	}
 	return kvs, nil
 }

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -4156,6 +4156,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -4156,6 +4156,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -4156,6 +4156,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -4156,6 +4156,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/docs/plugins/fluentbit/output/syslog.md
+++ b/docs/plugins/fluentbit/output/syslog.md
@@ -20,3 +20,4 @@ Syslog output plugin allows you to deliver messages to Syslog servers. <br /> **
 | syslogMessageKey | Key key name that contains the message to deliver. | string |
 | tls | Syslog output plugin supports TTL/SSL, for more details about the properties available and general configuration, please refer to the TLS/SSL section. | *[plugins.TLS](../tls.md) |
 | networking | Include fluentbit networking options for this output-plugin | *plugins.Networking |
+| totalLimitSize | Limit the maximum number of Chunks in the filesystem for the current output logical destination. | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -8093,6 +8093,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.
@@ -36649,6 +36653,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -8093,6 +8093,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.
@@ -36649,6 +36653,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               tcp:
                 description: TCP defines TCP Output configuration.


### PR DESCRIPTION
### What this PR does / why we need it:
This PR is to support the storage.total_limit_size parameter in the syslog output plugin. This property was introduced in Fluent Bit v1.6 and it is used for limiting the total size in bytes of chunks that can exist in the filesystem for a certain logical output destination.

### Which issue(s) this PR fixes:
Fixes #1317 

### Does this PR introduced a user-facing change?
```release-note
Added the ability to specify the storage.total_limit_size parameter for the syslog output plugin.
```

### Additional documentation, usage docs, etc.:
```docs
- [Usage]: https://github.com/fluent/fluent-operator/blob/master/docs/plugins/fluentbit/output/syslog.md
```