### PR TITLE
renovate: Use GitHub app to retrieve a token

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,13 +15,15 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: write
-      pull-requests: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@5712c6a41dea6cdf32c72d92a763bd417e6606aa # v44.0.5
@@ -30,6 +32,6 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
         env:
           LOG_LEVEL: ${{ env.ACTIONS_STEP_DEBUG == 'true' && 'debug' || 'info' }}
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_REPOSITORIES: ${{ steps.app-token.outputs.token }}
           RENOVATE_ALLOW_SCRIPTS: true
           RENOVATE_SEPARATE_MAJOR_MINOR: false


### PR DESCRIPTION
As Renovate will run with a different token, there is no need for
specific workflow permissions anymore.

Instead the GitHub app should have sufficient permissions to create a
PullRequest on the repo.

See https://github.com/actions/create-github-app-token/blob/main/README.md
on instructions how to add the GitHub App.

Please note we need to configure following on the repo settings:

variable RENOVATE_APP_ID
secret   RENOVATE_PRIVATE_KEY

I named it specific like this so we can dedicate this app specifically
to Renovate and therefore also keep permissions limited to the Renovate
usecase.

We can test by rerunning the renovate workflow on this PR after we put the GitHub App and variables and secrets in place on this repo.
