### PR TITLE
allow s3 output plugin to get keys from secrets

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/output/s3.go
+++ b/apis/fluentd/v1alpha1/plugins/output/s3.go
@@ -1,11 +1,13 @@
 package output
 
+import "github.com/fluent/fluent-operator/v3/apis/fluentd/v1alpha1/plugins"
+
 // S3 defines the parameters for out_s3 output plugin
 type S3 struct {
 	// The AWS access key id.
-	AwsKeyId *string `json:"awsKeyId,omitempty"`
+	AwsKeyId *plugins.Secret `json:"awsKeyId,omitempty"`
 	// The AWS secret key.
-	AwsSecKey *string `json:"awsSecKey,omitempty"`
+	AwsSecKey *plugins.Secret `json:"awsSecKey,omitempty"`
 	// The Amazon S3 bucket name.
 	S3Bucket *string `json:"s3Bucket,omitempty"`
 	// The Amazon S3 region name

--- a/apis/fluentd/v1alpha1/plugins/output/s3.go
+++ b/apis/fluentd/v1alpha1/plugins/output/s3.go
@@ -5,9 +5,13 @@ import "github.com/fluent/fluent-operator/v3/apis/fluentd/v1alpha1/plugins"
 // S3 defines the parameters for out_s3 output plugin
 type S3 struct {
 	// The AWS access key id.
-	AwsKeyId *plugins.Secret `json:"awsKeyId,omitempty"`
+	AwsKeyId *string `json:"awsKeyId,omitempty"`
 	// The AWS secret key.
-	AwsSecKey *plugins.Secret `json:"awsSecKey,omitempty"`
+	AwsSecKey *string `json:"awsSecKey,omitempty"`
+	// The AWS access key id from Secrets.
+	AwsKeyIdFromSecret *plugins.Secret `json:"awsKeyIdFromSecret,omitempty"`
+	// The AWS secret key from Secrets.
+	AwsSecKeyFromSecret *plugins.Secret `json:"awsSecKeyFromSecret,omitempty"`
 	// The Amazon S3 bucket name.
 	S3Bucket *string `json:"s3Bucket,omitempty"`
 	// The Amazon S3 region name

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -678,10 +678,18 @@ func (o *Output) kafka2Plugin(parent *params.PluginStore, loader plugins.SecretL
 
 func (o *Output) s3Plugin(parent *params.PluginStore, loader plugins.SecretLoader) *params.PluginStore {
 	if o.S3.AwsKeyId != nil {
-		parent.InsertPairs("aws_key_id", fmt.Sprint(*o.S3.AwsKeyId))
+		value, err := loader.LoadSecret(*o.S3.AwsKeyId)
+		if err != nil {
+			return nil
+		}
+		parent.InsertPairs("aws_key_id", value)
 	}
 	if o.S3.AwsSecKey != nil {
-		parent.InsertPairs("aws_sec_key", fmt.Sprint(*o.S3.AwsSecKey))
+		value, err := loader.LoadSecret(*o.S3.AwsSecKey)
+		if err != nil {
+			return nil
+		}
+		parent.InsertPairs("aws_sec_key", value)
 	}
 	if o.S3.S3Bucket != nil {
 		parent.InsertPairs("s3_bucket", fmt.Sprint(*o.S3.S3Bucket))

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -677,19 +677,23 @@ func (o *Output) kafka2Plugin(parent *params.PluginStore, loader plugins.SecretL
 }
 
 func (o *Output) s3Plugin(parent *params.PluginStore, loader plugins.SecretLoader) *params.PluginStore {
-	if o.S3.AwsKeyId != nil {
-		value, err := loader.LoadSecret(*o.S3.AwsKeyId)
+	if o.S3.AwsKeyIdFromSecret != nil {
+		value, err := loader.LoadSecret(*o.S3.AwsKeyIdFromSecret)
 		if err != nil {
 			return nil
 		}
 		parent.InsertPairs("aws_key_id", value)
+	} else if o.S3.AwsKeyId != nil {
+		parent.InsertPairs("aws_key_id", fmt.Sprint(*o.S3.AwsKeyId))
 	}
-	if o.S3.AwsSecKey != nil {
-		value, err := loader.LoadSecret(*o.S3.AwsSecKey)
+	if o.S3.AwsSecKeyFromSecret != nil {
+		value, err := loader.LoadSecret(*o.S3.AwsSecKeyFromSecret)
 		if err != nil {
 			return nil
 		}
 		parent.InsertPairs("aws_sec_key", value)
+	} else if o.S3.AwsSecKey != nil {
+		parent.InsertPairs("aws_sec_key", fmt.Sprint(*o.S3.AwsSecKey))
 	}
 	if o.S3.S3Bucket != nil {
 		parent.InsertPairs("s3_bucket", fmt.Sprint(*o.S3.S3Bucket))

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_clusteroutputs.yaml
@@ -2358,9 +2358,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL

--- a/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/charts/fluentd-crds/crds/fluentd.fluent.io_outputs.yaml
@@ -2358,9 +2358,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL

--- a/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_clusteroutputs.yaml
@@ -2358,9 +2358,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL

--- a/config/crd/bases/fluentd.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentd.fluent.io_outputs.yaml
@@ -2358,9 +2358,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL

--- a/docs/plugins/fluentd/output/s3.md
+++ b/docs/plugins/fluentd/output/s3.md
@@ -5,8 +5,10 @@ S3 defines the parameters for out_s3 output plugin
 
 | Field | Description | Scheme |
 | ----- | ----------- | ------ |
-| awsKeyId |  | *[plugins.Secret](../secret.md) |
-| awsSecKey |  | *[plugins.Secret](../secret.md) |
+| awsKeyId | The AWS access key id. | *string |
+| awsSecKey | The AWS secret key. | *string |
+| awsKeyIdFromSecret | The AWS access key id from Secrets. | *[plugins.Secret](../secret.md) |
+| awsSecKeyFromSecret | The AWS secret key from Secrets.  | *[plugins.Secret](../secret.md) |
 | s3Bucket | The Amazon S3 bucket name. | *string |
 | s3Region | The Amazon S3 region name | *string |
 | s3Endpoint | The endpoint URL (like \"http://localhost:9000/\") | *string |

--- a/docs/plugins/fluentd/output/s3.md
+++ b/docs/plugins/fluentd/output/s3.md
@@ -5,8 +5,8 @@ S3 defines the parameters for out_s3 output plugin
 
 | Field | Description | Scheme |
 | ----- | ----------- | ------ |
-| awsKeyId | The AWS access key id. | *string |
-| awsSecKey | The AWS secret key. | *string |
+| awsKeyId |  | *[plugins.Secret](../secret.md) |
+| awsSecKey |  | *[plugins.Secret](../secret.md) |
 | s3Bucket | The Amazon S3 bucket name. | *string |
 | s3Region | The Amazon S3 region name | *string |
 | s3Endpoint | The endpoint URL (like \"http://localhost:9000/\") | *string |

--- a/docs/plugins/fluentd/output/s3.md
+++ b/docs/plugins/fluentd/output/s3.md
@@ -8,7 +8,7 @@ S3 defines the parameters for out_s3 output plugin
 | awsKeyId | The AWS access key id. | *string |
 | awsSecKey | The AWS secret key. | *string |
 | awsKeyIdFromSecret | The AWS access key id from Secrets. | *[plugins.Secret](../secret.md) |
-| awsSecKeyFromSecret | The AWS secret key from Secrets.  | *[plugins.Secret](../secret.md) |
+| awsSecKeyFromSecret | The AWS secret key from Secrets. | *[plugins.Secret](../secret.md) |
 | s3Bucket | The Amazon S3 bucket name. | *string |
 | s3Region | The Amazon S3 region name | *string |
 | s3Endpoint | The endpoint URL (like \"http://localhost:9000/\") | *string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -10950,9 +10950,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL
@@ -39854,9 +39926,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -10950,9 +10950,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL
@@ -39854,9 +39926,81 @@ spec:
                         awsKeyId:
                           description: The AWS access key id.
                           type: string
+                        awsKeyIdFromSecret:
+                          description: The AWS access key id from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         awsSecKey:
                           description: The AWS secret key.
                           type: string
+                        awsSecKeyFromSecret:
+                          description: The AWS secret key from Secrets.
+                          properties:
+                            valueFrom:
+                              description: ValueSource defines how to find a value's
+                                key.
+                              properties:
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          type: object
                         forcePathStyle:
                           description: This prevents AWS SDK from breaking endpoint
                             URL


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

This allows `AwsKeyId` and `AwsSecKey` to be pulled from secrets like the cloudwatch output plugin

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
