### PR TITLE
feat: Expose lua filter type_array_key parameter

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/filter/lua_types.go
@@ -28,6 +28,9 @@ type Lua struct {
 	// Note that starting from Fluent Bit v1.6 integer data types are preserved
 	// and not converted to double as in previous versions.
 	TypeIntKey []string `json:"typeIntKey,omitempty"`
+	// If these keys are matched, the fields are handled as array. If more than
+	// one key, delimit by space. It is useful the array can be empty.
+	TypeArrayKey []string `json:"typeArrayKey,omitempty"`
 	// If enabled, Lua script will be executed in protected mode.
 	// It prevents to crash when invalid Lua script is executed. Default is true.
 	ProtectedMode *bool `json:"protectedMode,omitempty"`
@@ -76,6 +79,10 @@ func (l *Lua) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 		kvs.Insert("type_int_key", strings.Join(l.TypeIntKey, " "))
 	}
 
+	if l.TypeArrayKey != nil && len(l.TypeArrayKey) > 0 {
+		kvs.Insert("type_array_key", strings.Join(l.TypeIntKey, " "))
+	}
+
 	if l.ProtectedMode != nil {
 		kvs.Insert("protected_mode", strconv.FormatBool(*l.ProtectedMode))
 	}
@@ -83,5 +90,6 @@ func (l *Lua) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	if l.TimeAsTable {
 		kvs.Insert("time_as_table", "true")
 	}
+
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/filter/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/plugins/filter/zz_generated.deepcopy.go
@@ -335,6 +335,11 @@ func (in *Lua) DeepCopyInto(out *Lua) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TypeArrayKey != nil {
+		in, out := &in.TypeArrayKey, &out.TypeArrayKey
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ProtectedMode != nil {
 		in, out := &in.ProtectedMode, &out.ProtectedMode
 		*out = new(bool)

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfilters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfilters.yaml
@@ -464,6 +464,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
@@ -464,6 +464,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.

--- a/config/crd/bases/fluentbit.fluent.io_clusterfilters.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterfilters.yaml
@@ -464,6 +464,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.

--- a/config/crd/bases/fluentbit.fluent.io_filters.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_filters.yaml
@@ -464,6 +464,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.

--- a/docs/plugins/fluentbit/filter/lua.md
+++ b/docs/plugins/fluentbit/filter/lua.md
@@ -9,5 +9,6 @@ The Lua Filter allows you to modify the incoming records using custom Lua Script
 | call | Lua function name that will be triggered to do filtering. It's assumed that the function is declared inside the Script defined above. | string |
 | code | Inline LUA code instead of loading from a path via script. | string |
 | typeIntKey | If these keys are matched, the fields are converted to integer. If more than one key, delimit by space. Note that starting from Fluent Bit v1.6 integer data types are preserved and not converted to double as in previous versions. | []string |
+| typeArrayKey | If these keys are matched, the fields are handled as array. If more than one key, delimit by space. It is useful the array can be empty. | []string |
 | protectedMode | If enabled, Lua script will be executed in protected mode. It prevents to crash when invalid Lua script is executed. Default is true. | *bool |
 | timeAsTable | By default when the Lua script is invoked, the record timestamp is passed as a Floating number which might lead to loss precision when the data is converted back. If you desire timestamp precision enabling this option will pass the timestamp as a Lua table with keys sec for seconds since epoch and nsec for nanoseconds. | bool |

--- a/docs/plugins/fluentbit/output/open_telemetry.md
+++ b/docs/plugins/fluentbit/output/open_telemetry.md
@@ -15,7 +15,7 @@ The OpenTelemetry plugin allows you to take logs, metrics, and traces from Fluen
 | tracesUri | Specify an optional HTTP URI for the target web server listening for traces, e.g: /v1/traces | string |
 | header | Add a HTTP header key/value pair. Multiple headers can be set. | map[string]string |
 | logResponsePayload | Log the response payload within the Fluent Bit log. | *bool |
-| logsBodyKeyAttributes | Adds unmatched keys as attributes when true. | *bool |
 | addLabel | This allows you to add custom labels to all metrics exposed through the OpenTelemetry exporter. You may have multiple of these fields. | map[string]string |
+| logsBodyKeyAttributes | If true, remaining unmatched keys are added as attributes. | *bool |
 | tls |  | *[plugins.TLS](../tls.md) |
 | networking | Include fluentbit networking options for this output-plugin | *plugins.Networking |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -463,6 +463,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.
@@ -14959,6 +14966,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -463,6 +463,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.
@@ -14959,6 +14966,13 @@ spec:
                             If you desire timestamp precision enabling this option will pass the timestamp as
                             a Lua table with keys sec for seconds since epoch and nsec for nanoseconds.
                           type: boolean
+                        typeArrayKey:
+                          description: |-
+                            If these keys are matched, the fields are handled as array. If more than
+                            one key, delimit by space. It is useful the array can be empty.
+                          items:
+                            type: string
+                          type: array
                         typeIntKey:
                           description: |-
                             If these keys are matched, the fields are converted to integer.


### PR DESCRIPTION
The lua filter was missing a parameter `type_array_key`.

I've copied the parameter description into the type comment from the
fluent-bit docs.

Ran `make generate manifests docs-update verify build`.

Signed-off-by: Zoltán Reegn <zoltan.reegn@gmail.com>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
lua filter: add `type_array_key`

```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```

