### PR TITLE
refactor: switch to reusable pointer conversion method in utils packa…

### DIFF
--- a/apis/fluentbit/v1alpha2/clusterfilter_types_test.go
+++ b/apis/fluentbit/v1alpha2/clusterfilter_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/filter"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -135,11 +136,11 @@ func TestClusterFilterList_Load(t *testing.T) {
 						KubeURL:          "http://127.0.0.1:6443",
 						KubeCAFile:       "root.ca",
 						KubeCAPath:       "/root/.kube/crt",
-						Labels:           ptr(true),
-						Annotations:      ptr(true),
-						DNSWaitTime:      ptr[int32](30),
-						UseKubelet:       ptr(true),
-						KubeletPort:      ptr[int32](10000),
+						Labels:           utils.ToPtr(true),
+						Annotations:      utils.ToPtr(true),
+						DNSWaitTime:      utils.ToPtr[int32](30),
+						UseKubelet:       utils.ToPtr(true),
+						KubeletPort:      utils.ToPtr[int32](10000),
 						KubeMetaCacheTTL: "60s",
 					},
 				},
@@ -163,8 +164,8 @@ func TestClusterFilterList_Load(t *testing.T) {
 						CommonParams: plugins.CommonParams{
 							Alias: "throttle.application-xy",
 						},
-						Rate:     ptr[int64](200),
-						Window:   ptr[int64](300),
+						Rate:     utils.ToPtr[int64](200),
+						Window:   utils.ToPtr[int64](300),
 						Interval: "1s",
 					},
 				},
@@ -494,11 +495,11 @@ func TestClusterFilterList_Load_As_Yaml(t *testing.T) {
 						KubeURL:          "http://127.0.0.1:6443",
 						KubeCAFile:       "root.ca",
 						KubeCAPath:       "/root/.kube/crt",
-						Labels:           ptr(true),
-						Annotations:      ptr(true),
-						DNSWaitTime:      ptr[int32](30),
-						UseKubelet:       ptr(true),
-						KubeletPort:      ptr[int32](10000),
+						Labels:           utils.ToPtr(true),
+						Annotations:      utils.ToPtr(true),
+						DNSWaitTime:      utils.ToPtr[int32](30),
+						UseKubelet:       utils.ToPtr(true),
+						KubeletPort:      utils.ToPtr[int32](10000),
 						KubeMetaCacheTTL: "60s",
 					},
 				},
@@ -522,8 +523,8 @@ func TestClusterFilterList_Load_As_Yaml(t *testing.T) {
 						CommonParams: plugins.CommonParams{
 							Alias: "throttle.application-xy",
 						},
-						Rate:     ptr[int64](200),
-						Window:   ptr[int64](300),
+						Rate:     utils.ToPtr[int64](200),
+						Window:   utils.ToPtr[int64](300),
 						Interval: "1s",
 					},
 				},

