### PR TITLE
Added the ability to set `DB.locking` on fluentbit tail inputs

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/input/tail_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/input/tail_types.go
@@ -59,6 +59,8 @@ type Tail struct {
 	// Set a default synchronization (I/O) method. Values: Extra, Full, Normal, Off.
 	// +kubebuilder:validation:Enum:=Extra;Full;Normal;Off
 	DBSync string `json:"dbSync,omitempty"`
+	// Specify that the database will be accessed only by Fluent Bit.
+	DBLocking *bool `json:"dbLocking,omitempty"`
 	// Set a limit of memory that Tail plugin can use when appending data to the Engine.
 	// If the limit is reach, it will be paused; when the data is flushed it resumes.
 	MemBufLimit string `json:"memBufLimit,omitempty"`
@@ -152,6 +154,9 @@ func (t *Tail) Params(_ plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if t.DBSync != "" {
 		kvs.Insert("DB.Sync", t.DBSync)
+	}
+	if t.DBLocking != nil {
+		kvs.Insert("DB.locking", fmt.Sprint(*t.DBLocking))
 	}
 	if t.MemBufLimit != "" {
 		kvs.Insert("Mem_Buf_Limit", t.MemBufLimit)

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterinputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterinputs.yaml
@@ -692,6 +692,10 @@ spec:
                     description: Specify the database file to keep track of monitored
                       files and offsets.
                     type: string
+                  dbLocking:
+                    description: Specify that the database will be accessed only by
+                      Fluent Bit.
+                    type: boolean
                   dbSync:
                     description: 'Set a default synchronization (I/O) method. Values:
                       Extra, Full, Normal, Off.'

--- a/config/crd/bases/fluentbit.fluent.io_clusterinputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterinputs.yaml
@@ -692,6 +692,10 @@ spec:
                     description: Specify the database file to keep track of monitored
                       files and offsets.
                     type: string
+                  dbLocking:
+                    description: Specify that the database will be accessed only by
+                      Fluent Bit.
+                    type: boolean
                   dbSync:
                     description: 'Set a default synchronization (I/O) method. Values:
                       Extra, Full, Normal, Off.'

--- a/docs/plugins/fluentbit/input/tail.md
+++ b/docs/plugins/fluentbit/input/tail.md
@@ -18,6 +18,7 @@ The Tail input plugin allows to monitor one or several text files. <br /> It has
 | skipLongLines | When a monitored file reach it buffer capacity due to a very long line (Buffer_Max_Size), the default behavior is to stop monitoring that file. Skip_Long_Lines alter that behavior and instruct Fluent Bit to skip long lines and continue processing other lines that fits into the buffer size. | *bool |
 | db | Specify the database file to keep track of monitored files and offsets. | string |
 | dbSync | Set a default synchronization (I/O) method. Values: Extra, Full, Normal, Off. | string |
+| dbLocking | Specify that the database will be accessed only by Fluent Bit. | *bool |
 | memBufLimit | Set a limit of memory that Tail plugin can use when appending data to the Engine. If the limit is reach, it will be paused; when the data is flushed it resumes. | string |
 | parser | Specify the name of a parser to interpret the entry as a structured message. | string |
 | key | When a message is unstructured (no parser applied), it's appended as a string under the key name log. This option allows to define an alternative name for that key. | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -2806,6 +2806,10 @@ spec:
                     description: Specify the database file to keep track of monitored
                       files and offsets.
                     type: string
+                  dbLocking:
+                    description: Specify that the database will be accessed only by
+                      Fluent Bit.
+                    type: boolean
                   dbSync:
                     description: 'Set a default synchronization (I/O) method. Values:
                       Extra, Full, Normal, Off.'

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -2806,6 +2806,10 @@ spec:
                     description: Specify the database file to keep track of monitored
                       files and offsets.
                     type: string
+                  dbLocking:
+                    description: Specify that the database will be accessed only by
+                      Fluent Bit.
+                    type: boolean
                   dbSync:
                     description: 'Set a default synchronization (I/O) method. Values:
                       Extra, Full, Normal, Off.'


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

[This config value](https://docs.fluentbit.io/manual/pipeline/inputs/tail#config) is missing from the fluentbit input CRD.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added the ability to set `DB.locking` on fluentbit tail inputs
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A
