### PR TITLE
Remove influxdb host validation in  ClusterOutput

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/influxdb_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/influxdb_types.go
@@ -14,13 +14,10 @@ import (
 // **For full documentation, refer to https://docs.fluentbit.io/manual/pipeline/outputs/influxdb**
 type InfluxDB struct {
 	// IP address or hostname of the target InfluxDB service.
-	// +kubebuilder:validation:Format="hostname"
-	// +kubebuilder:validation:Format="ipv4"
-	// +kubebuilder:validation:Format="ipv6"
 	Host string `json:"host"`
 	// TCP port of the target InfluxDB service.
-	//  +kubebuilder:validation:Maximum=65536
-	//  +kubebuilder:validation:Minimum=0
+	//  +kubebuilder:validation:Maximum=65535
+	//  +kubebuilder:validation:Minimum=1
 	Port *int32 `json:"port,omitempty"`
 	// InfluxDB database name where records will be inserted.
 	Database string `json:"database,omitempty"`

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1747,7 +1747,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -1917,8 +1916,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -1747,7 +1747,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -1917,8 +1916,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1747,7 +1747,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -1917,8 +1916,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -1747,7 +1747,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -1917,8 +1916,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5784,7 +5784,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -5954,8 +5953,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for
@@ -34472,7 +34471,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -34642,8 +34640,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5784,7 +5784,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -5954,8 +5953,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for
@@ -34472,7 +34471,6 @@ spec:
                     type: string
                   host:
                     description: IP address or hostname of the target InfluxDB service.
-                    format: ipv6
                     type: string
                   httpPassword:
                     description: Password for user defined in HTTP_User
@@ -34642,8 +34640,8 @@ spec:
                   port:
                     description: TCP port of the target InfluxDB service.
                     format: int32
-                    maximum: 65536
-                    minimum: 0
+                    maximum: 65535
+                    minimum: 1
                     type: integer
                   sequenceTag:
                     description: The name of the tag whose value is incremented for


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

This PR removes the validation of the ipv4, ipv6 and hostname. This is because the Kubebuilder doesn't support using multiple format validations for a single field. In original code, there were three formation validations(hostname, ipv4, ipv6), but only the last one(ipv6) would be applied.

This PR also remedies port range. The highest valid port number is 65535, not 65536. Port 0 is a reserved port in TCP/IP

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1359

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```