### PR TITLE
Fix(doc): open_search.md referencing elasticsearch name

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/open_search_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/open_search_types.go
@@ -80,11 +80,11 @@ type OpenSearch struct {
 	IdKey string `json:"idKey,omitempty"`
 	// Operation to use to write in bulk requests.
 	WriteOperation string `json:"writeOperation,omitempty"`
-	// When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3.
+	// When enabled, replace field name dots with underscore, required by Opensearch 2.0-2.3.
 	ReplaceDots *bool `json:"replaceDots,omitempty"`
-	// When enabled print the elasticsearch API calls to stdout (for diag only)
+	// When enabled print the Opensearch API calls to stdout (for diag only)
 	TraceOutput *bool `json:"traceOutput,omitempty"`
-	// When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error
+	// When enabled print the Opensearch API calls to stdout when Opensearch returns an error
 	TraceError *bool `json:"traceError,omitempty"`
 	// Use current time for index generation instead of message record
 	CurrentTimeIndex *bool `json:"currentTimeIndex,omitempty"`

--- a/docs/plugins/fluentbit/output/open_search.md
+++ b/docs/plugins/fluentbit/output/open_search.md
@@ -30,9 +30,9 @@ OpenSearch is the opensearch output plugin, allows to ingest your records into a
 | generateID | When enabled, generate _id for outgoing records. This prevents duplicate records when retrying OpenSearch. | *bool |
 | idKey | If set, _id will be the value of the key from incoming record and Generate_ID option is ignored. | string |
 | writeOperation | Operation to use to write in bulk requests. | string |
-| replaceDots | When enabled, replace field name dots with underscore, required by Elasticsearch 2.0-2.3. | *bool |
-| traceOutput | When enabled print the elasticsearch API calls to stdout (for diag only) | *bool |
-| traceError | When enabled print the elasticsearch API calls to stdout when elasticsearch returns an error | *bool |
+| replaceDots | When enabled, replace field name dots with underscore, required by Opensearch 2.0-2.3. | *bool |
+| traceOutput | When enabled print the Opensearch API calls to stdout (for diag only) | *bool |
+| traceError | When enabled print the Opensearch API calls to stdout when Opensearch returns an error | *bool |
 | currentTimeIndex | Use current time for index generation instead of message record | *bool |
 | logstashPrefixKey | Prefix keys with this string | string |
 | suppressTypeName | When enabled, mapping types is removed and Type option is ignored. Types are deprecated in APIs in v7.0. This options is for v7.0 or later. | *bool |


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

This PR fixes `fluentbit/plugins/open_search.md` that still referenced Elasticsearch
No issue has been created for this