### PR TITLE
Add option to disable operator resources in Helm chart

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -145,3 +146,4 @@ rules:
       - get
       - watch
       - patch
+{{- end }}

--- a/charts/fluent-operator/templates/fluent-operator-clusterRoleBinding.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRoleBinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enable }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
 - kind: ServiceAccount
   name: fluent-operator
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enable }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -129,3 +130,4 @@ spec:
       securityContext:
         {{ toYaml .Values.operator.podSecurityContext | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/fluent-operator/templates/fluentbit-lua-config.yaml
+++ b/charts/fluent-operator/templates/fluentbit-lua-config.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.Kubernetes -}}
+{{- if .Values.fluentbit.enable -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,4 +27,5 @@ data:
 
       return 1, timestamp, new_record
     end
+{{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/serviceaccount.yaml
+++ b/charts/fluent-operator/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enable }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   labels:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator
+{{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -25,6 +25,9 @@ operator:
   container:
     repository: "kubesphere/fluent-operator"
     tag: "latest"
+  # If set to false, this will disable the creation of ClusterRole, ClusterRoleBinding,
+  # Deployment, and ServiceAccount resources to avoid conflicts when deploying multiple instances. 
+  enable: true
   # nodeSelector configuration for Fluent Operator. Ref: https://kubernetes.io/docs/user-guide/node-selection/
   nodeSelector: {}
   # Node tolerations applied to Fluent Operator. Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Fixes https://github.com/fluent/fluent-operator/issues/1308
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add option to disable operator resources in Helm chart
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
Now can deploy fluent-operator and fluentbit one after another like this
helm install fluent-operator --create-namespace -n fluent charts/fluent-operator/  --set containerRuntime=containerd --set operator.enable=true --set fluentbit.enable=false
helm install fluentbit --create-namespace -n fluent charts/fluent-operator/  --set containerRuntime=containerd --set operator.enable=false --set fluentbit.enable=true

If operator.enable be set to false, this will disable the creation of ClusterRole, ClusterRoleBinding,Deployment, and ServiceAccount resources
```