### PR TITLE
Update fluentd image references

### DIFF
--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -401,7 +401,7 @@ fluentd:
   port: 24224
   image:
     repository: "ghcr.io/fluent/fluent-operator/fluentd"
-    tag: "v1.17.0"
+    tag: "v1.17.0-4"
   # Numbers of the Fluentd instance
   # Applicable when the mode is "collector", and will be ignored when the mode is "agent"
   replicas: 1

--- a/manifests/fluentd/fluentd-cluster-cfg-output-buffer-example.yaml
+++ b/manifests/fluentd/fluentd-cluster-cfg-output-buffer-example.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 3
-  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-cluster-cfg-output-es.yaml
+++ b/manifests/fluentd/fluentd-cluster-cfg-output-es.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-cluster-cfg-output-kafka.yaml
+++ b/manifests/fluentd/fluentd-cluster-cfg-output-kafka.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-mixed-cfgs-multi-tenant-output.yaml
+++ b/manifests/fluentd/fluentd-mixed-cfgs-multi-tenant-output.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-mixed-cfgs-output-es.yaml
+++ b/manifests/fluentd/fluentd-mixed-cfgs-output-es.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/fluentd/fluentd-namespaced-cfg-output-es.yaml
+++ b/manifests/fluentd/fluentd-namespaced-cfg-output-es.yaml
@@ -11,7 +11,7 @@ spec:
       bind: 0.0.0.0
       port: 24224
   replicas: 1
-  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/quick-start/fluentd-forward.yaml
+++ b/manifests/quick-start/fluentd-forward.yaml
@@ -11,7 +11,7 @@ spec:
         bind: 0.0.0.0
         port: 24224
   replicas: 1
-  image: kubesphere/fluentd:v1.14.4
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"

--- a/manifests/quick-start/fluentd-http.yaml
+++ b/manifests/quick-start/fluentd-http.yaml
@@ -11,7 +11,7 @@ spec:
         bind: 0.0.0.0
         port: 9880
   replicas: 1
-  image: kubesphere/fluentd:v1.14.4
+  image: ghcr.io/fluent/fluent-operator/fluentd:v1.17.0-4
   fluentdCfgSelector: 
     matchLabels:
       config.fluentd.fluent.io/enabled: "true"


### PR DESCRIPTION
Reference the latest build.
Fix fluentd image references so they all point to ghcr.io

Signed-off-by: Zoltán Reegn <zoltan.reegn@gmail.com>

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```