### PR TITLE
Add `workers` param for s3 output

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/s3_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/s3_types.go
@@ -65,7 +65,9 @@ type S3 struct {
 	// Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID.
 	ExternalId string `json:"ExternalId,omitempty"`
 	// Option to specify an AWS Profile for credentials.
-	Profile      string `json:"Profile,omitempty"`
+	Profile string `json:"Profile,omitempty"`
+	// Specify number of worker threads to use to output to S3
+	Workers      *int32 `json:"Workers,omitempty"`
 	*plugins.TLS `json:"tls,omitempty"`
 }
 
@@ -158,6 +160,9 @@ func (o *S3) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	}
 	if o.Profile != "" {
 		kvs.Insert("profile", o.Profile)
+	}
+	if o.Workers != nil {
+		kvs.Insert("workers", fmt.Sprint(*o.Workers))
 	}
 	if o.TLS != nil {
 		tls, err := o.TLS.Params(sl)

--- a/apis/fluentbit/v1alpha2/plugins/output/s3_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/s3_types_test.go
@@ -41,6 +41,7 @@ func TestOutput_S3_Params(t *testing.T) {
 		RetryLimit:               ptrAny(int32(1)),
 		ExternalId:               "external_id",
 		Profile:                  "my-profile",
+		Workers:                  ptrAny(int32(1)),
 	}
 
 	expected := params.NewKVs()
@@ -71,6 +72,7 @@ func TestOutput_S3_Params(t *testing.T) {
 	expected.Insert("retry_limit", "1")
 	expected.Insert("external_id", "external_id")
 	expected.Insert("profile", "my-profile")
+	expected.Insert("workers", "1")
 
 	kvs, err := s3.Params(sl)
 	g.Expect(err).NotTo(HaveOccurred())

--- a/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
@@ -948,6 +948,11 @@ func (in *S3) DeepCopyInto(out *S3) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Workers != nil {
+		in, out := &in.Workers, &out.Workers
+		*out = new(int32)
+		**out = **in
+	}
 	if in.TLS != nil {
 		in, out := &in.TLS, &out.TLS
 		*out = new(plugins.TLS)

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -3523,6 +3523,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/crds/fluentbit.fluent.io_outputs.yaml
@@ -3523,6 +3523,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -3523,6 +3523,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -3523,6 +3523,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/docs/plugins/fluentbit/output/s3.md
+++ b/docs/plugins/fluentbit/output/s3.md
@@ -32,4 +32,5 @@ The S3 output plugin, allows to flush your records into a S3 time series databas
 | RetryLimit | Integer value to set the maximum number of retries allowed. | *int32 |
 | ExternalId | Specify an external ID for the STS API, can be used with the role_arn parameter if your role requires an external ID. | string |
 | Profile | Option to specify an AWS Profile for credentials. | string |
+| Workers | Specify number of worker threads to use to output to S3 | *int32 |
 | tls |  | *[plugins.TLS](../tls.md) |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -7659,6 +7659,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer
@@ -36558,6 +36563,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -7659,6 +7659,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer
@@ -36558,6 +36563,11 @@ spec:
                     description: Use the S3 PutObject API, instead of the multipart
                       upload API.
                     type: boolean
+                  Workers:
+                    description: Specify number of worker threads to use to output
+                      to S3
+                    format: int32
+                    type: integer
                   tls:
                     description: Fluent Bit provides integrated support for Transport
                       Layer Security (TLS) and it predecessor Secure Sockets Layer


### PR DESCRIPTION
### What this PR does / why we need it:

The Operator does not pass the "workers" parameter to the S3 Output plugin. This PR is so that that parameter will be recognized and passed.

### Which issue(s) this PR fixes:

Fixes #1646

### Does this PR introduced a user-facing change?

```release-note
Support `Workers` parameter for S3 Output Plugin
```

### Additional documentation, usage docs, etc.:

```docs

```
