### PR TITLE
fix: use fully-qualified DNS name in Fluent Bit ClusterOutput

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-output-forward.yaml
+++ b/charts/fluent-operator/templates/fluentbit-output-forward.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   matchRegex: (?:kube|service)\.(.*)
   forward:
-    host: {{ printf "%s.%s.svc" .Values.fluentd.name .Release.Namespace | quote }}
+    host: {{ printf "%s.%s.svc.cluster.local" .Values.fluentd.name .Release.Namespace | quote }}
     port: {{ .Values.fluentd.forward.port }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Update the Fluent Bit forward ClusterOutput template to use the fully-qualified domain name (.svc.cluster.local) instead of the partially qualified name (.svc) to ensure reliable service discovery across all namespaces and prevent cross-namespace DNS resolution issues.

Fixes #1794

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
