### PR TITLE
feat: Add livenessProbe to FluentBit template (fluentbit-fluentBit.yaml)

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -73,6 +73,19 @@ spec:
   volumes:
 {{ toYaml .Values.fluentbit.additionalVolumes | indent 4 }}
   {{- end }}
+{{- with .Values.fluentbit.livenessProbe }}
+{{- if .enabled }}
+  livenessProbe:
+    httpGet:
+      port: 2020
+      path: /
+    initialDelaySeconds: {{ .initialDelaySeconds }}
+    periodSeconds: {{ .periodSeconds }}
+    timeoutSeconds: {{ .timeoutSeconds }}
+    successThreshold: {{ .successThreshold }}
+    failureThreshold: {{ .failureThreshold }}
+{{- end }}
+{{- end }}
   {{- if .Values.fluentbit.additionalVolumesMounts }}
   volumesMounts:
 {{ toYaml .Values.fluentbit.additionalVolumesMounts | indent 4 }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -86,6 +86,14 @@ fluentbit:
     tlsConfig: {}
     relabelings: []
     metricRelabelings: []
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 15
+    successThreshold: 1
+    failureThreshold: 8
+
   image:
     repository: "ghcr.io/fluent/fluent-operator/fluent-bit"
     tag: "3.1.8"


### PR DESCRIPTION
### What this PR does / why we need it:
There is FluentBit object built-in helm chart. Since FluentBit supports livenessProbes in CRD, it will be good to have ability to define health probe for built-in FluentBit object.



### Which issue(s) this PR fixes:
We got case with fluent-bit processes hang, metrics/api endpoints are not respond in this case, livenessProbe will help a lot.
