### PR TITLE
Fix Kubernetes Events DBSync config

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/input/kubernetes_events_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/input/kubernetes_events_types.go
@@ -61,7 +61,7 @@ func (k *KubernetesEvents) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 		kvs.Insert("DB", k.DB)
 	}
 	if k.DBSync != "" {
-		kvs.Insert("DB_Sync", k.DBSync)
+		kvs.Insert("DB.Sync", k.DBSync)
 	}
 	if k.IntervalSec != nil {
 		kvs.Insert("Interval_Sec", fmt.Sprint(*k.IntervalSec))


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Fixes a bug with the config generation of the Kubernetes Events input.

`DB_Sync` is not a valid configuration option, it should be `DB.Sync`.

Generated config:
```
[Input]
    Name    kubernetes_events
    Alias    system-events
    Tag    kube-events
    DB    /fluent-bit/tail/system-events-pos.db
    DB_Sync    normal
    Kube_URL    https://kubernetes.default.svc:443
    Kube_CA_File    /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
    Kube_Token_File    /var/run/secrets/kubernetes.io/serviceaccount/token
```

Error:
```
[2025/04/04 01:53:01] [error] [config] kubernetes_events: unknown configuration property 'db_sync'. The following properties are allowed: kube_url, interval_sec, interval_nsec, tls.debug, tls.verify, tls.vhost, kube_ca_file, kube_ca_path, kube_token_file, kube_token_ttl, kube_request_limit, kube_retention_time, kube_namespace, db, and db.sync.
```

### Which issue(s) this PR fixes:
Cannot find any pre-existing issue

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
