### PR TITLE
Support both IPv4 and IPv6 addresses in http_listen configuration

### DIFF
--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
@@ -97,7 +97,7 @@ type Service struct {
 	// enable Health check feature at http://127.0.0.1:2020/api/v1/health Note: Enabling this will not automatically configure kubernetes to use fluentbit's healthcheck endpoint
 	HealthCheck *bool `json:"healthCheck,omitempty"`
 	// Address to listen
-	// +kubebuilder:validation:Pattern:="^\\d{1,3}.\\d{1,3}.\\d{1,3}.\\d{1,3}$"
+	// +kubebuilder:validation:Pattern:="^(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$"
 	HttpListen string `json:"httpListen,omitempty"`
 	// Port to listen
 	// +kubebuilder:validation:Minimum:=1

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -345,7 +345,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbitconfigs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_fluentbitconfigs.yaml
@@ -377,7 +377,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen

--- a/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -345,7 +345,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen

--- a/config/crd/bases/fluentbit.fluent.io_fluentbitconfigs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbitconfigs.yaml
@@ -377,7 +377,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen

--- a/docs/best-practice/monitoring.md
+++ b/docs/best-practice/monitoring.md
@@ -5,7 +5,7 @@ Fluent Bit comes with a built-in HTTP Server. According to the official [documen
 ```conf
 [SERVICE]
     HTTP_Server  On
-    HTTP_Listen  0.0.0.0
+    HTTP_Listen  '::'
     HTTP_PORT    2020
 ```
 
@@ -29,7 +29,7 @@ spec:
     matchLabels:
       fluentbit.fluent.io/enabled: 'true'
   service:
-    httpListen: 0.0.0.0
+    httpListen: '::'
     httpPort: 2020
     httpServer: true
     parsersFile: parsers.conf

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -1803,7 +1803,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen
@@ -16685,7 +16685,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -1803,7 +1803,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen
@@ -16685,7 +16685,7 @@ spec:
                     type: boolean
                   httpListen:
                     description: Address to listen
-                    pattern: ^\d{1,3}.\d{1,3}.\d{1,3}.\d{1,3}$
+                    pattern: ^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(([A-Fa-f0-9:]+:+)+[A-Fa-f0-9]*)$
                     type: string
                   httpPort:
                     description: Port to listen


### PR DESCRIPTION
Although `fluent-bit` supports IPv6, HTTP listening on an IPv6 address fails due to the address validation currently supporting IPv4 only. Improve the RegEx to support both IPv4 and IPv6 good enough™

Notes:
- the IPv6 RegEx part matches also the unspecified address `::`
- the IPv4 RegEx part was improved to match the dot delimiter `.` literally (it previously matched every character, due to missing escaping)

Fixes https://github.com/fluent/fluent-operator/issues/1615