### PR TITLE
feat: Add support for reload_after, sniffer_class_name es output parameters

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/output/es.go
+++ b/apis/fluentd/v1alpha1/plugins/output/es.go
@@ -43,6 +43,8 @@ type ElasticsearchCommon struct {
 	FailOnPuttingTemplateRetryExceeded *bool `json:"failOnPuttingTemplateRetryExceeded,omitempty"`
 	// Optional, Indicates that the plugin should reset connection on any error (reconnect on next send) (default: false)
 	ReconnectOnError *bool `json:"reconnectOnError,omitempty"`
+	// Optional, When ReloadConnections true, this is the integer number of operations after which the plugin will reload the connections. The default value is 10000.
+	ReloadAfter *uint32 `json:"reloadAfter,omitempty"`
 	// Optional, Automatically reload connection after 10000 documents (default: true)
 	ReloadConnections *bool `json:"reloadConnections,omitempty"`
 	// Optional, Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the request, this can be useful to quickly remove a dead node from the list of addresses (default: false)
@@ -50,6 +52,8 @@ type ElasticsearchCommon struct {
 	// Optional, HTTP Timeout (default: 5)
 	// +kubebuilder:validation:Pattern:="^\\d+(s|m|h|d)$"
 	RequestTimeout *string `json:"requestTimeout,omitempty"`
+	// Optional, Provide a different sniffer class name
+	SnifferClassName *string `json:"snifferClassName,omitempty"`
 	// Optional, Suppress '[types removal]' warnings on elasticsearch 7.x
 	SuppressTypeName *bool `json:"suppressTypeName,omitempty"`
 	// Optional, Enable Index Lifecycle Management (ILM)

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -467,6 +467,10 @@ func (o *Output) elasticsearchPluginCommon(common *ElasticsearchCommon, parent *
 		parent.InsertPairs("reconnect_on_error", fmt.Sprint(*common.ReconnectOnError))
 	}
 
+	if common.ReloadAfter != nil {
+		parent.InsertPairs("reload_after", fmt.Sprint(*common.ReloadAfter))
+	}
+
 	if common.ReloadConnections != nil {
 		parent.InsertPairs("reload_connections", fmt.Sprint(*common.ReloadConnections))
 	}
@@ -477,6 +481,10 @@ func (o *Output) elasticsearchPluginCommon(common *ElasticsearchCommon, parent *
 
 	if common.RequestTimeout != nil {
 		parent.InsertPairs("request_timeout", fmt.Sprint(*common.RequestTimeout))
+	}
+
+	if common.SnifferClassName != nil {
+		parent.InsertPairs("sniffer_class_name", fmt.Sprint(*common.SnifferClassName))
 	}
 
 	if common.SuppressTypeName != nil {

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -803,6 +803,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -821,6 +827,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -1118,6 +1128,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -1136,6 +1152,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -803,6 +803,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -821,6 +827,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -1118,6 +1128,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -1136,6 +1152,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -803,6 +803,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -821,6 +827,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -1118,6 +1128,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -1136,6 +1152,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -803,6 +803,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -821,6 +827,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -1118,6 +1128,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -1136,6 +1152,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation

--- a/docs/plugins/fluentd/output/es.md
+++ b/docs/plugins/fluentd/output/es.md
@@ -23,9 +23,11 @@ Elasticsearch defines the parameters for out_es output plugin
 | maxRetryPuttingTemplate | Optional, You can specify times of retry putting template (default: 10) | *uint32 |
 | failOnPuttingTemplateRetryExceeded | Optional, Indicates whether to fail when max_retry_putting_template is exceeded. If you have multiple output plugin, you could use this property to do not fail on fluentd statup (default: false) | *bool |
 | reconnectOnError | Optional, Indicates that the plugin should reset connection on any error (reconnect on next send) (default: false) | *bool |
+| reloadAfter | Optional, When ReloadConnections true, this is the integer number of operations after which the plugin will reload the connections. The default value is 10000. | *uint32 |
 | reloadConnections | Optional, Automatically reload connection after 10000 documents (default: true) | *bool |
 | reloadOnFailure | Optional, Indicates that the elasticsearch-transport will try to reload the nodes addresses if there is a failure while making the request, this can be useful to quickly remove a dead node from the list of addresses (default: false) | *bool |
 | requestTimeout | Optional, HTTP Timeout (default: 5) | *string |
+| snifferClassName | Optional, Provide a different sniffer class name | *string |
 | suppressTypeName | Optional, Suppress '[types removal]' warnings on elasticsearch 7.x | *bool |
 | enableIlm | Optional, Enable Index Lifecycle Management (ILM) | *bool |
 | ilmPolicyId | Optional, Specify ILM policy id | *string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -9287,6 +9287,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -9305,6 +9311,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -9602,6 +9612,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -9620,6 +9636,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -38097,6 +38117,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -38115,6 +38141,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -38412,6 +38442,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -38430,6 +38466,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -9287,6 +9287,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -9305,6 +9311,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -9602,6 +9612,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -9620,6 +9636,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -38097,6 +38117,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -38115,6 +38141,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation
@@ -38412,6 +38442,12 @@ spec:
                             reset connection on any error (reconnect on next send)
                             (default: false)'
                           type: boolean
+                        reloadAfter:
+                          description: Optional, When ReloadConnections true, this
+                            is the integer number of operations after which the plugin
+                            will reload the connections. The default value is 10000.
+                          format: int32
+                          type: integer
                         reloadConnections:
                           description: 'Optional, Automatically reload connection
                             after 10000 documents (default: true)'
@@ -38430,6 +38466,10 @@ spec:
                         scheme:
                           description: 'Specify https if your Elasticsearch endpoint
                             supports SSL (default: http).'
+                          type: string
+                        snifferClassName:
+                          description: Optional, Provide a different sniffer class
+                            name
                           type: string
                         sslVerify:
                           description: Optional, Force certificate validation


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

CRDs in current form and operator itself lack support for `reload_after` and `sniffer_class_name` elasticsearch output parameters.


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```
No.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```
https://github.com/uken/fluent-plugin-elasticsearch?tab=readme-ov-file#sniffer-class-name
https://github.com/uken/fluent-plugin-elasticsearch?tab=readme-ov-file#reload-after
```