### PR TITLE
Support setting fluent-bit bufferChunkSize for tail input

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
@@ -28,6 +28,9 @@ spec:
     {{- with .Values.fluentbit.input.tail.bufferMaxSize }}
     bufferMaxSize: {{ . | quote }}
     {{- end }}
+    {{- with .Values.fluentbit.input.tail.bufferChunkSize }}
+    bufferChunkSize: {{ . | quote }}
+    {{- end }}
     skipLongLines: {{ .Values.fluentbit.input.tail.skipLongLines }}
     db: /fluent-bit/tail/pos.db
     dbSync: Normal

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -225,6 +225,7 @@ fluentbit:
       refreshIntervalSeconds: 10
       memBufLimit: 100MB
       bufferMaxSize: ""
+      bufferChunkSize: ""
       path: "/var/log/containers/*.log"
       skipLongLines: true
       readFromHead: false


### PR DESCRIPTION
In our use case we would like to customize the bufferChunkSize dependent on the client need and we see that the property is not exposed yet in the helmchart even though it is already in the crd. 