### PR TITLE
Expose fluentbit init-container values in helm chart

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -103,5 +103,9 @@ spec:
 {{- if .Values.fluentbit.disableLogVolumes }}
   disableLogVolumes: {{ .Values.fluentbit.disableLogVolumes }}
 {{- end }}
+{{- if .Values.fluentbit.initContainers }}
+  initContainers:
+  {{ toYaml .Values.fluentbit.initContainers | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -134,6 +134,8 @@ fluentbit:
           - matchExpressions:
               - key: node-role.kubernetes.io/edge
                 operator: DoesNotExist
+  # initContainers configuration for Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  initContainers: []
   # nodeSelector configuration for Fluent Bit pods. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
   # Node tolerations applied to Fluent Bit pods. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION


<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
This PR allows us to configure the initContainers in fluentbit custom resource. Fluentbit CRD schema already has the option to configure initContainers. So just exposing the same in values.yaml.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1319 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```