### PR TITLE
Update fluent-operator-clusterRole.yaml

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -39,7 +39,6 @@ rules:
       - secrets
       - configmaps
       - serviceaccounts
-      - configmaps
       - services
       - namespaces
     verbs:


### PR DESCRIPTION
Remove the redundant "configmaps" from resources.

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Remove the redundant "configmaps" in resources.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/fluent/fluent-operator/issues/1501

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```