### PR TITLE
ci/build: Copy and build all go files for fluent-manager

### DIFF
--- a/cmd/fluent-manager/Dockerfile
+++ b/cmd/fluent-manager/Dockerfile
@@ -12,14 +12,14 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY cmd/fluent-manager/main.go main.go
+COPY cmd/fluent-manager/*.go ./
 COPY apis apis/
 COPY controllers controllers/
 COPY pkg pkg/
 
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager .
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Related to https://github.com/fluent/fluent-operator/pull/1781.

Fixes `Dockerfile` so we COPY and build all go files.