### PR TITLE
Updates fluent-manager base image

### DIFF
--- a/cmd/fluent-manager/Dockerfile
+++ b/cmd/fluent-manager/Dockerfile
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GO111MODULE=on go build 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM kubesphere/distroless-static:nonroot
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot


### PR DESCRIPTION
The base image being used was not maintained and based off an EOL'd Debian image.

Fixes #1787