### PR TITLE
release: Updates setup kustomization to reference specific version

### DIFF
--- a/manifests/setup/fluent-operator-deployment.yaml
+++ b/manifests/setup/fluent-operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
           mountPath: /var/run/docker.sock
       containers:
       - name: fluent-operator
-        image: kubesphere/fluent-operator:latest
+        image: ghcr.io/fluent/fluent-operator/fluent-operator:v3.5.0
         env:
           - name: NAMESPACE
             valueFrom:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -40352,7 +40352,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: kubesphere/fluent-operator:latest
+        image: ghcr.io/fluent/fluent-operator/fluent-operator:v3.5.0
         name: fluent-operator
         resources:
           limits:


### PR DESCRIPTION
We should not release our `setup.yaml` with a `latest` image in the _Deployment_.