### PR TITLE
feat: support rollout restart for daemonset and statefulset

### DIFF
--- a/controllers/fluent_controller_finalizer.go
+++ b/controllers/fluent_controller_finalizer.go
@@ -143,8 +143,20 @@ func (r *FluentdReconciler) mutate(obj client.Object, fd *fluentdv1alpha1.Fluent
 		expected := operator.MakeStatefulSet(*fd)
 
 		return func() error {
+			// Preserve the kubectl.kubernetes.io/restartedAt annotation
+			restartedAt := o.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+
 			o.Labels = expected.Labels
 			o.Spec = expected.Spec
+
+			// Restore the kubectl.kubernetes.io/restartedAt annotation if it existed
+			if restartedAt != "" {
+				if o.Spec.Template.Annotations == nil {
+					o.Spec.Template.Annotations = make(map[string]string)
+				}
+				o.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = restartedAt
+			}
+
 			if err := ctrl.SetControllerReference(fd, o, r.Scheme); err != nil {
 				return err
 			}
@@ -153,8 +165,20 @@ func (r *FluentdReconciler) mutate(obj client.Object, fd *fluentdv1alpha1.Fluent
 	case *appsv1.DaemonSet:
 		expected := operator.MakeFluentdDaemonSet(*fd)
 		return func() error {
+			// Preserve the kubectl.kubernetes.io/restartedAt annotation
+			restartedAt := o.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"]
+
 			o.Labels = expected.Labels
 			o.Spec = expected.Spec
+
+			// Restore the kubectl.kubernetes.io/restartedAt annotation if it existed
+			if restartedAt != "" {
+				if o.Spec.Template.Annotations == nil {
+					o.Spec.Template.Annotations = make(map[string]string)
+				}
+				o.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = restartedAt
+			}
+
 			if err := ctrl.SetControllerReference(fd, o, r.Scheme); err != nil {
 				return err
 			}

--- a/docs/plugins/fluentbit/output/azure_log_analytics.md
+++ b/docs/plugins/fluentbit/output/azure_log_analytics.md
@@ -8,5 +8,6 @@ Azure Log Analytics is the Azure Log Analytics output plugin, allows you to inge
 | customerID | Customer ID or Workspace ID | *[plugins.Secret](../secret.md) |
 | sharedKey | Specify the primary or the secondary client authentication key | *[plugins.Secret](../secret.md) |
 | logType | Name of the event type. | string |
+| logTypeKey | Set a record key that will populate 'logtype'. If the key is found, it will have precedence | string |
 | timeKey | Specify the name of the key where the timestamp is stored. | string |
 | timeGenerated | If set, overrides the timeKey value with the `time-generated-field` HTTP header value. | *bool |


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
To support `kubectl rollout restart ds/sts`, this pr preserves the `kubectl.kubernetes.io/restartedAt` annotation when reconciling. 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```