### PR TITLE
Add logs_body_key_attributes option for OpenTelemetry output plugin

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/open_telemetry_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/open_telemetry_types.go
@@ -36,8 +36,10 @@ type OpenTelemetry struct {
 	// Log the response payload within the Fluent Bit log.
 	LogResponsePayload *bool `json:"logResponsePayload,omitempty"`
 	// This allows you to add custom labels to all metrics exposed through the OpenTelemetry exporter. You may have multiple of these fields.
-	AddLabel     map[string]string `json:"addLabel,omitempty"`
-	*plugins.TLS `json:"tls,omitempty"`
+	AddLabel map[string]string `json:"addLabel,omitempty"`
+	// If true, remaining unmatched keys are added as attributes.
+	LogsBodyKeyAttributes *bool `json:"logsBodyKeyAttributes,omitempty"`
+	*plugins.TLS          `json:"tls,omitempty"`
 	// Include fluentbit networking options for this output-plugin
 	*plugins.Networking `json:"networking,omitempty"`
 }
@@ -91,6 +93,9 @@ func (o *OpenTelemetry) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	kvs.InsertStringMap(o.AddLabel, func(k, v string) (string, string) {
 		return "add_label", fmt.Sprintf(" %s    %s", k, v)
 	})
+	if o.LogsBodyKeyAttributes != nil {
+		kvs.Insert("logs_body_key_attributes", fmt.Sprint(*o.LogsBodyKeyAttributes))
+	}
 	if o.TLS != nil {
 		tls, err := o.TLS.Params(sl)
 		if err != nil {

--- a/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
@@ -765,6 +765,11 @@ func (in *OpenTelemetry) DeepCopyInto(out *OpenTelemetry) {
 			(*out)[key] = val
 		}
 	}
+	if in.LogsBodyKeyAttributes != nil {
+		in, out := &in.LogsBodyKeyAttributes, &out.LogsBodyKeyAttributes
+		*out = new(bool)
+		**out = **in
+	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
 		*out = new(plugins.TLS)

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -2856,6 +2856,9 @@ spec:
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
                     type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
+                    type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web
                       server listening for logs, e.g: /v1/logs'

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -2856,6 +2856,9 @@ spec:
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
                     type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
+                    type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web
                       server listening for logs, e.g: /v1/logs'

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -2856,6 +2856,9 @@ spec:
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
                     type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
+                    type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web
                       server listening for logs, e.g: /v1/logs'

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -2856,6 +2856,9 @@ spec:
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
                     type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
+                    type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web
                       server listening for logs, e.g: /v1/logs'

--- a/docs/plugins/fluentbit/output/open_telemetry.md
+++ b/docs/plugins/fluentbit/output/open_telemetry.md
@@ -15,6 +15,7 @@ The OpenTelemetry plugin allows you to take logs, metrics, and traces from Fluen
 | tracesUri | Specify an optional HTTP URI for the target web server listening for traces, e.g: /v1/traces | string |
 | header | Add a HTTP header key/value pair. Multiple headers can be set. | map[string]string |
 | logResponsePayload | Log the response payload within the Fluent Bit log. | *bool |
+| logsBodyKeyAttributes | Adds unmatched keys as attributes when true. | *bool |
 | addLabel | This allows you to add custom labels to all metrics exposed through the OpenTelemetry exporter. You may have multiple of these fields. | map[string]string |
 | tls |  | *[plugins.TLS](../tls.md) |
 | networking | Include fluentbit networking options for this output-plugin | *plugins.Networking |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -6793,6 +6793,9 @@ spec:
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
                     type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
+                    type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web
                       server listening for logs, e.g: /v1/logs'
@@ -35348,6 +35351,9 @@ spec:
                     type: object
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
+                    type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
                     type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -6793,6 +6793,9 @@ spec:
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
                     type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
+                    type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web
                       server listening for logs, e.g: /v1/logs'
@@ -35348,6 +35351,9 @@ spec:
                     type: object
                   logResponsePayload:
                     description: Log the response payload within the Fluent Bit log.
+                    type: boolean
+                  logsBodyKeyAttributes:
+                    description: If true, remaining unmatched keys are added as attributes.
                     type: boolean
                   logsUri:
                     description: 'Specify an optional HTTP URI for the target web


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

It adds the `logs_body_key_attributes` option for the OpenTelemetry output plugin.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1321

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add logsBodyKeyAttributes boolean option to opentelemetry output plugin.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```