### PR TITLE
Move dash so that labelKeys and removeKeys on separate line

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-loki.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-loki.yaml
@@ -114,12 +114,12 @@ spec:
 {{ .labels | toYaml | indent 6 }}
     {{ end -}}
     
-    {{ if .labelKeys -}}
+    {{- if .labelKeys }}
     labelKeys:
 {{ .labelKeys | toYaml | indent 6 }}
     {{ end -}}
 
-    {{ if .removeKeys -}}
+    {{- if .removeKeys }}
     removeKeys:
 {{ .removeKeys | toYaml | indent 6 }}
     {{ end -}}


### PR DESCRIPTION

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Adds a newline before the `fluentbit.output.loki.labelKeys` to prevent it from being appended to the previous block.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1508

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
None
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```