### PR TITLE
Bump fluent-bit-crds and fluentd-crds sub-charts to 3.4.2.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -127,7 +127,9 @@ For patch releases, cherry-pick the commits from the release branch into the mas
 
 This repo includes a "development" chart in the [charts/](./charts/fluent-operator/) directory. For each release, this chart must be published to the [fluent/helm-charts](https://github.com/fluent/helm-charts/tree/main/charts/fluent-operator/) repository which is where Fluent Operators install the chart from. This is currently a manual process. Follow these instructions to update and publish the chart:
 
-- Bump `version` and `appVersion` in the [charts/fluet-operator/Chart.yaml](./charts/fluent-operator/Chart.yaml) file in this repo
+- Bump `version` and `appVersion` in the [charts/fluent-operator/Chart.yaml](./charts/fluent-operator/Chart.yaml) file in this repo
+- Bump `version` and `appVersion` in the [charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml](./charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml) and [charts/fluent-operator/charts/fluentd-crds/Chart.yaml](./charts/fluent-operator/charts/fluentd-crds/Chart.yaml) directory
+- Bump the `fluent-bit-crds` and `fluentd-crds` version under `dependencies` in [charts/fluent-operator/Chart.yaml](./charts/fluent-operator/Chart.yaml)
 - Manually "sync" (copy, open a PR) the local [chart](./charts/fluent-operator) to [fluent/helm-charts](https://github.com/fluent/helm-charts/tree/main/charts/fluent-operator/)
 
 ## Fluentd/Fluent-bit Images

--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -19,9 +19,9 @@ maintainers:
 dependencies:
   - name: fluent-bit-crds
     repository: "file://charts/fluent-bit-crds"
-    version: 3.4.1
+    version: 3.4.2
     condition: fluentbit.crdsEnable
   - name: fluentd-crds
     repository: "file://charts/fluentd-crds"
-    version: 3.4.1
+    version: 3.4.2
     condition: fluentd.crdsEnable

--- a/charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml
+++ b/charts/fluent-operator/charts/fluent-bit-crds/Chart.yaml
@@ -14,7 +14,7 @@ description: A Helm chart delivering fluenbt-bit controller CRDS
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.1
+version: 3.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fluent-operator/charts/fluentd-crds/Chart.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/Chart.yaml
@@ -14,7 +14,7 @@ description: A Helm chart delivering fluentd controller CRDS
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.1
+version: 3.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Updates the `fluent-bit-crds` and `fluentd-crds` charts to v3.4.2 and updates RELEASE docs.

Once merged, this will be synced to https://github.com/fluent/helm-charts.
