### PR TITLE
add ClusterFirstWithHostNet for kubeedge fluentbit

### DIFF
--- a/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
+++ b/manifests/kubeedge/fluentbit-fluentbit-edge.yaml
@@ -29,6 +29,7 @@ spec:
               - key: node-role.kubernetes.io/edge
                 operator: Exists
   hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
   volumes:
     - name: host-proc
       hostPath:


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
When we enable `hostNetwork: true` for the Fluent Bit edge pod, if `ClusterFirstWithHostNet` is not used, the `<cloud-prometheus-service-host>` service (like `prometheus.default.svc`) will not be reachable.

```yaml
  prometheusRemoteWrite:
    host: <cloud-prometheus-service-host>
    port: <cloud-prometheus-service-port>
    uri: /api/v1/write
    addLabels : 
      app : fluentbit
      node: ${NODE_NAME}
      job : kubeedge
```
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
