### PR TITLE
helm: Align crds charts appVersion with operator version

### DIFF
--- a/charts/fluent-bit-crds/Chart.yaml
+++ b/charts/fluent-bit-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fluent-bit-crds
 description: A helm chart for Fluent-Bit custom resource definitions (CRDs) used by fluent-operator.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: v3.5.0
 keywords:
   - logging
   - fluentd

--- a/charts/fluentd-crds/Chart.yaml
+++ b/charts/fluentd-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fluentd-crds
 description: A helm chart for Fluentd custom resource definitions (CRDs) used by fluent-operator.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: v3.5.0
 keywords:
   - logging
   - fluentd


### PR DESCRIPTION
Also bumping the chart version itself because of https://github.com/fluent/fluent-operator/pull/1762 that got just merged.