### PR TITLE
chore(deps): Update operator-sdk from v1.41.1 to v1.42.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ARCH ?= arm64
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= crd:generateEmbeddedObjectMeta=true,allowDangerousTypes=true
-OPERATOR_SDK_VERSION ?= v1.41.1
+OPERATOR_SDK_VERSION ?= v1.42.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
https://v1-42-x.sdk.operatorframework.io/docs/upgrading-sdk-version/v1.42.0/

no migrations required
