### PR TITLE
feat: add rdkafka gem installation to Dockerfiles for fluent-watcher

### DIFF
--- a/cmd/fluent-watcher/fluentd/Dockerfile.amd64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.amd64
@@ -22,6 +22,8 @@ RUN apk update \
  && apk add --no-cache --virtual .build-deps \
         build-base linux-headers \
         ruby-dev gnupg \
+        bash \
+        openssl-dev \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.13.22 \
  && gem install json -v 2.6.2 \

--- a/cmd/fluent-watcher/fluentd/Dockerfile.amd64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.amd64
@@ -35,6 +35,7 @@ RUN apk update \
  && gem install elasticsearch -v 7.13.3 \
  && gem install elasticsearch-xpack -v 7.13.3 \
  && gem install fluent-plugin-detect-exceptions -v 0.0.14 \
+ && gem install rdkafka -v 0.19.0 \
  && gem install \
          fluent-plugin-s3 \
          fluent-plugin-grok-parser \

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64
@@ -43,6 +43,7 @@ RUN apt-get update \
  && gem install elasticsearch -v 7.13.3 \
  && gem install elasticsearch-xpack -v 7.13.3 \
  && gem install fluent-plugin-detect-exceptions -v 0.0.14 \
+ && gem install rdkafka -v 0.19.0 \
  && gem install \
          fluent-plugin-s3 \
          fluent-plugin-grok-parser \

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64
@@ -28,7 +28,7 @@ RUN apt-get update \
             ca-certificates \
  && buildDeps=" \
       make gcc g++ libc-dev \
-      wget bzip2 gnupg dirmngr \
+      wget bzip2 gnupg dirmngr bash openssl build-essential  \
     " \
  && apt-get install -y --no-install-recommends $buildDeps \
  && echo 'gem: --no-document' >> /etc/gemrc \
@@ -64,7 +64,7 @@ RUN apt-get update \
  && cd /tmp && tar -xjf jemalloc-5.3.0.tar.bz2 && cd jemalloc-5.3.0/ \
  && ./configure && make \
  && mv lib/libjemalloc.so.2 /usr/lib \
- && apt-get purge -y --auto-remove \
+ && apt-get purge -y --allow-remove-essential --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \
                   $buildDeps \
  && rm -rf /var/lib/apt/lists/* \

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
@@ -19,7 +19,7 @@ RUN apt-get update \
             ca-certificates \
  && buildDeps=" \
       make gcc g++ libc-dev \
-      wget bzip2 gnupg dirmngr\
+      wget bzip2 gnupg dirmngr bash openssl build-essential \
     " \
  && apt-get install -y --no-install-recommends $buildDeps \
  && echo 'gem: --no-document' >> /etc/gemrc \

--- a/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
+++ b/cmd/fluent-watcher/fluentd/Dockerfile.arm64.base
@@ -33,6 +33,7 @@ RUN apt-get update \
  && gem install elasticsearch -v 7.13.3 \
  && gem install elasticsearch-xpack -v 7.13.3 \
  && gem install fluent-plugin-detect-exceptions -v 0.0.14 \
+ && gem install rdkafka -v 0.19.0 \
  && gem install \
          fluent-plugin-s3 \
          fluent-plugin-grok-parser \


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Hi, I want to use [Kafka FluentD plugin](https://github.com/fluent/fluent-plugin-kafka), but the base library [ruby-kafka is deprecated](https://github.com/zendesk/ruby-kafka?tab=readme-ov-file#deprecation-notice), which is also not compatible with my Strimzi Kafka installation. Then I tried to use the new rdkafka part of this plugin, but it fails with the fluent-operator image because it needs to have the C rdkafka library installed as well. I tried to create my own image, but now I want to publish this fix for all users.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
- rdkafka part of fluent-plugin-kafka can be now used with fluent-operator FluentD image.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```