### PR TITLE
feat(charts): Add ability for custom `positionDB` for `FluentBit`

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -22,8 +22,7 @@ spec:
 {{ toYaml .Values.fluentbit.imagePullSecrets | indent 4 }}
   {{- end }}
   positionDB:
-    hostPath:
-      path: /var/lib/fluent-bit/
+{{- toYaml .Values.fluentbit.positionDB | nindent 4 }}
   resources:
 {{- toYaml .Values.fluentbit.resources | nindent 4  }}
   fluentBitConfigName: fluent-bit-config

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -120,6 +120,12 @@ fluentbit:
   # Specify additional custom annotations for fluentbit-serviceaccount
   serviceAccountAnnotations: {}
 
+  # Specify storage for position db. You will use it if tail input is enabled.
+  ## Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#volumesource-v1-core
+  positionDB:
+    hostPath:
+      path: /var/lib/fluent-bit/
+
   ## Reference to one or more secrets to be used when pulling images
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

When `kind: FluentBit` is created using the official HELM chart, `positionDB` is locked to `hostPath.path: /var/lib/fluent-bit/`:
https://github.com/fluent/fluent-operator/blob/07df44ddb20e305570cedc6e87d500ca6bee87e3/charts/fluent-operator/templates/fluentbit-fluentBit.yaml#L24-L26

I prefer flexibility: the user can replace this value.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1547

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
