### PR TITLE
Add missing multiline ClusterFilter values

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterfilter-multiline.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterfilter-multiline.yaml
@@ -18,6 +18,12 @@ spec:
       emitterType: {{ .Values.fluentbit.filter.multiline.emitterType }}
       flushMs: {{ .Values.fluentbit.filter.multiline.flushMs }}
       parser: "{{- join "," .Values.fluentbit.filter.multiline.parsers -}}"
+      {{- if .Values.fluentbit.filter.multiline.mode }}
+      mode: {{ .Values.fluentbit.filter.multiline.mode }}
+      {{- end }}
+      {{- if .Values.fluentbit.filter.multiline.emitterName }}
+      emitterName: {{ .Values.fluentbit.filter.multiline.emitterName }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/templates/fluentbit-clusterfilter-multiline.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterfilter-multiline.yaml
@@ -13,7 +13,10 @@ spec:
   filters:
   - multiline:
       keyContent: {{ .Values.fluentbit.filter.multiline.keyContent | quote }}
+      buffer: {{ .Values.fluentbit.filter.multiline.buffer }}
       emitterMemBufLimit: {{ .Values.fluentbit.filter.multiline.emitterMemBufLimit }}
+      emitterType: {{ .Values.fluentbit.filter.multiline.emitterType }}
+      flushMs: {{ .Values.fluentbit.filter.multiline.flushMs }}
       parser: "{{- join "," .Values.fluentbit.filter.multiline.parsers -}}"
 {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -388,6 +388,10 @@ fluentbit:
       emitterMemBufLimit: 120
       emitterType: memory
       flushMs: 2000
+      # Optional: mode can be either "parser" or "partial_message"
+      # mode: parser
+      # Optional: Name for the emitter input instance which re-emits the completed records at the beginning of the pipeline.
+      # emitterName: my-emitter
       parsers:
         - go
         - python

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -383,8 +383,11 @@ fluentbit:
     multiline:
       enable: false
       keyContent: log
+      buffer: false
       # emitterMemBufLimit 120 (MB)
       emitterMemBufLimit: 120
+      emitterType: memory
+      flushMs: 2000
       parsers:
         - go
         - python


### PR DESCRIPTION
### What this PR does / why we need it:
- adds missing values to the multiline ClusterFilter object

### Which issue(s) this PR fixes:
Fixes https://github.com/fluent/fluent-operator/issues/1580

### Does this PR introduced a user-facing change?
```release-note
None
```

### Additional documentation, usage docs, etc.:
```docs

```
