### PR TITLE
Adding namespaceClusterFbCfg to ClusterFluentBitConfig custom resource.

### DIFF
--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -7,6 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:
+  {{- if .Values.fluentbit.namespaceClusterFbCfg }}
+  namespace: {{ .Values.fluentbit.namespaceClusterFbCfg }}
+  {{- end }}
   service:
     parsersFiles:
       - /fluent-bit/etc/parsers.conf

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -388,7 +388,9 @@ fluentbit:
     javaMultiline:
     # use in filter for parser generic springboot multiline log format
       enable: false
-
+    #Using namespaceClusterFbCfg, deploy fluent-bit configmap and secret in this namespace.
+    #If it is not defined, it is in the namespace of the fluent-operator.
+  namespaceClusterFbCfg: ""
 fluentd:
   # Installs a sub chart carrying the CRDs for the fluentd controller. The sub chart is enabled by default.
   crdsEnable: true


### PR DESCRIPTION
Deploy fluent-bit configmap and secret in the namespace provided in the namespaceClusterFbCfg which is used in ClusterFluentBitConfig customresource > spec section. If it is not defined, they are created in the namespace of the fluent-operator.
Signed-off-by: Bharathi Talakola <divya.cs237@gmail.com>

### What this PR does / why we need it:
At present "fluent-bit-config" secret is getting created in the fluent-operator namespace by default. It can be configured using "namespace" key from ClusterFluentBitConfig CRD but this namespace key is not configured at the CR level.
https://github.com/fluent/fluent-operator/blob/release-3.2/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml#L191-L231.
Hence added namespace field to ClusterFluentBitConfig customresource > spec section.

### Which issue(s) this PR fixes:

Fixes: https://github.com/fluent/fluent-operator/issues/1365


### Does this PR introduced a user-facing change?
None

### Additional documentation, usage docs, etc.:
```
apiVersion: fluentbit.fluent.io/v1alpha2
kind: ClusterFluentBitConfig
metadata:
  name: fluent-bit-config
  labels:
    app.kubernetes.io/name: fluent-bit
spec:
  namespace: "fluentbit-namespace"
  
```