### PR TITLE
(ci/fluentbit) fix: Adds permission to publish packages 

### DIFF
--- a/.github/workflows/build-fluentbit-image.yaml
+++ b/.github/workflows/build-fluentbit-image.yaml
@@ -223,6 +223,8 @@ jobs:
   manifest:
     name: Publish image manifests
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     needs: [build, build-debug, build-tags]
     steps:
       - name: Login to GHCR


### PR DESCRIPTION
The "publish fluentbit image" CI pipeline is currently failing with:

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/cbb1b290-d283-47b7-bd27-4b3ef19432fb" />

This is because the `manifest` job does not have permission to publish GH packages.