### PR TITLE
Validate region and its value in Kinesis Output plugin

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/kinesis_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/kinesis_types.go
@@ -15,6 +15,8 @@ import (
 // https://github.com/aws/amazon-kinesis-streams-for-fluent-bit <br />
 type Kinesis struct {
 	// The AWS region.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	Region string `json:"region"`
 	// The name of the Kinesis Streams Delivery stream that you want log records sent to.
 	Stream string `json:"stream"`

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -2109,6 +2109,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -2109,6 +2109,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -2109,6 +2109,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -2109,6 +2109,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -6245,6 +6245,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).
@@ -35143,6 +35144,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -6245,6 +6245,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).
@@ -35143,6 +35144,7 @@ spec:
                     type: string
                   region:
                     description: The AWS region.
+                    minLength: 1
                     type: string
                   roleARN:
                     description: ARN of an IAM role to assume (for cross account access).


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1613

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Validate the region filed and its value in Kinesis output plugin. the region is required and is not allowed empty. 
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
