### PR TITLE
Fix ClusterParser/ClusterMultilineParser namespace filtering bug (#1778)

### DIFF
--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -340,7 +340,9 @@ func (r *FluentBitConfigReconciler) ListFluentBitConfigResources(
 		return filters, outputs, parsers, clusterParsers, multipleParsers, clusterMultipleParsers, err
 	}
 
-	if err := listClusterResources(ctx, r.Client, &cfg.Spec.ClusterMultilineParserSelector, &clusterMultipleParsers); err != nil {
+	if err := listClusterResources(
+		ctx, r.Client, &cfg.Spec.ClusterMultilineParserSelector, &clusterMultipleParsers,
+	); err != nil {
 		return filters, outputs, parsers, clusterParsers, multipleParsers, clusterMultipleParsers, err
 	}
 


### PR DESCRIPTION
ClusterParsers and ClusterMultilineParsers are cluster-scoped resources and should not be filtered by namespace. This bug was introduced in commit 30cd0c37 (PR #1708) where the code was refactored to use a listNamespacedResources helper function that incorrectly added namespace filtering for cluster-scoped resources.

This caused ClusterParsers referenced from namespace-scoped Filters to not be generated in parsers.conf with their hash-suffixed names, leading to fluent-bit pods crashlooping with 'requested parser not found' errors.

The fix:
1. Changes the function to use listClusterResources (which doesn't filter by namespace) for ClusterParsers and ClusterMultilineParsers.
2. Renames ListNamespacedResources to ListFluentBitConfigResources to better reflect that it lists both namespaced and cluster-scoped resources needed by a FluentBitConfig.

Note: The original code (pre-refactor) also had a bug where ClusterMultilineParsers were incorrectly filtered by namespace.

Fixes #1778
