### PR TITLE
ClusterInput/ClusterOutput helm chart changes 

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
+++ b/charts/fluent-operator/templates/fluentbit-clusterinput-tail.yaml
@@ -32,6 +32,10 @@ spec:
     bufferChunkSize: {{ . | quote }}
     {{- end }}
     skipLongLines: {{ .Values.fluentbit.input.tail.skipLongLines }}
+    skipEmptyLines: {{ .Values.fluentbit.input.tail.skipEmptyLines }}
+    {{- if .Values.fluentbit.input.tail.ignoredOlder }}
+    ignoredOlder: {{ .Values.fluentbit.input.tail.ignoredOlder }}
+    {{- end }}
     db: /fluent-bit/tail/pos.db
     dbSync: Normal
     storageType: {{ .Values.fluentbit.input.tail.storageType }}

--- a/charts/fluent-operator/templates/fluentbit-output-kafka.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-kafka.yaml
@@ -10,6 +10,7 @@ metadata:
     fluentbit.fluent.io/enabled: "true"
     fluentbit.fluent.io/component: logging
 spec:
+  logLevel: "{{ .logLevel }}"
   matchRegex: (?:kube|service)\.(.*)
   kafka:
     brokers: {{ .brokers | quote }}

--- a/charts/fluent-operator/templates/fluentbit-output-loki.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-loki.yaml
@@ -36,6 +36,7 @@ metadata:
 spec:
   matchRegex: (?:kube|service)\.(.*)
   retry_limit: "{{ .retryLimit }}"
+  logLevel: "{{ .logLevel }}"
   loki:
     {{- with .host }}
     host: {{ . | quote }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -231,6 +231,7 @@ fluentbit:
       bufferChunkSize: ""
       path: "/var/log/containers/*.log"
       skipLongLines: true
+      skipEmptyLines: true
       readFromHead: false
       # Use storageType as "filesystem" if you want to use filesystem as the buffering mechanism for tail input.
       storageType: memory
@@ -296,6 +297,7 @@ fluentbit:
     #        vhost: "<Hostname to be used for TLS SNI extension>"
     kafka:
       enable: false
+      logLevel: info
       brokers: "<kafka broker list like xxx.xxx.xxx.xxx:9092,yyy.yyy.yyy.yyy:9092>"
       topics: ks-log
     opentelemetry: {}
@@ -321,6 +323,7 @@ fluentbit:
       # Switch for generation of fluentbit loki ClusterOutput (and loki basic auth http user and pass secrets if required)
       enable: false # Bool
       retryLimit: "no_limits"
+      logLevel: "info"
       host: 127.0.0.1 # String
       port: 3100 # Int
       # Either, give http{User,Password},tenantID string values specifying them directly


### PR DESCRIPTION
Change to control ClusterOutput logLevel for loki and kafka.
ClusterInput tail - ability to set ignoredOlder, skipEmptyLines by default.