### PR TITLE
Adjust RELEASE.md to also bump the helm chart for a release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -83,6 +83,10 @@ For new minor and major releases, create the `release-<major>.<minor>` branch st
 From now on, all work happens on the `release-<major>.<minor>` branch.
 
 Bump the version in the `VERSION` file in the root of the repository.
+Bump `version`, `appVersion` and the `version` of the dependencies in following files in this repo
+- [charts/fluet-operator/Chart.yaml](./charts/fluent-operator/Chart.yaml)
+- [charts/fluent-operator/charts/fluentd-crds/Chart.yaml](./charts/fluent-operator/charts/fluentd-crds/Chart.yaml)
+- [charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml](./charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml)
 
 Regenerate setup.yaml based on latest code and then commit the changed bundle.yaml to the `release-<major>.<minor>` branch:
 
@@ -127,7 +131,6 @@ For patch releases, cherry-pick the commits from the release branch into the mas
 
 This repo includes a "development" chart in the [charts/](./charts/fluent-operator/) directory. For each release, this chart must be published to the [fluent/helm-charts](https://github.com/fluent/helm-charts/tree/main/charts/fluent-operator/) repository which is where Fluent Operators install the chart from. This is currently a manual process. Follow these instructions to update and publish the chart:
 
-- Bump `version` and `appVersion` in the [charts/fluet-operator/Chart.yaml](./charts/fluent-operator/Chart.yaml) file in this repo
 - Manually "sync" (copy, open a PR) the local [chart](./charts/fluent-operator) to [fluent/helm-charts](https://github.com/fluent/helm-charts/tree/main/charts/fluent-operator/)
 
 ## Fluentd/Fluent-bit Images


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

The current v3.4.0 release is not usable via HELM as the versions of the charts were not adjusted.
To prevent this in the future, I adjusted the release documentation.
For each release the version and appVersions should also be bumped.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
