### PR TITLE
Added the ability to set `Owner_References` on fluentbit kubernetes filter

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/filter/kubernetes_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/filter/kubernetes_types.go
@@ -103,6 +103,8 @@ type Kubernetes struct {
 	// Include Kubernetes namespace metadata only and no pod metadata.
 	// If this is set, the values of Labels and Annotations are ignored.
 	NamespaceMetadataOnly *bool `json:"namespaceMetadataOnly,omitempty"`
+	// Include Kubernetes owner references in the extra metadata.
+	OwnerReferences *bool `json:"ownerReferences,omitempty"`
 }
 
 func (_ *Kubernetes) Name() string {
@@ -216,6 +218,9 @@ func (k *Kubernetes) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if k.NamespaceMetadataOnly != nil {
 		kvs.Insert("Namespace_Metadata_Only", fmt.Sprint(*k.NamespaceMetadataOnly))
+	}
+	if k.OwnerReferences != nil {
+		kvs.Insert("Owner_References", fmt.Sprint(*k.OwnerReferences))
 	}
 	return kvs, nil
 }

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfilters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfilters.yaml
@@ -279,6 +279,10 @@ spec:
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
                           type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
+                          type: boolean
                         regexParser:
                           description: |-
                             Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_filters.yaml
@@ -279,6 +279,10 @@ spec:
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
                           type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
+                          type: boolean
                         regexParser:
                           description: |-
                             Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.

--- a/config/crd/bases/fluentbit.fluent.io_clusterfilters.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterfilters.yaml
@@ -279,6 +279,10 @@ spec:
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
                           type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
+                          type: boolean
                         regexParser:
                           description: |-
                             Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.

--- a/config/crd/bases/fluentbit.fluent.io_filters.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_filters.yaml
@@ -279,6 +279,10 @@ spec:
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
                           type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
+                          type: boolean
                         regexParser:
                           description: |-
                             Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.

--- a/docs/plugins/fluentbit/filter/kubernetes.md
+++ b/docs/plugins/fluentbit/filter/kubernetes.md
@@ -39,3 +39,4 @@ Kubernetes filter allows to enrich your log files with Kubernetes metadata. <br 
 | namespaceLabels | Include Kubernetes namespace resource labels in the extra metadata. | *bool |
 | namespaceAnnotations | Include Kubernetes namespace resource annotations in the extra metadata. | *bool |
 | namespaceMetadataOnly | Include Kubernetes namespace metadata only and no pod metadata. If this is set, the values of Labels and Annotations are ignored. | *bool |
+| ownerReferences | Include Kubernetes owner references in the extra metadata. | *bool |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -278,6 +278,10 @@ spec:
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
                           type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
+                          type: boolean
                         regexParser:
                           description: |-
                             Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.
@@ -14918,6 +14922,10 @@ spec:
                           description: |-
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
+                          type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
                           type: boolean
                         regexParser:
                           description: |-

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -278,6 +278,10 @@ spec:
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
                           type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
+                          type: boolean
                         regexParser:
                           description: |-
                             Set an alternative Parser to process record Tag and extract pod_name, namespace_name, container_name and docker_id.
@@ -14918,6 +14922,10 @@ spec:
                           description: |-
                             Include Kubernetes namespace metadata only and no pod metadata.
                             If this is set, the values of Labels and Annotations are ignored.
+                          type: boolean
+                        ownerReferences:
+                          description: Include Kubernetes owner references in the
+                            extra metadata.
                           type: boolean
                         regexParser:
                           description: |-


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

[This config value](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes#configuration-parameters) is missing from the fluentbit filter CRD.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added the ability to set `Owner_References` on fluentbit kubernetes filter
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A
