### PR TITLE
Pin GitHub actions on commit hash according to best practices

### DIFF
--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -168,7 +168,7 @@ jobs:
         with:
           go-version: 1.22.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -215,7 +215,7 @@ jobs:
         with:
           go-version: 1.22.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build and Push Image for Fluent Bit
         id: docker-build
@@ -234,7 +234,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       
       - name: Build and Push Fluent Bit Debug Image
         id: docker-build-debug

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -79,7 +79,7 @@ jobs:
             
       - name: docker metadata for building
         id: image-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
@@ -91,7 +91,7 @@ jobs:
 
       - name: docker tags for cloning
         id: image-tags
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             raw,latest
@@ -124,7 +124,7 @@ jobs:
 
       - name: docker metadata
         id: image-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           flavor: |
@@ -138,7 +138,7 @@ jobs:
 
       - name: docker tags for cloning
         id: image-tags
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           flavor: |
             latest=false

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -179,7 +179,7 @@ jobs:
           fetch-depth: 0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -226,7 +226,7 @@ jobs:
           fetch-depth: 0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -20,7 +20,7 @@ jobs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }}
 
@@ -75,7 +75,7 @@ jobs:
       labels: ${{ steps.image-metadata.outputs.labels }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             
       - name: docker metadata for building
         id: image-metadata
@@ -120,7 +120,7 @@ jobs:
       release_tags: ${{ steps.image-tags.outputs.tags }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: docker metadata
         id: image-metadata
@@ -174,7 +174,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -221,7 +221,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Build and Push Image for Fluent Bit
         id: docker-build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: ./cmd/fluent-watcher/fluentbit/Dockerfile
@@ -238,7 +238,7 @@ jobs:
       
       - name: Build and Push Fluent Bit Debug Image
         id: docker-build-debug
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: ./cmd/fluent-watcher/fluentbit/Dockerfile.debug

--- a/.github/workflows/build-fb-image.yaml
+++ b/.github/workflows/build-fb-image.yaml
@@ -164,7 +164,7 @@ jobs:
     name: Build Fluent Bit prod image
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: 1.22.0
 
@@ -211,7 +211,7 @@ jobs:
     name: Build Fluent Bit debug image
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: 1.22.0
 

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -89,14 +89,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
     
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}
@@ -145,14 +145,14 @@ jobs:
     needs: [build, determine-tags]
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: docker.io
           username: ${{ secrets.REGISTRY_USER }}

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
           platforms: linux/amd64,linux/arm64
     

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Configure image tags 
         id: image-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: |
             ${{ env.GHCR_REPO }}

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: cmd/fluent-watcher/fluentd/Dockerfile

--- a/.github/workflows/build-fluentd-image.yaml
+++ b/.github/workflows/build-fluentd-image.yaml
@@ -19,7 +19,7 @@ jobs:
       VERSION: ${{ steps.get-version.outputs.VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }}
       
@@ -81,7 +81,7 @@ jobs:
           - runs-on: ubuntu-24.04-arm # Builds arm64 on arm64 hosts 
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -109,7 +109,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -61,7 +61,7 @@ jobs:
             
       - name: docker metadata
         id: image-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: "ghcr.io/${{ env.GITHUB_IMAGE }}"
           tags: |
@@ -74,7 +74,7 @@ jobs:
 
       - name: docker tags for cloning
         id: image-tags
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           tags: |
             raw,latest

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -106,7 +106,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             
       - name: docker metadata
         id: image-metadata
@@ -98,7 +98,7 @@ jobs:
       - build-image-metadata
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -116,7 +116,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: ./cmd/fluent-manager/Dockerfile

--- a/.github/workflows/bump-fluent-bit-version.yaml
+++ b/.github/workflows/bump-fluent-bit-version.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate version format
         run: |

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           go-version: 1.22.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -86,7 +86,7 @@ jobs:
         with:
           go-version: 1.22.0 
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -117,7 +117,7 @@ jobs:
         with:
           go-version: 1.22.0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -151,7 +151,7 @@ jobs:
         with:
           go-version: 1.22.0
           
-      - uses: actions/cache@v4
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -174,7 +174,7 @@ jobs:
   #       with:
   #         go-version: 1.16.x
 
-  #     - uses: actions/cache@v4
+  #     - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
   #       with:
   #         path: ~/go/pkg/mod
   #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -98,7 +98,7 @@ jobs:
           curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.25.1/bin/linux/amd64/kubectl && sudo install kubectl /usr/local/bin/kubectl
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
           version: v3.6.3
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -157,7 +157,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -180,7 +180,7 @@ jobs:
   #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
   #       with:
   #         fetch-depth: 0
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,7 @@ jobs:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: 1.22.0
 
@@ -82,7 +82,7 @@ jobs:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: 1.22.0 
 
@@ -113,7 +113,7 @@ jobs:
       GO111MODULE: "on"
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: 1.22.0
 
@@ -147,7 +147,7 @@ jobs:
     name: Binary build
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: 1.22.0
           
@@ -170,7 +170,7 @@ jobs:
   #   name: Docker amd64 build
   #   steps:
   #     - name: Install Go
-  #       uses: actions/setup-go@v5
+  #       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
   #       with:
   #         go-version: 1.16.x
 

--- a/.github/workflows/release-tool.yaml
+++ b/.github/workflows/release-tool.yaml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure Git
         run: |
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.validate-and-prepare.outputs.release_branch }}-work
 

--- a/.github/workflows/scan-docker-image-action.yaml
+++ b/.github/workflows/scan-docker-image-action.yaml
@@ -34,7 +34,7 @@
       steps:
             
         - name: Login to ${{ inputs.source_registry }}
-          uses: docker/login-action@v3
+          uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
           with:
             registry: ${{ inputs.source_registry }}
             username: ${{ secrets.registry_username }}


### PR DESCRIPTION
For compliance with best practices and prevent supply chain attacks this PR pins all GitHub actions on their commit hash. 

Dependabot understands this format and will raise PRs for new releases (once a month with current dependabot configuration).

I made separate commits for each action that I pinned for traceability in the repo (would be great to merge this using a merge commit to keep that traceability).

For the reviewer you can navigate to each action and compare the hash related to a specific version as following example.

<img width="894" alt="image" src="https://github.com/user-attachments/assets/040a1972-84ce-4f27-accc-0a24b6fd7858" />
