### PR TITLE
feat: add support for multiple forward and http in globaInputs

### DIFF
--- a/pkg/operator/fluentd-service.go
+++ b/pkg/operator/fluentd-service.go
@@ -50,8 +50,10 @@ func MakeFluentdService(fd fluentdv1alpha1.Fluentd) *corev1.Service {
 		},
 	}
 
-	// read inputs definition from globalInputs
+	// Read inputs definition from globalInputs
 	globalInputs := fd.Spec.GlobalInputs
+	firstForwardPort := true
+	firstHttpPort := true
 	for _, input := range globalInputs {
 
 		if input.Forward != nil {
@@ -60,13 +62,18 @@ func MakeFluentdService(fd fluentdv1alpha1.Fluentd) *corev1.Service {
 				forwardPort = DefaultForwardPort
 			}
 
+			forwardName := DefaultForwardName
+			if !firstForwardPort {
+				forwardName = fmt.Sprintf("%s-%d", DefaultForwardName, forwardPort)
+			}
 			forwardContainerPort := corev1.ServicePort{
-				Name:       DefaultForwardName,
+				Name:       forwardName,
 				Port:       forwardPort,
 				TargetPort: intstr.FromString(FluentdForwardPortName),
 				Protocol:   corev1.ProtocolTCP,
 			}
 			svc.Spec.Ports = append(svc.Spec.Ports, forwardContainerPort)
+			firstForwardPort = false
 			continue
 		}
 
@@ -75,13 +82,18 @@ func MakeFluentdService(fd fluentdv1alpha1.Fluentd) *corev1.Service {
 			if httpPort == 0 {
 				httpPort = DefaultHttpPort
 			}
+			httpName := DefaultHttpName
+			if !firstHttpPort {
+				httpName = fmt.Sprintf("%s-%d", DefaultHttpName, httpPort)
+			}
 			httpContainerPort := corev1.ServicePort{
-				Name:       DefaultHttpName,
+				Name:       httpName,
 				Port:       httpPort,
 				TargetPort: intstr.FromString(FluentdHttpPortName),
 				Protocol:   corev1.ProtocolTCP,
 			}
 			svc.Spec.Ports = append(svc.Spec.Ports, httpContainerPort)
+			firstHttpPort = false
 		}
 	}
 

--- a/pkg/operator/fluentd-service.go
+++ b/pkg/operator/fluentd-service.go
@@ -10,11 +10,6 @@ import (
 	fluentdv1alpha1 "github.com/fluent/fluent-operator/v3/apis/fluentd/v1alpha1"
 )
 
-const (
-	FluentdForwardPortName = "forward"
-	FluentdHttpPortName    = "http"
-)
-
 func MakeFluentdService(fd fluentdv1alpha1.Fluentd) *corev1.Service {
 	var name string
 	var labels map[string]string
@@ -71,7 +66,7 @@ func MakeFluentdService(fd fluentdv1alpha1.Fluentd) *corev1.Service {
 			forwardContainerPort := corev1.ServicePort{
 				Name:       forwardName,
 				Port:       forwardPort,
-				TargetPort: intstr.FromString(FluentdForwardPortName),
+				TargetPort: intstr.FromString(forwardName),
 				Protocol:   corev1.ProtocolTCP,
 			}
 			svc.Spec.Ports = append(svc.Spec.Ports, forwardContainerPort)
@@ -91,7 +86,7 @@ func MakeFluentdService(fd fluentdv1alpha1.Fluentd) *corev1.Service {
 			httpContainerPort := corev1.ServicePort{
 				Name:       httpName,
 				Port:       httpPort,
-				TargetPort: intstr.FromString(FluentdHttpPortName),
+				TargetPort: intstr.FromString(httpName),
 				Protocol:   corev1.ProtocolTCP,
 			}
 			svc.Spec.Ports = append(svc.Spec.Ports, httpContainerPort)

--- a/pkg/operator/fluentd-service.go
+++ b/pkg/operator/fluentd-service.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/operator/sts.go
+++ b/pkg/operator/sts.go
@@ -188,8 +188,10 @@ func makeFluentdPorts(fd fluentdv1alpha1.Fluentd) []corev1.ContainerPort {
 		},
 	}
 
-	// read inputs definition from globalInputs
+	// Read inputs definition from globalInputs
 	globalInputs := fd.Spec.GlobalInputs
+	firstForwardPort := true
+	firstHttpPort := true
 	for _, input := range globalInputs {
 		if input.Forward != nil {
 			forwardPort := DefaultForwardPort
@@ -197,11 +199,16 @@ func makeFluentdPorts(fd fluentdv1alpha1.Fluentd) []corev1.ContainerPort {
 				forwardPort = *input.Forward.Port
 			}
 
+			forwardName := DefaultForwardName
+			if !firstForwardPort {
+				forwardName = fmt.Sprintf("%s-%d", DefaultForwardName, forwardPort)
+			}
 			ports = append(ports, corev1.ContainerPort{
-				Name:          DefaultForwardName,
+				Name:          forwardName,
 				ContainerPort: forwardPort,
 				Protocol:      corev1.ProtocolTCP,
 			})
+			firstForwardPort = false
 			continue
 		}
 		if input.Http != nil {
@@ -210,11 +217,16 @@ func makeFluentdPorts(fd fluentdv1alpha1.Fluentd) []corev1.ContainerPort {
 				httpPort = *input.Http.Port
 			}
 
+			httpName := DefaultHttpName
+			if !firstHttpPort {
+				httpName = fmt.Sprintf("%s-%d", DefaultHttpName, httpPort)
+			}
 			ports = append(ports, corev1.ContainerPort{
-				Name:          DefaultHttpName,
+				Name:          httpName,
 				ContainerPort: httpPort,
 				Protocol:      corev1.ProtocolTCP,
 			})
+			firstHttpPort = false
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:
There are cases were we would like to add several forward or http global inputs to the same fluent deployment.
for example, separate processing logic depending on tag prefix.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1833

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Added support for multiple forward and http in globaInputs.
```

### Additional information
The PR does not include an breaking changes, since the first iteration of forward/http port name stays the same in the container and service of fluentd. The code can be further simplified by removing the backward compatibility logic.