### PR TITLE
ci: Add arm64 makefile targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,8 @@ build-op-amd64:
 	docker build --platform=linux/amd64 -f cmd/fluent-manager/Dockerfile . -t ${FO_IMG}
 
 # Build arm64 Fluent Operator container image
-.PHONY: build-op-amd64
-build-op-amd64:
+.PHONY: build-op-arm64
+build-op-arm64:
 	docker build --platform=linux/arm64 -f cmd/fluent-manager/Dockerfile . -t ${FO_IMG}
 
 # Build amd64 Fluent Bit container image
@@ -161,12 +161,12 @@ build-fb-arm64:
 # Build amd64 Fluentd container image
 .PHONY: build-fd-amd64
 build-fd-amd64:
-	docker build --platform=linux/amd64 -f cmd/fluent-watcher/fluentd/Dockerfile.amd64 . -t ${FD_IMG}
+	docker build --platform=linux/amd64 -f cmd/fluent-watcher/fluentd/Dockerfile . -t ${FD_IMG}
 
 # Build arm64 Fluentd container image
 .PHONY: build-fd-arm64
 build-fd-arm64:
-	docker build --platform=linux/arm64 -f cmd/fluent-watcher/fluentd/Dockerfile.amd64 . -t ${FD_IMG}
+	docker build --platform=linux/arm64 -f cmd/fluent-watcher/fluentd/Dockerfile . -t ${FD_IMG}
 
 # Prepare for arm64 building
 prepare-build:


### PR DESCRIPTION
Adds `arm64` make targets for building arm64 images locally.

Example builds of fluent-operator:

arm64:
```
❯ make build-arm64
docker build --platform=linux/arm64 -f cmd/fluent-manager/Dockerfile . -t kubesphere/fluent-operator:v3.5.0
[+] Building 1.4s (18/18) FINISHED                                                                                                                                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                       0.2s
 => => transferring dockerfile: 37B                                                                                                                                                                                                                        0.1s
 => [internal] load .dockerignore                                                                                                                                                                                                                          0.0s
 => => transferring context: 35B                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/kubesphere/distroless-static:nonroot                                                                                                                                                                            1.1s
 => [internal] load metadata for docker.io/library/golang:1.24.5-alpine3.21                                                                                                                                                                                1.0s
 => [builder  1/10] FROM docker.io/library/golang:1.24.5-alpine3.21@sha256:6edc20586dd08dacad538c1f09984bc2aa61720be59056cf75429691f294d731                                                                                                                0.0s
 => [stage-1 1/3] FROM docker.io/kubesphere/distroless-static:nonroot@sha256:6a3500b086c2856fbc189f5d11351bdbcf7c4dc5673c2b6070aac9d607da90d7                                                                                                              0.0s
 => [internal] load build context                                                                                                                                                                                                                          0.0s
 => => transferring context: 23.33kB                                                                                                                                                                                                                       0.0s
 => CACHED [builder  2/10] WORKDIR /workspace                                                                                                                                                                                                              0.0s
 => CACHED [builder  3/10] COPY go.mod go.mod                                                                                                                                                                                                              0.0s
 => CACHED [builder  4/10] COPY go.sum go.sum                                                                                                                                                                                                              0.0s
 => CACHED [builder  5/10] RUN go mod download                                                                                                                                                                                                             0.0s
 => CACHED [builder  6/10] COPY cmd/fluent-manager/main.go main.go                                                                                                                                                                                         0.0s
 => CACHED [builder  7/10] COPY apis apis/                                                                                                                                                                                                                 0.0s
 => CACHED [builder  8/10] COPY controllers controllers/                                                                                                                                                                                                   0.0s
 => CACHED [builder  9/10] COPY pkg pkg/                                                                                                                                                                                                                   0.0s
 => CACHED [builder 10/10] RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -a -o manager main.go                                                                                                                                         0.0s
 => CACHED [stage-1 2/3] COPY --from=builder /workspace/manager .                                                                                                                                                                                          0.0s
 => exporting to image                                                                                                                                                                                                                                     0.0s
 => => exporting layers                                                                                                                                                                                                                                    0.0s
 => => writing image sha256:69aeeca020798969424364037fdca5e027bc4b09ed9ddf355733ccf1eac05066                                                                                                                                                               0.0s
 => => naming to docker.io/kubesphere/fluent-operator:v3.5.0  
```
amd64:
```
❯ make build-amd64
docker build --platform=linux/amd64 -f cmd/fluent-manager/Dockerfile . -t kubesphere/fluent-operator:v3.5.0
[+] Building 337.0s (18/18) FINISHED                                                                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                       0.0s
 => => transferring dockerfile: 37B                                                                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                          0.0s
 => => transferring context: 35B                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/kubesphere/distroless-static:nonroot                                                                                                                                                                            0.3s
 => [internal] load metadata for docker.io/library/golang:1.24.5-alpine3.21                                                                                                                                                                                0.3s
 => [builder  1/10] FROM docker.io/library/golang:1.24.5-alpine3.21@sha256:6edc20586dd08dacad538c1f09984bc2aa61720be59056cf75429691f294d731                                                                                                                0.0s
 => CACHED [stage-1 1/3] FROM docker.io/kubesphere/distroless-static:nonroot@sha256:6a3500b086c2856fbc189f5d11351bdbcf7c4dc5673c2b6070aac9d607da90d7                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                                                                                          0.0s
 => => transferring context: 23.33kB                                                                                                                                                                                                                       0.0s
 => CACHED [builder  2/10] WORKDIR /workspace                                                                                                                                                                                                              0.0s
 => CACHED [builder  3/10] COPY go.mod go.mod                                                                                                                                                                                                              0.0s
 => CACHED [builder  4/10] COPY go.sum go.sum                                                                                                                                                                                                              0.0s
 => CACHED [builder  5/10] RUN go mod download                                                                                                                                                                                                             0.0s
 => CACHED [builder  6/10] COPY cmd/fluent-manager/main.go main.go                                                                                                                                                                                         0.0s
 => CACHED [builder  7/10] COPY apis apis/                                                                                                                                                                                                                 0.0s
 => CACHED [builder  8/10] COPY controllers controllers/                                                                                                                                                                                                   0.0s
 => CACHED [builder  9/10] COPY pkg pkg/                                                                                                                                                                                                                   0.0s
 => [builder 10/10] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go                                                                                                                                              335.4s
 => [stage-1 2/3] COPY --from=builder /workspace/manager .                                                                                                                                                                                                 0.5s
 => exporting to image                                                                                                                                                                                                                                     0.2s
 => => exporting layers                                                                                                                                                                                                                                    0.2s
 => => writing image sha256:9c648fe14f110e205107400f8dab14a4a1b9151a237c73060d918690c07038b8                                                                                                                                                               0.0s
 => => naming to docker.io/kubesphere/fluent-operator:v3.5.0     
```