### PR TITLE
Re-factor build workflow for fluent-operator.

### DIFF
--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -115,8 +115,7 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=long,prefix=,priority=1000 # DEBUG, REMOVE THIS
-            # type=sha,format=long,prefix=,enable=${{ github.event_name == 'pull_request' }},priority=1000
+            type=sha,format=long,prefix=,enable=${{ github.event_name == 'pull_request' }},priority=1000
 
       - name: Build and push image (pull request)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This PR refactors the `build-op-image` workflow to follow the standards set forth in the `build-fluentbit-image` and `build-fluentd-image` workflows.

In summary:

* Now building both `amd64` and `arm64` images on native runners with no emulation
* For pull requests: to help with testing PR's, the workflow will now push an image tagged by commit SHA for each commit to a PR (this functionality existed but was broken previously) to GHCR
* For tag pushes (eg, releases): pushes images to GHCR and DockerHub 