### PR TITLE
ci: Ensure helm tests run on changes to the chart

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -1,0 +1,56 @@
+name: Helm CI
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-*'
+    paths:
+      - ".github/workflows/helm-ci.yaml"
+      - "charts/**"
+      - "tests/**"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+
+env:
+  KUBECTL_VERSION: v1.25.1
+  HELM_VERSION: v3.17.2
+
+jobs:
+  helm-tests:
+    name: helm e2e tests
+    runs-on: ubuntu-22.04
+
+    timeout-minutes: 30
+
+    env:
+      GO111MODULE: "on"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Setup kubectl
+        uses: marcofranssen/setup-kubectl@d81bf181729cee2bc813ac2ea2f74dec90f01f99 # v1.3.0
+        with:
+          kubectlVersion: ${{ env.KUBECTL_VERSION }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Install dependences
+        run: make ginkgo kind
+
+      - name: Run helm e2e tests
+        run: make helm-e2e

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -116,40 +116,6 @@ jobs:
       - name: Run e2e tests
         run:  make e2e
 
-  helm_tests:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    name: helm e2e tests
-    env:
-      GO111MODULE: "on"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Install Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
-        with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
-
-      - name: Setup kubectl
-        uses: marcofranssen/setup-kubectl@d81bf181729cee2bc813ac2ea2f74dec90f01f99 # v1.3.0
-        with:
-          kubectlVersion: ${{ env.KUBECTL_VERSION }}
-
-      - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      - name: Install dependences
-        run: make ginkgo kind
-
-      - name: Run helm e2e tests
-        run: make helm-e2e
-
   build:
     runs-on: ubuntu-22.04
     timeout-minutes: 30


### PR DESCRIPTION
This ensures PRs, like this will run the helm ci

https://github.com/fluent/fluent-operator/pull/1585

Moved it out of the main workflow so it doesn't affect running other workflows that shouldn't be required so we can have bit more finegraining on the paths.