--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types_test.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/multilineparser"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/output"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/parser"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 )
 
 const (
@@ -385,10 +386,10 @@ pipeline:
 	cfg = ClusterFluentBitConfig{
 		Spec: FluentBitConfigSpec{
 			Service: &Service{
-				Daemon:       ptr(false),
-				FlushSeconds: ptr[float64](1),
-				GraceSeconds: ptr[int64](30),
-				HttpServer:   ptr(true),
+				Daemon:       utils.ToPtr(false),
+				FlushSeconds: utils.ToPtr[float64](1),
+				GraceSeconds: utils.ToPtr[int64](30),
+				HttpServer:   utils.ToPtr(true),
 				LogLevel:     "info",
 				ParsersFile:  "parsers.conf",
 			},
@@ -401,7 +402,7 @@ func Test_FluentBitConfig_RenderMainConfig(t *testing.T) {
 
 	sl := plugins.NewSecretLoader(nil, "testnamespace")
 
-	disableInotifyWatcher := ptr(true)
+	disableInotifyWatcher := utils.ToPtr(true)
 
 	inputObj := &ClusterInput{
 		TypeMeta: metav1.TypeMeta{
@@ -419,10 +420,10 @@ func Test_FluentBitConfig_RenderMainConfig(t *testing.T) {
 				Tag:                    "logs.foo.bar",
 				Path:                   "/logs/containers/apps0",
 				ExcludePath:            "/logs/containers/exclude_path",
-				SkipLongLines:          ptr(true),
+				SkipLongLines:          utils.ToPtr(true),
 				IgnoreOlder:            "5m",
 				MemBufLimit:            "5MB",
-				RefreshIntervalSeconds: ptr[int64](10),
+				RefreshIntervalSeconds: utils.ToPtr[int64](10),
 				DB:                     "/fluent-bit/tail/pos.db",
 			},
 		},
@@ -506,10 +507,10 @@ func Test_FluentBitConfig_RenderMainConfig(t *testing.T) {
 			Match: "logs.foo.bar",
 			Syslog: &output.Syslog{
 				Host: "example.com",
-				Port: ptr[int32](3300),
+				Port: utils.ToPtr[int32](3300),
 				Mode: "tls",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 				SyslogMessageKey:  "log",
 				SyslogHostnameKey: "do_app_name",
@@ -539,14 +540,14 @@ func Test_FluentBitConfig_RenderMainConfig(t *testing.T) {
 			Match: "logs.foo.bar",
 			HTTP: &output.HTTP{
 				Host:           "https://example2.com",
-				Port:           ptr[int32](433),
+				Port:           utils.ToPtr[int32](433),
 				Uri:            "/logs",
 				Headers:        headers,
 				Format:         "json_lines",
 				JsonDateKey:    "timestamp",
 				JsonDateFormat: "iso8601",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 			},
 		},
@@ -566,7 +567,7 @@ func Test_FluentBitConfig_RenderMainConfig(t *testing.T) {
 			Match: "*",
 			OpenSearch: &output.OpenSearch{
 				Host:  "https://example2.com",
-				Port:  ptr[int32](9200),
+				Port:  utils.ToPtr[int32](9200),
 				Index: "my_index",
 				Type:  "my_type",
 			},
@@ -587,7 +588,7 @@ func Test_FluentBitConfig_RenderMainConfig(t *testing.T) {
 			Match: "*",
 			Elasticsearch: &output.Elasticsearch{
 				Host:           "https://example2.com",
-				Port:           ptr[int32](9200),
+				Port:           utils.ToPtr[int32](9200),
 				Index:          "my_index",
 				Type:           "my_type",
 				WriteOperation: "upsert",
@@ -634,7 +635,7 @@ func Test_FluentBitConfig_RenderMainConfigYaml(t *testing.T) {
 
 	sl := plugins.NewSecretLoader(nil, "testnamespace")
 
-	disableInotifyWatcher := ptr(true)
+	disableInotifyWatcher := utils.ToPtr(true)
 
 	inputObj := &ClusterInput{
 		TypeMeta: metav1.TypeMeta{
@@ -652,10 +653,10 @@ func Test_FluentBitConfig_RenderMainConfigYaml(t *testing.T) {
 				Tag:                    "logs.foo.bar",
 				Path:                   "/logs/containers/apps0",
 				ExcludePath:            "/logs/containers/exclude_path",
-				SkipLongLines:          ptr(true),
+				SkipLongLines:          utils.ToPtr(true),
 				IgnoreOlder:            "5m",
 				MemBufLimit:            "5MB",
-				RefreshIntervalSeconds: ptr[int64](10),
+				RefreshIntervalSeconds: utils.ToPtr[int64](10),
 				DB:                     "/fluent-bit/tail/pos.db",
 			},
 		},
@@ -739,10 +740,10 @@ func Test_FluentBitConfig_RenderMainConfigYaml(t *testing.T) {
 			Match: "logs.foo.bar",
 			Syslog: &output.Syslog{
 				Host: "example.com",
-				Port: ptr[int32](3300),
+				Port: utils.ToPtr[int32](3300),
 				Mode: "tls",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 				SyslogMessageKey:  "log",
 				SyslogHostnameKey: "do_app_name",
@@ -772,14 +773,14 @@ func Test_FluentBitConfig_RenderMainConfigYaml(t *testing.T) {
 			Match: "logs.foo.bar",
 			HTTP: &output.HTTP{
 				Host:           "https://example2.com",
-				Port:           ptr[int32](433),
+				Port:           utils.ToPtr[int32](433),
 				Uri:            "/logs",
 				Headers:        headers,
 				Format:         "json_lines",
 				JsonDateKey:    "timestamp",
 				JsonDateFormat: "iso8601",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 			},
 		},
@@ -799,7 +800,7 @@ func Test_FluentBitConfig_RenderMainConfigYaml(t *testing.T) {
 			Match: "*",
 			OpenSearch: &output.OpenSearch{
 				Host:  "https://example2.com",
-				Port:  ptr[int32](9200),
+				Port:  utils.ToPtr[int32](9200),
 				Index: "my_index",
 				Type:  "my_type",
 			},
@@ -820,7 +821,7 @@ func Test_FluentBitConfig_RenderMainConfigYaml(t *testing.T) {
 			Match: "*",
 			Elasticsearch: &output.Elasticsearch{
 				Host:           "https://example2.com",
-				Port:           ptr[int32](9200),
+				Port:           utils.ToPtr[int32](9200),
 				Index:          "my_index",
 				Type:           "my_type",
 				WriteOperation: "upsert",
@@ -908,10 +909,10 @@ func TestRenderMainConfigK8s(t *testing.T) {
 			Tail: &input.Tail{
 				Tag:                    "kube.*",
 				Path:                   "/var/log/containers/*.log",
-				SkipLongLines:          ptr(true),
+				SkipLongLines:          utils.ToPtr(true),
 				IgnoreOlder:            "5m",
 				MemBufLimit:            "5MB",
-				RefreshIntervalSeconds: ptr[int64](10),
+				RefreshIntervalSeconds: utils.ToPtr[int64](10),
 				DB:                     "/fluent-bit/tail/pos.db",
 			},
 		},
@@ -942,7 +943,7 @@ func TestRenderMainConfigK8s(t *testing.T) {
 					Parser: &filter.Parser{
 						KeyName:     "log",
 						Parser:      "bar",
-						ReserveData: ptr(true),
+						ReserveData: utils.ToPtr(true),
 					},
 				},
 			},
@@ -967,7 +968,7 @@ func TestRenderMainConfigK8s(t *testing.T) {
 			Match: "kube.*",
 			OpenSearch: &output.OpenSearch{
 				Host:  "foo.bar",
-				Port:  ptr[int32](9200),
+				Port:  utils.ToPtr[int32](9200),
 				Index: "foo-index",
 			},
 		},
@@ -987,7 +988,7 @@ func TestRenderMainConfigK8s(t *testing.T) {
 			Match: "kube.*",
 			Elasticsearch: &output.Elasticsearch{
 				Host:           "foo.bar",
-				Port:           ptr[int32](9200),
+				Port:           utils.ToPtr[int32](9200),
 				Index:          "foo-index",
 				WriteOperation: "update",
 			},
@@ -1031,10 +1032,10 @@ func TestRenderMainConfigK8sInYaml(t *testing.T) {
 			Tail: &input.Tail{
 				Tag:                    "kube.*",
 				Path:                   "/var/log/containers/*.log",
-				SkipLongLines:          ptr(true),
+				SkipLongLines:          utils.ToPtr(true),
 				IgnoreOlder:            "5m",
 				MemBufLimit:            "5MB",
-				RefreshIntervalSeconds: ptr[int64](10),
+				RefreshIntervalSeconds: utils.ToPtr[int64](10),
 				DB:                     "/fluent-bit/tail/pos.db",
 			},
 		},
@@ -1059,7 +1060,7 @@ func TestRenderMainConfigK8sInYaml(t *testing.T) {
 						{Parser: &filter.Parser{
 							KeyName:     "log",
 							Parser:      "test",
-							ReserveData: ptr(true),
+							ReserveData: utils.ToPtr(true),
 						}},
 					},
 				},
@@ -1081,7 +1082,7 @@ func TestRenderMainConfigK8sInYaml(t *testing.T) {
 					Match: "kube.*",
 					Elasticsearch: &output.Elasticsearch{
 						Host:  "foo.bar",
-						Port:  ptr[int32](9200),
+						Port:  utils.ToPtr[int32](9200),
 						Index: "foo-index",
 					},
 				},
@@ -1105,7 +1106,7 @@ func TestRenderMainConfigK8sInYaml(t *testing.T) {
 					Parser: &filter.Parser{
 						KeyName:     "log",
 						Parser:      "bar",
-						ReserveData: ptr(true),
+						ReserveData: utils.ToPtr(true),
 					},
 				},
 			},
@@ -1130,7 +1131,7 @@ func TestRenderMainConfigK8sInYaml(t *testing.T) {
 			Match: "kube.*",
 			OpenSearch: &output.OpenSearch{
 				Host:  "foo.bar",
-				Port:  ptr[int32](9200),
+				Port:  utils.ToPtr[int32](9200),
 				Index: "foo-index",
 			},
 		},
@@ -1150,7 +1151,7 @@ func TestRenderMainConfigK8sInYaml(t *testing.T) {
 			Match: "kube.*",
 			Elasticsearch: &output.Elasticsearch{
 				Host:           "foo.bar",
-				Port:           ptr[int32](9200),
+				Port:           utils.ToPtr[int32](9200),
 				Index:          "foo-index",
 				WriteOperation: "update",
 			},
@@ -1178,10 +1179,10 @@ func TestClusterFluentBitConfig_RenderMainConfig_WithParsersFiles(t *testing.T) 
 	cfbc := ClusterFluentBitConfig{
 		Spec: FluentBitConfigSpec{
 			Service: &Service{
-				Daemon:       ptr(false),
-				FlushSeconds: ptr[float64](1),
-				GraceSeconds: ptr[int64](30),
-				HttpServer:   ptr(true),
+				Daemon:       utils.ToPtr(false),
+				FlushSeconds: utils.ToPtr[float64](1),
+				GraceSeconds: utils.ToPtr[int64](30),
+				HttpServer:   utils.ToPtr(true),
 				LogLevel:     "info",
 				ParsersFiles: []string{"parsers.conf", "parsers_multiline.conf"},
 			},

--- a/apis/fluentbit/v1alpha2/clusterinput_types_test.go
+++ b/apis/fluentbit/v1alpha2/clusterinput_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/input"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -86,18 +87,18 @@ func TestClusterInputList_Load(t *testing.T) {
 		Spec: InputSpec{
 			Alias: "input0_alias",
 			Tail: &input.Tail{
-				DisableInotifyWatcher:  ptr(true),
+				DisableInotifyWatcher:  utils.ToPtr(true),
 				Tag:                    "logs.foo.bar",
 				Path:                   "/logs/containers/apps0",
 				ExcludePath:            "/logs/containers/exclude_path",
-				SkipLongLines:          ptr(true),
+				SkipLongLines:          utils.ToPtr(true),
 				IgnoreOlder:            "5m",
 				MemBufLimit:            "5MB",
-				RefreshIntervalSeconds: ptr[int64](10),
+				RefreshIntervalSeconds: utils.ToPtr[int64](10),
 				DB:                     "/fluent-bit/tail/pos.db",
 				Parser:                 "docker",
-				DockerMode:             ptr(true),
-				DockerModeFlushSeconds: ptr[int64](4),
+				DockerMode:             utils.ToPtr(true),
+				DockerModeFlushSeconds: utils.ToPtr[int64](4),
 				DockerModeParser:       "docker-mode-parser",
 			},
 		},
@@ -115,8 +116,8 @@ func TestClusterInputList_Load(t *testing.T) {
 			Alias: "input2_alias",
 			Dummy: &input.Dummy{
 				Tag:     "logs.foo.bar",
-				Rate:    ptr[int32](3),
-				Samples: ptr[int32](5),
+				Rate:    utils.ToPtr[int32](3),
+				Samples: utils.ToPtr[int32](5),
 			},
 		},
 	}
@@ -134,7 +135,7 @@ func TestClusterInputList_Load(t *testing.T) {
 			PrometheusScrapeMetrics: &input.PrometheusScrapeMetrics{
 				Tag:            "logs.foo.bar",
 				Host:           "https://example3.com",
-				Port:           ptr[int32](433),
+				Port:           utils.ToPtr[int32](433),
 				ScrapeInterval: "10s",
 				MetricsPath:    "/metrics",
 			},
@@ -199,7 +200,7 @@ func TestFluentbitMetricClusterInputList_Load(t *testing.T) {
 			FluentBitMetrics: &input.FluentbitMetrics{
 				Tag:            "logs.foo.bar",
 				ScrapeInterval: "2",
-				ScrapeOnStart:  ptr(true),
+				ScrapeOnStart:  utils.ToPtr(true),
 			},
 		},
 	}
@@ -215,7 +216,7 @@ func TestFluentbitMetricClusterInputList_Load(t *testing.T) {
 		Spec: InputSpec{
 			Alias: "input1_alias",
 			Forward: &input.Forward{
-				Port:            ptr[int32](433),
+				Port:            utils.ToPtr[int32](433),
 				Listen:          "0.0.0.0",
 				BufferChunkSize: "1M",
 				BufferMaxSize:   "6M",
@@ -262,18 +263,18 @@ func TestClusterInputList_Load_As_Yaml(t *testing.T) {
 		Spec: InputSpec{
 			Alias: "input0_alias",
 			Tail: &input.Tail{
-				DisableInotifyWatcher:  ptr(true),
+				DisableInotifyWatcher:  utils.ToPtr(true),
 				Tag:                    "logs.foo.bar",
 				Path:                   "/logs/containers/apps0",
 				ExcludePath:            "/logs/containers/exclude_path",
-				SkipLongLines:          ptr(true),
+				SkipLongLines:          utils.ToPtr(true),
 				IgnoreOlder:            "5m",
 				MemBufLimit:            "5MB",
-				RefreshIntervalSeconds: ptr[int64](10),
+				RefreshIntervalSeconds: utils.ToPtr[int64](10),
 				DB:                     "/fluent-bit/tail/pos.db",
 				Parser:                 "docker",
-				DockerMode:             ptr(true),
-				DockerModeFlushSeconds: ptr[int64](4),
+				DockerMode:             utils.ToPtr(true),
+				DockerModeFlushSeconds: utils.ToPtr[int64](4),
 				DockerModeParser:       "docker-mode-parser",
 			},
 		},
@@ -291,8 +292,8 @@ func TestClusterInputList_Load_As_Yaml(t *testing.T) {
 			Alias: "input2_alias",
 			Dummy: &input.Dummy{
 				Tag:     "logs.foo.bar",
-				Rate:    ptr[int32](3),
-				Samples: ptr[int32](5),
+				Rate:    utils.ToPtr[int32](3),
+				Samples: utils.ToPtr[int32](5),
 			},
 		},
 	}
@@ -310,7 +311,7 @@ func TestClusterInputList_Load_As_Yaml(t *testing.T) {
 			PrometheusScrapeMetrics: &input.PrometheusScrapeMetrics{
 				Tag:            "logs.foo.bar",
 				Host:           "https://example3.com",
-				Port:           ptr[int32](433),
+				Port:           utils.ToPtr[int32](433),
 				ScrapeInterval: "10s",
 				MetricsPath:    "/metrics",
 			},

--- a/apis/fluentbit/v1alpha2/clusteroutput_types_test.go
+++ b/apis/fluentbit/v1alpha2/clusteroutput_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/output"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -151,10 +152,10 @@ func TestClusterOutputList_Load(t *testing.T) {
 			Match: "logs.foo.bar",
 			Syslog: &output.Syslog{
 				Host: "example.com",
-				Port: ptr[int32](3300),
+				Port: utils.ToPtr[int32](3300),
 				Mode: "tls",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 				SyslogMessageKey:  "log",
 				SyslogHostnameKey: "do_app_name",
@@ -184,14 +185,14 @@ func TestClusterOutputList_Load(t *testing.T) {
 			Match: "logs.foo.bar",
 			HTTP: &output.HTTP{
 				Host:           "https://example2.com",
-				Port:           ptr[int32](433),
+				Port:           utils.ToPtr[int32](433),
 				Uri:            "/logs",
 				Headers:        headers,
 				Format:         "json_lines",
 				JsonDateKey:    "timestamp",
 				JsonDateFormat: "iso8601",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 			},
 		},
@@ -211,7 +212,7 @@ func TestClusterOutputList_Load(t *testing.T) {
 			Match: "*",
 			OpenSearch: &output.OpenSearch{
 				Host:  "https://example2.com",
-				Port:  ptr[int32](9200),
+				Port:  utils.ToPtr[int32](9200),
 				Index: "my_index",
 				Type:  "my_type",
 			},
@@ -236,15 +237,15 @@ func TestClusterOutputList_Load(t *testing.T) {
 			Match: "logs.foo.bar",
 			PrometheusRemoteWrite: &output.PrometheusRemoteWrite{
 				Host:               "https://example3.com",
-				Port:               ptr[int32](433),
+				Port:               utils.ToPtr[int32](433),
 				URI:                "/prometheus/v1/write?prometheus_server=YOUR_DATA_SOURCE_NAME",
 				Proxy:              "https://proxy:533",
 				Headers:            headers,
-				LogResponsePayload: ptr(true),
+				LogResponsePayload: utils.ToPtr(true),
 				AddLabels:          addLabels,
-				Workers:            ptr[int32](3),
+				Workers:            utils.ToPtr[int32](3),
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 			},
 		},
@@ -291,10 +292,10 @@ func TestClusterOutputList_Load_As_Yaml(t *testing.T) {
 			Match: "logs.foo.bar",
 			Syslog: &output.Syslog{
 				Host: "example.com",
-				Port: ptr[int32](3300),
+				Port: utils.ToPtr[int32](3300),
 				Mode: "tls",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 				SyslogMessageKey:  "log",
 				SyslogHostnameKey: "do_app_name",
@@ -324,14 +325,14 @@ func TestClusterOutputList_Load_As_Yaml(t *testing.T) {
 			Match: "logs.foo.bar",
 			HTTP: &output.HTTP{
 				Host:           "https://example2.com",
-				Port:           ptr[int32](433),
+				Port:           utils.ToPtr[int32](433),
 				Uri:            "/logs",
 				Headers:        headers,
 				Format:         "json_lines",
 				JsonDateKey:    "timestamp",
 				JsonDateFormat: "iso8601",
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 			},
 		},
@@ -351,7 +352,7 @@ func TestClusterOutputList_Load_As_Yaml(t *testing.T) {
 			Match: "*",
 			OpenSearch: &output.OpenSearch{
 				Host:  "https://example2.com",
-				Port:  ptr[int32](9200),
+				Port:  utils.ToPtr[int32](9200),
 				Index: "my_index",
 				Type:  "my_type",
 			},
@@ -376,15 +377,15 @@ func TestClusterOutputList_Load_As_Yaml(t *testing.T) {
 			Match: "logs.foo.bar",
 			PrometheusRemoteWrite: &output.PrometheusRemoteWrite{
 				Host:               "https://example3.com",
-				Port:               ptr[int32](433),
+				Port:               utils.ToPtr[int32](433),
 				URI:                "/prometheus/v1/write?prometheus_server=YOUR_DATA_SOURCE_NAME",
 				Proxy:              "https://proxy:533",
 				Headers:            headers,
-				LogResponsePayload: ptr(true),
+				LogResponsePayload: utils.ToPtr(true),
 				AddLabels:          addLabels,
-				Workers:            ptr[int32](3),
+				Workers:            utils.ToPtr[int32](3),
 				TLS: &plugins.TLS{
-					Verify: ptr(true),
+					Verify: utils.ToPtr(true),
 				},
 			},
 		},
@@ -433,7 +434,7 @@ func TestLokiOutputWithStructuredMetadata_Load(t *testing.T) {
 			Match: "kube.*",
 			Loki: &output.Loki{
 				Host: "loki-gateway",
-				Port: ptr[int32](3100),
+				Port: utils.ToPtr[int32](3100),
 				Labels: []string{
 					"job=fluentbit",
 					"environment=production",
@@ -486,7 +487,7 @@ func TestLokiOutputWithStructuredMetadata_LoadAsYaml(t *testing.T) {
 			Match: "kube.*",
 			Loki: &output.Loki{
 				Host: "loki-gateway",
-				Port: ptr[int32](3100),
+				Port: utils.ToPtr[int32](3100),
 				Labels: []string{
 					"job=fluentbit",
 					"environment=production",

--- a/apis/fluentbit/v1alpha2/filter_types_test.go
+++ b/apis/fluentbit/v1alpha2/filter_types_test.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/filter"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 )
-
-func ptr[T any](v T) *T { return &v }
 
 func TestFilterList_Load(t *testing.T) {
 	testcases := []struct {
@@ -85,14 +84,14 @@ func TestFilterList_Load(t *testing.T) {
 								Parser: &filter.Parser{
 									KeyName:     "msg",
 									Parser:      "second-parser",
-									ReserveData: ptr(true),
+									ReserveData: utils.ToPtr(true),
 								},
 							},
 							{
 								Parser: &filter.Parser{
 									KeyName:     "msg",
 									Parser:      "third-parser",
-									ReserveData: ptr(true),
+									ReserveData: utils.ToPtr(true),
 								},
 							},
 						},
@@ -257,14 +256,14 @@ func TestFilterList_LoadAsYaml(t *testing.T) {
 							Parser: &filter.Parser{
 								KeyName:     "msg",
 								Parser:      "second-parser",
-								ReserveData: ptr(true),
+								ReserveData: utils.ToPtr(true),
 							},
 						},
 						{
 							Parser: &filter.Parser{
 								KeyName:     "msg",
 								Parser:      "third-parser",
-								ReserveData: ptr(true),
+								ReserveData: utils.ToPtr(true),
 							},
 						},
 					},

--- a/apis/fluentbit/v1alpha2/plugins/output/datadog_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/datadog_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 )
 
@@ -15,14 +16,14 @@ func TestOutput_DataDog_Params(t *testing.T) {
 
 	dd := DataDog{
 		Host:          "http-intake.logs.datadoghq.com",
-		TLS:           ptr(true),
+		TLS:           utils.ToPtr(true),
 		Compress:      "gzip",
 		Service:       "service_name",
 		Source:        "app_name",
 		Tags:          "foo:bar",
 		MessageKey:    "message",
 		JSONDateKey:   "timestamp",
-		IncludeTagKey: ptr(true),
+		IncludeTagKey: utils.ToPtr(true),
 		TagKey:        "tagkey",
 	}
 

--- a/apis/fluentbit/v1alpha2/plugins/output/gelf_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/gelf_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 )
 
@@ -15,15 +16,15 @@ func TestOutput_Gelf_Params(t *testing.T) {
 
 	dd := Gelf{
 		Host:            "127.0.0.1",
-		Port:            ptr[int32](1234),
+		Port:            utils.ToPtr[int32](1234),
 		Mode:            "udp",
 		ShortMessageKey: "short_message",
 		TimestampKey:    "timestamp",
 		HostKey:         "host",
 		FullMessageKey:  "full_message",
 		LevelKey:        "level",
-		PacketSize:      ptr[int32](1000),
-		Compress:        ptr(true),
+		PacketSize:      utils.ToPtr[int32](1000),
+		Compress:        utils.ToPtr(true),
 	}
 
 	expected := params.NewKVs()

--- a/apis/fluentbit/v1alpha2/plugins/output/influxdb_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/influxdb_types_test.go
@@ -5,12 +5,9 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 )
-
-func ptr[T any](v T) *T {
-	return &v
-}
 
 func TestOutput_InfluxDB_Params(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -19,14 +16,14 @@ func TestOutput_InfluxDB_Params(t *testing.T) {
 
 	dd := InfluxDB{
 		Host:            "127.0.0.1",
-		Port:            ptr[int32](8086),
+		Port:            utils.ToPtr[int32](8086),
 		Database:        "fluentbit",
 		Bucket:          "buck",
 		Org:             "orgnis",
 		SequenceTag:     "_inc",
 		TagKeys:         []string{"foo", "bar", "foo:bar"},
-		AutoTags:        ptr(false),
-		TagsListEnabled: ptr(true),
+		AutoTags:        utils.ToPtr(false),
+		TagsListEnabled: utils.ToPtr(true),
 		TagsListKey:     "taglist_key",
 	}
 

--- a/apis/fluentbit/v1alpha2/plugins/output/kinesis_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/kinesis_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	"github.com/onsi/gomega"
 )
 
@@ -22,7 +23,7 @@ func TestOutput_Kinesis_Params(t *testing.T) {
 		RoleARN:           "arn:aws:iam:test",
 		Endpoint:          "test_endpoint",
 		STSEndpoint:       "test_sts_endpoint",
-		AutoRetryRequests: ptr(true),
+		AutoRetryRequests: utils.ToPtr(true),
 		ExternalID:        "test_external_id",
 	}
 

--- a/apis/fluentbit/v1alpha2/plugins/output/open_telemetry_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/open_telemetry_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,7 @@ func TestOpenTelemetry_Params(t *testing.T) {
 	sl := plugins.NewSecretLoader(fc, "test_namespace")
 	ot := OpenTelemetry{
 		Host:                  "otlp-collector.example.com",
-		Port:                  ptr[int32](443),
+		Port:                  utils.ToPtr[int32](443),
 		HTTPUser:              &plugins.Secret{ValueFrom: plugins.ValueSource{SecretKeyRef: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "http_secret"}, Key: "http_user"}}},
 		HTTPPasswd:            &plugins.Secret{ValueFrom: plugins.ValueSource{SecretKeyRef: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "http_secret"}, Key: "http_passwd"}}},
 		Proxy:                 "expected_proxy",
@@ -33,12 +34,12 @@ func TestOpenTelemetry_Params(t *testing.T) {
 		LogsUri:               "expected_logs_uri",
 		TracesUri:             "expected_traces_uri",
 		Header:                map[string]string{"custom_header_key": "custom_header_val"},
-		LogResponsePayload:    ptr(true),
+		LogResponsePayload:    utils.ToPtr(true),
 		AddLabel:              map[string]string{"add_label_key": "add_label_val"},
-		LogsBodyKeyAttributes: ptr(true),
+		LogsBodyKeyAttributes: utils.ToPtr(true),
 		LogsBodyKey:           "expected_logs_body_key",
-		TLS:                   &plugins.TLS{Verify: ptr(false)},
-		Networking:            &plugins.Networking{SourceAddress: ptr("expected_source_address")},
+		TLS:                   &plugins.TLS{Verify: utils.ToPtr(false)},
+		Networking:            &plugins.Networking{SourceAddress: utils.ToPtr("expected_source_address")},
 	}
 
 	expected := params.NewKVs()

--- a/apis/fluentbit/v1alpha2/plugins/output/s3_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/s3_types_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
 	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
 	. "github.com/onsi/gomega"
 )
 
@@ -25,23 +26,23 @@ func TestOutput_S3_Params(t *testing.T) {
 		StoreDirLimitSize:        "0",
 		S3KeyFormat:              "/fluent-bit-logs/$TAG/%Y/%m/%d/%H/%M/%S",
 		S3KeyFormatTagDelimiters: ".",
-		StaticFilePath:           ptr(false),
-		UsePutObject:             ptr(false),
+		StaticFilePath:           utils.ToPtr(false),
+		UsePutObject:             utils.ToPtr(false),
 		RoleArn:                  "role",
 		Endpoint:                 "endpoint",
 		StsEndpoint:              "sts_endpoint",
 		CannedAcl:                "canned_acl",
 		Compression:              "gzip",
 		ContentType:              "text/plain",
-		SendContentMd5:           ptr(false),
-		AutoRetryRequests:        ptr(true),
+		SendContentMd5:           utils.ToPtr(false),
+		AutoRetryRequests:        utils.ToPtr(true),
 		LogKey:                   "log_key",
-		PreserveDataOrdering:     ptr(true),
+		PreserveDataOrdering:     utils.ToPtr(true),
 		StorageClass:             "storage_class",
-		RetryLimit:               ptr[int32](1),
+		RetryLimit:               utils.ToPtr[int32](1),
 		ExternalId:               "external_id",
 		Profile:                  "my-profile",
-		Workers:                  ptr[int32](1),
+		Workers:                  utils.ToPtr[int32](1),
 	}
 
 	expected := params.NewKVs()


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

- Using the reusable `ToPtr` method in `utils` package to adhere to clean code practices.
- Removed 2 `ptr` methods in random directories because we have one in `utils` package that can be shared and reused across all other packages.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1749 

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
