### PR TITLE
Bump docker builds to Go v1.24.5

### DIFF
--- a/cmd/fluent-manager/Dockerfile
+++ b/cmd/fluent-manager/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24.1
+ARG GO_VERSION=1.24.5
 
 # Build the manager binary \
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine3.21 as builder

--- a/cmd/fluent-watcher/fluentbit/Dockerfile
+++ b/cmd/fluent-watcher/fluentbit/Dockerfile
@@ -1,5 +1,5 @@
 ARG FLUENT_BIT_BASE_VERSION=3.2.4 \
-    GO_VERSION=1.24.1
+    GO_VERSION=1.24.5
 
 FROM golang:${GO_VERSION}-alpine3.21 as buildergo
 RUN mkdir -p /fluent-bit

--- a/cmd/fluent-watcher/fluentbit/Dockerfile.debug
+++ b/cmd/fluent-watcher/fluentbit/Dockerfile.debug
@@ -1,5 +1,5 @@
 ARG FLUENT_BIT_BASE_VERSION=3.2.4 \
-    GO_VERSION=1.24.1
+    GO_VERSION=1.24.5
 
 FROM golang:${GO_VERSION}-alpine3.21 as buildergo
 RUN mkdir -p /fluent-bit

--- a/cmd/fluent-watcher/fluentd/Dockerfile
+++ b/cmd/fluent-watcher/fluentd/Dockerfile
@@ -1,5 +1,5 @@
 ARG FLUENTD_BASE_VERSION \
-    GO_VERSION=1.24.1
+    GO_VERSION=1.24.5
 
 FROM golang:${GO_VERSION} as builder
 

--- a/docs/best-practice/forwarding-logs-via-http/Dockerfile
+++ b/docs/best-practice/forwarding-logs-via-http/Dockerfile
@@ -1,4 +1,4 @@
-GO_VERSION=1.24.1
+GO_VERSION=1.24.5
 # Build the manager binary
 FROM golang:${GO_VERSION} as builder
 


### PR DESCRIPTION
When we bumped the toolchain to Go 1.24.5, we did not update the Fluentbit/Fluentd Dockerfiles to use 1.24.5 and their builds are now failing:

```
#16 [buildergo 7/7] RUN CGO_ENABLED=0 go build -ldflags '-w -s' -o /fluent-bit/fluent-bit /code/cmd/fluent-watcher/fluentbit/main.go
#16 0.052 go: go.mod requires go >= 1.24.5 (running go 1.24.1; GOTOOLCHAIN=local)
```