### PR TITLE
Adding namespaceClusterFbCfg to ClusterFluentBitConfig custom resource

### DIFF
--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
+  {{- if .Values.fluentbit.namespaceClusterFbCfg }}
+  namespace: {{ .Values.fluentbit.namespaceClusterFbCfg }}
+  {{- end }}
   service:
     parsersFiles:
       - /fluent-bit/etc/parsers.conf

--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-{{- if .Values.fluentbit.namespaceClusterFbCfg }}
+  {{- if .Values.fluentbit.namespaceClusterFbCfg }}
   namespace: {{ .Values.fluentbit.namespaceClusterFbCfg }}
-{{- end }}
+  {{- end }}
   service:
     parsersFiles:
       - /fluent-bit/etc/parsers.conf

--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -7,9 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
-  {{- if .Values.fluentbit.namespaceClusterFbCfg }}
+{{- if .Values.fluentbit.namespaceClusterFbCfg }}
   namespace: {{ .Values.fluentbit.namespaceClusterFbCfg }}
-  {{- end }}
+{{- end }}
   service:
     parsersFiles:
       - /fluent-bit/etc/parsers.conf

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -388,6 +388,9 @@ fluentbit:
     javaMultiline:
     # use in filter for parser generic springboot multiline log format
       enable: false
+  #Using namespaceClusterFbCfg, deploy fluent-bit configmap and secret in this namespace.
+  #If it is not defined, it is in the namespace of the fluent-operator
+  namespaceClusterFbCfg: ""
 
 fluentd:
   # Installs a sub chart carrying the CRDs for the fluentd controller. The sub chart is enabled by default.

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -389,7 +389,7 @@ fluentbit:
     # use in filter for parser generic springboot multiline log format
       enable: false
   #Using namespaceClusterFbCfg, deploy fluent-bit configmap and secret in this namespace.
-  #If it is not defined, it is in the namespace of the fluent-operator
+  #If it is not defined, it is in the namespace of the fluent-operator.
   namespaceClusterFbCfg: ""
 
 fluentd:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -389,7 +389,7 @@ fluentbit:
     # use in filter for parser generic springboot multiline log format
       enable: false
   #Using namespaceClusterFbCfg, deploy fluent-bit configmap and secret in this namespace.
-  #If it is not defined, it is in the namespace of the fluent-operator.
+  #If it is not defined, it is in the namespace of the fluent-operator
   namespaceClusterFbCfg: ""
 
 fluentd:


### PR DESCRIPTION
  #Using namespaceClusterFbCfg, deploy fluent-bit configmap and secret in this namespace.
  #If it is not defined, it is in the namespace of the fluent-operator

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```