### PR TITLE
fluentd: Fix docker tag

### DIFF
--- a/cmd/fluent-watcher/fluentd/Dockerfile
+++ b/cmd/fluent-watcher/fluentd/Dockerfile
@@ -10,8 +10,7 @@ WORKDIR /code
 RUN echo $(ls -al /code)
 RUN CGO_ENABLED=0 go build -ldflags '-w -s' -o /fluentd/fluentd-watcher /code/cmd/fluent-watcher/fluentd/main.go
 
-# See https://github.com/fluent/fluentd-docker-image/issues/425
-FROM fluent/fluentd:v${FLUENTD_BASE_VERSION}-debian-1.0
+FROM fluent/fluentd:v${FLUENTD_BASE_VERSION}-debian
 
 LABEL org.opencontainers.image.description "A Fluentd image for use with fluent-operator"
 


### PR DESCRIPTION
fluentd's docker tagging scheme recently changed:

https://github.com/fluent/fluentd-docker-image/issues/425#issuecomment-2750585471