### PR TITLE
Fixed nil pointer dereference (panic) when port numbers are unset

### DIFF
--- a/pkg/operator/sts.go
+++ b/pkg/operator/sts.go
@@ -221,10 +221,11 @@ func makeFluentdPorts(fd fluentdv1alpha1.Fluentd) []corev1.ContainerPort {
 	globalInputs := fd.Spec.GlobalInputs
 	for _, input := range globalInputs {
 		if input.Forward != nil {
-			forwardPort := *input.Forward.Port
-			if forwardPort == 0 {
-				forwardPort = DefaultForwardPort
+			forwardPort := DefaultForwardPort
+			if input.Forward.Port != nil {
+				forwardPort = *input.Forward.Port
 			}
+
 			ports = append(ports, corev1.ContainerPort{
 				Name:          DefaultForwardName,
 				ContainerPort: forwardPort,
@@ -233,10 +234,11 @@ func makeFluentdPorts(fd fluentdv1alpha1.Fluentd) []corev1.ContainerPort {
 			continue
 		}
 		if input.Http != nil {
-			httpPort := *input.Http.Port
-			if httpPort == 0 {
-				httpPort = DefaultHttpPort
+			httpPort := DefaultHttpPort
+			if input.Http.Port != nil {
+				httpPort = *input.Http.Port
 			}
+
 			ports = append(ports, corev1.ContainerPort{
 				Name:          DefaultHttpName,
 				ContainerPort: httpPort,


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

When `spec.globalInputs/*/forward` is non-nil, but the port is unset, the operator panics and crashes. This PR adds a nil check to prevent this.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed the operator panicking when Fluentd global inputs are set but no port is provided
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A