### PR TITLE
Addition of rdkafka gem to support rdkafka_group for fluent-plugin-kafka

### DIFF
--- a/cmd/fluent-watcher/fluentd/Dockerfile
+++ b/cmd/fluent-watcher/fluentd/Dockerfile
@@ -36,7 +36,7 @@ RUN buildDeps="make gcc g++ libc-dev" \
         fluent-plugin-grafana-loki \
         fluent-plugin-cloudwatch-logs \
         fluent-plugin-datadog \
-        fluent-plugin-prometheus
+        fluent-plugin-prometheus \
  && gem sources --clear-all \
  && apt-get purge -y --auto-remove \
                   -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
fluent-plugin-kafka has support for rdkafka_group that is based on rdkafka (based on librdkafka) which does not automatically come with the plugin and must be installed explicitly.

### What this PR does / why we need it:

It is needed to fix the issue below.

### Which issue(s) this PR fixes:

Fixes #1866 

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
Fluentd image now includes rdkafka, enabling use of rdkafka_group.

See: https://github.com/fluent/fluent-plugin-kafka?tab=readme-ov-file#input-plugin-type-rdkafka_group-supports-kafka-consumer-groups-uses-rdkafka-ruby
```
