### PR TITLE
Make fluentbit livenessProbe more flexible

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -72,17 +72,10 @@ spec:
   volumes:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.fluentbit.livenessProbe }}
-  {{- if .enabled }}
+  {{- if .Values.fluentbit.livenessProbe.enabled }}
   livenessProbe:
-    httpGet:
-      port: 2020
-      path: /
-    initialDelaySeconds: {{ .initialDelaySeconds }}
-    periodSeconds: {{ .periodSeconds }}
-    timeoutSeconds: {{ .timeoutSeconds }}
-    successThreshold: {{ .successThreshold }}
-    failureThreshold: {{ .failureThreshold }}
+  {{- with omit .Values.fluentbit.livenessProbe "enabled" }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
   {{- with .Values.fluentbit.additionalVolumesMounts }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -95,6 +95,9 @@ fluentbit:
     metricRelabelings: []
   livenessProbe:
     enabled: true
+    httpGet:
+      port: 2020
+      path: /
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 15


### PR DESCRIPTION
We still encounter hangs during logs reopen (on rotation), fluent reloads. Seems that it's related to issue: https://github.com/fluent/fluent-bit/issues/5485

What we can do quick - is to analyze metrics of fluent (fluentbit_input_records_total) in livenessProbes and trigger pod restart if no logs on input during some time specified. 

I want to be able to use not only http probe, but any definition possible for livenessProbe. 

PR does not have breaking changes, yaml will be generated the same as in previous version. 