### PR TITLE
helm-chart: Add ability to configure additional rbac for fluent-operator cluster-role

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-clusterRole.yaml
@@ -145,7 +145,7 @@ rules:
       - get
       - watch
       - patch
-  {{- with .Values.operator.rbac.AdditionalRules }}
+  {{- with .Values.operator.rbac.additionalRules }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- end }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -36,7 +36,7 @@ operator:
       name: fluent-operator
     # Adds additional permissions to Fluent Operator, since operator cannot give permissions it does not have.
     # Use case includes adding permission to a custom fluent-bit deployment to access kubelet.
-    AdditionalRules: []
+    additionalRules: []
   # Container security context for Fluent Operator container. Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext: {}
   # Fluent Operator resources. Usually user needn't to adjust these.


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
Expand the chart to add ability to configure additional rbac for fluent-operator cluster-role.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1399 #1772

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Expand the chart to add ability to configure additional rbac for fluent-operator cluster-role
```
