### PR TITLE
charts: fix chart version and appVersion

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 3.3.0
+version: 3.4.0
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
 appVersion: "3.4.0"
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg
@@ -19,9 +19,9 @@ maintainers:
 dependencies:
   - name: fluent-bit-crds
     repository: "file://charts/fluent-bit-crds"
-    version: 3.3.0
+    version: 3.4.0
     condition: fluentbit.crdsEnable
   - name: fluentd-crds
     repository: "file://charts/fluentd-crds"
-    version: 3.3.0
+    version: 3.4.0
     condition: fluentd.crdsEnable

--- a/charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml
@@ -14,11 +14,11 @@ description: A Helm chart delivering fluenbt-bit controller CRDS
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
-appVersion: "3.3.0"
+appVersion: "3.4.0"

--- a/charts/fluent-operator/charts/fluentd-crds/Chart.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/Chart.yaml
@@ -14,11 +14,11 @@ description: A Helm chart delivering fluentd controller CRDS
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
-appVersion: "3.3.0"
+appVersion: "3.4.0"


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
The current v3.4.0 release is not usable with HELM as the version and appVersion of the chars were not updated.
Once this is merge the tag v3.4.0 should be forced pushed with those changes to fix the current release. Otherwise a v3.4.1 is needed.

Related to https://github.com/fluent/fluent-operator/pull/1619

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
