### PR TITLE
fix: correct parameter name from client_certAuth to client_cert_auth

### DIFF
--- a/apis/fluentd/v1alpha1/plugins/common/common_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/common_types.go
@@ -347,7 +347,7 @@ func (t *Transport) Params(_ plugins.SecretLoader) (*params.PluginStore, error) 
 		ps.InsertPairs("client_cert_auth", fmt.Sprint(*t.ClientCertAuth))
 	}
 	if t.CaCertPath != nil {
-		ps.InsertPairs("ca_certPath", fmt.Sprint(*t.CaCertPath))
+		ps.InsertPairs("ca_cert_path", fmt.Sprint(*t.CaCertPath))
 	}
 	if t.CaPrivateKeyPath != nil {
 		ps.InsertPairs("ca_private_key_path", fmt.Sprint(*t.CaPrivateKeyPath))


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

This PR fixes incorrect parameter naming in the Transport plugin. The parameter `client_certAuth` was using camelCase instead of snake_case, which caused TLS mutual authentication to fail because Fluentd doesn't recognize the incorrectly named parameter.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1819

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fix Transport plugin parameter name from client_certAuth to client_cert_auth to match Fluentd's snake_case convention
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
- [Fluentd TLS documentation](https://docs.fluentd.org/input/http#how-to-enable-tls-mutual-authentication)
