### PR TITLE
feat(helm/fluent-operator): add option to disable rbac creation

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.enable }}
+{{- if and .Values.operator.enable .Values.operator.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/fluent-operator/templates/fluent-operator-clusterRoleBinding.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRoleBinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.operator.enable }}
+{{- if and .Values.operator.enable .Values.operator.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -38,6 +38,9 @@ operator:
   priorityClassName: ""
   # Pod security context for Fluent Operator. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   podSecurityContext: {}
+  rbac:
+    # -- Specifies whether to create the ClusterRole and ClusterRoleBinding.
+    create: true
   # Container security context for Fluent Operator container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext: {}
   # Fluent Operator resources. Usually user needn't to adjust these.


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Enable or disable ClusterRole and RoleBinding creation.
The use case is to allow users to use this chart in clusters where creating such objetcs is not allowed by helm deployment.
Also, it's adding the ability to customize the rules, as not all of them are required for the operator to work.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes (https://github.com/fluent/helm-charts/issues/215)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
None

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
To use this feature, simply update a propertie  in the values.
```docs
...
operator:
  rbac:
    create: true
...
```

* set `true` for enable but it's default value.
* set `false` for disable.

