### PR TITLE
Fix some `lll` warnings.

### DIFF
--- a/cmd/doc-gen/main.go
+++ b/cmd/doc-gen/main.go
@@ -19,7 +19,8 @@ import (
 const (
 	firstParagraph = `# API Docs
 This Document documents the types introduced by the %s Operator.
-> Note this document is generated from code comments. When contributing a change to this document please do so by changing the code comments.`
+> Note this document is generated from code comments.
+> When contributing a change to this document please do so by changing the code comments.`
 
 	fluentbitPluginPath = "apis/fluentbit/v1alpha2/plugins/"
 	fluentdPluginPath   = "apis/fluentd/v1alpha1/plugins/"

--- a/controllers/fluent_controller_finalizer.go
+++ b/controllers/fluent_controller_finalizer.go
@@ -114,7 +114,13 @@ func (r *FluentdReconciler) delete(ctx context.Context, fd *fluentdv1alpha1.Flue
 func (r *FluentdReconciler) mutate(obj client.Object, fd *fluentdv1alpha1.Fluentd) controllerutil.MutateFn {
 	switch o := obj.(type) {
 	case *rbacv1.ClusterRole:
-		expected, _, _ := operator.MakeRBACObjects(fd.Name, fd.Namespace, "fluentd", fd.Spec.RBACRules, fd.Spec.ServiceAccountAnnotations)
+		expected, _, _ := operator.MakeRBACObjects(
+			fd.Name,
+			fd.Namespace,
+			"fluentd",
+			fd.Spec.RBACRules,
+			fd.Spec.ServiceAccountAnnotations,
+		)
 
 		return func() error {
 			o.Rules = expected.Rules

--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -292,7 +292,8 @@ func listNamespacedResources[T client.ObjectList](
 	if err != nil {
 		return err
 	}
-	if err := cli.List(ctx, list, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: sel}); err != nil {
+	matchingLabelSelector := client.MatchingLabelsSelector{Selector: sel}
+	if err := cli.List(ctx, list, client.InNamespace(namespace), matchingLabelSelector); err != nil {
 		return err
 	}
 	return nil
@@ -323,15 +324,33 @@ func (r *FluentBitConfigReconciler) ListNamespacedResources(
 		return filters, outputs, parsers, clusterParsers, multipleParsers, clusterMultipleParsers, err
 	}
 
-	if err := listNamespacedResources(ctx, r.Client, &clusterParsers, cfg.Namespace, &cfg.Spec.ClusterParserSelector); err != nil {
+	if err := listNamespacedResources(
+		ctx,
+		r.Client,
+		&clusterParsers,
+		cfg.Namespace,
+		&cfg.Spec.ClusterParserSelector,
+	); err != nil {
 		return filters, outputs, parsers, clusterParsers, multipleParsers, clusterMultipleParsers, err
 	}
 
-	if err := listNamespacedResources(ctx, r.Client, &multipleParsers, cfg.Namespace, &cfg.Spec.MultilineParserSelector); err != nil {
+	if err := listNamespacedResources(
+		ctx,
+		r.Client,
+		&multipleParsers,
+		cfg.Namespace,
+		&cfg.Spec.MultilineParserSelector,
+	); err != nil {
 		return filters, outputs, parsers, clusterParsers, multipleParsers, clusterMultipleParsers, err
 	}
 
-	if err := listNamespacedResources(ctx, r.Client, &clusterMultipleParsers, cfg.Namespace, &cfg.Spec.ClusterMultilineParserSelector); err != nil {
+	if err := listNamespacedResources(
+		ctx,
+		r.Client,
+		&clusterMultipleParsers,
+		cfg.Namespace,
+		&cfg.Spec.ClusterMultilineParserSelector,
+	); err != nil {
 		return filters, outputs, parsers, clusterParsers, multipleParsers, clusterMultipleParsers, err
 	}
 

--- a/controllers/fluentd_controller.go
+++ b/controllers/fluentd_controller.go
@@ -96,7 +96,13 @@ func (r *FluentdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Install RBAC resources for the filter plugin kubernetes
-	cr, sa, crb := operator.MakeRBACObjects(fd.Name, fd.Namespace, fluentdLowercase, fd.Spec.RBACRules, fd.Spec.ServiceAccountAnnotations)
+	cr, sa, crb := operator.MakeRBACObjects(
+		fd.Name,
+		fd.Namespace,
+		fluentdLowercase,
+		fd.Spec.RBACRules,
+		fd.Spec.ServiceAccountAnnotations,
+	)
 	// Deploy Fluentd ClusterRole
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, cr, r.mutate(cr, &fd)); err != nil {
 		return ctrl.Result{}, err

--- a/pkg/filenotify/filenotify.go
+++ b/pkg/filenotify/filenotify.go
@@ -7,7 +7,8 @@
 // These are wrapped up in a common interface so that either can be used interchangeably in your code.
 //
 // This package is adapted from https://github.com/moby/moby/tree/master/pkg/filenotify, Apache-2.0 License.
-// Hopefully this can be replaced with an external package sometime in the future, see https://github.com/fsnotify/fsnotify/issues/9
+// Hopefully this can be replaced with an external package sometime in the future.
+// See https://github.com/fsnotify/fsnotify/issues/9
 package filenotify
 
 import (

--- a/pkg/filenotify/fsnotify.go
+++ b/pkg/filenotify/fsnotify.go
@@ -3,7 +3,8 @@
 // Copyright Hugo Authors
 
 // Package filenotify is adapted from https://github.com/moby/moby/tree/master/pkg/filenotify, Apache-2.0 License.
-// Hopefully this can be replaced with an external package sometime in the future, see https://github.com/fsnotify/fsnotify/issues/9
+// Hopefully this can be replaced with an external package sometime in the future.
+// See https://github.com/fsnotify/fsnotify/issues/9
 package filenotify
 
 import "github.com/fsnotify/fsnotify"

--- a/pkg/filenotify/poller.go
+++ b/pkg/filenotify/poller.go
@@ -3,7 +3,8 @@
 // Copyright Hugo Authors
 
 // Package filenotify is adapted from https://github.com/moby/moby/tree/master/pkg/filenotify, Apache-2.0 License.
-// Hopefully this can be replaced with an external package sometime in the future, see https://github.com/fsnotify/fsnotify/issues/9
+// Hopefully this can be replaced with an external package sometime in the future.
+// See https://github.com/fsnotify/fsnotify/issues/9
 package filenotify
 
 import (


### PR DESCRIPTION
SSIA
I’ve not fixed kubebuild annotations, flag descriptions and logs yet. I consider that we may ignore such situation warnings.

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes partially #1707

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
