### PR TITLE
ci: Fix "ct lint" action 

### DIFF
--- a/charts/fluent-operator/Chart.yaml
+++ b/charts/fluent-operator/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - fluent-bit
   - fluentd
   - operator
-version: 3.4.4
+version: 3.4.2
 # renovate: datasource=docker depName=ghcr.io/fluent/fluent-operator/fluent-operator
 appVersion: "3.4.0"
 icon: https://raw.githubusercontent.com/fluent/fluent-operator/master/docs/images/fluent-operator-icon.svg

--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    test: testing
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: fluent-operator
   name: fluent-operator

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-test: true
-
 # Set this to containerd or crio if you want to collect CRI format logs
 containerRuntime: docker
 #  If you want to deploy a default Fluent Bit pipeline (including Fluent Bit Input, Filter, and output) to collect Kubernetes logs, you'll need to set the Kubernetes parameter to true


### PR DESCRIPTION
Fixes the action that runs `ct lint` which was previously erroring:

```
Linting charts...
Directory "charts/fluent-operator/templates" is not a valid chart directory. Skipping...
Directory "charts/fluent-operator/templates" is not a valid chart directory. Skipping...
Directory "charts/fluent-operator/templates" is not a valid chart directory. Skipping...
Directory "charts/fluent-operator" is not a valid chart directory. Skipping...
```

After the fix:

```
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 fluent-operator => (version: "3.4.3", path: "charts/fluent-operator")
------------------------------------------------------------------------------------------------------------------------

Saving 2 charts
Deleting outdated charts
Linting chart "fluent-operator => (version: \"3.4.3\", path: \"charts/fluent-operator\")"
Checking chart "fluent-operator => (version: \"3.4.3\", path: \"charts/fluent-operator\")" for a version bump...
Old chart version: 3.4.2
New chart version: 3.4.3
Chart version ok.
Validating /home/runner/work/fluent-operator/fluent-operator/charts/fluent-operator/Chart.yaml...
Validation success! 👍
Validating maintainers...
==> Linting charts/fluent-operator

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ fluent-operator => (version: "3.4.3", path: "charts/fluent-operator")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

This PR also pins related GHA actions to SHA and updates them.
