### PR TITLE
Fix fluentbit service selector not using pod labels when defined

### DIFF
--- a/pkg/operator/fluent-bit-service.go
+++ b/pkg/operator/fluent-bit-service.go
@@ -29,6 +29,11 @@ func MakeFluentbitService(fb fluentbitv1alpha2.FluentBit) *corev1.Service {
 		labels = fb.Labels
 	}
 
+	podLabelSelector := fb.Labels
+	if len(fb.Spec.Labels) > 0 {
+		podLabelSelector = fb.Spec.Labels
+	}
+
 	var FluentBitMetricsPort int32
 	if fb.Spec.MetricsPort != 0 {
 		FluentBitMetricsPort = fb.Spec.MetricsPort
@@ -43,7 +48,7 @@ func MakeFluentbitService(fb fluentbitv1alpha2.FluentBit) *corev1.Service {
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: fb.Labels,
+			Selector: podLabelSelector,
 			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

When `spec.labels` is defined, it is used to label created daemonset pods instead of `metadata.labels`. This causes the service, which always uses `metadata.labels`, to not select pods in some cases.

Unfortunately, because `spec.labels` is defined as `map[string]string` instead of a `*map[string]string`, it's not possible to tell the difference between a null `spec.labels` value (`labels: ~`, `labels: null`, or `labels` not set) and an empty `spec.labels` value (`labels: {}`). I think it's highly unlikely that anybody is doing this today, but if so, this could possibly be a breaking change.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
N/A

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed fluent bit service not always selecting pods when pod labels are set via `spec.labels`.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
N/A
