### PR TITLE
Add support for compression to the Fluentd HTTP output plugin

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/output/http.go
+++ b/apis/fluentd/v1alpha1/plugins/output/http.go
@@ -49,4 +49,7 @@ type Http struct {
 	ErrorResponseAsUnrecoverable *bool `json:"errorResponseAsUnrecoverable,omitempty"`
 	// The list of retryable response codes. If the response code is included in this list, out_http retries the buffer flush.
 	RetryableResponseCodes *string `json:"retryableResponseCodes,omitempty"`
+	// Compress enables the given compression method for HTTP requests.
+	// +kubebuilder:validation:Enum:=text;gzip
+	Compress *string `json:"compress,omitempty"`
 }

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -387,6 +387,10 @@ func (o *Output) httpPlugin(parent *params.PluginStore, loader plugins.SecretLoa
 		parent.InsertPairs("retryable_response_codes", fmt.Sprint(*o.Http.RetryableResponseCodes))
 	}
 
+	if o.Http.Compress != nil {
+		parent.InsertPairs("compress", fmt.Sprint(*o.Http.Compress))
+	}
+
 	return parent
 }
 

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -1868,6 +1868,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -1868,6 +1868,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -1868,6 +1868,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -1868,6 +1868,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters

--- a/docs/plugins/fluentd/output/http.md
+++ b/docs/plugins/fluentd/output/http.md
@@ -25,3 +25,4 @@ Http defines the parameters for out_http output plugin
 | tlsCiphers | TlsCiphers defines the cipher suites configuration of TLS. | *string |
 | errorResponseAsUnrecoverable | Raise UnrecoverableError when the response code is not SUCCESS. | *bool |
 | retryableResponseCodes | The list of retryable response codes. If the response code is included in this list, out_http retries the buffer flush. | *string |
+| compress | Compress enables the given compression method for HTTP requests. | *string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -10360,6 +10360,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters
@@ -39197,6 +39204,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -10360,6 +10360,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters
@@ -39197,6 +39204,13 @@ spec:
                                   type: object
                               type: object
                           type: object
+                        compress:
+                          description: Compress enables the given compression method
+                            for HTTP requests.
+                          enum:
+                          - text
+                          - gzip
+                          type: string
                         contentType:
                           description: ContentType defines Content-Type for HTTP request.
                             out_http automatically set Content-Type for built-in formatters


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

The fluentd HTTP output plugin is currently missing support for [the `compress` field](https://docs.fluentd.org/output/http#compress).

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added support for HTTP request compression to the Fluentd HTTP output plugin configuration.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A