### PR TITLE
feat(fluentbit): add support for multiline_buffer_limit configuration…

### DIFF
--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
@@ -126,6 +126,9 @@ type Service struct {
 	SchedulerBase *int32 `json:"schedulerBase,omitempty"`
 	// Set a maximum retry time in seconds for the scheduler. Supported in Fluent Bit >= 1.8.7
 	SchedulerCap *int32 `json:"schedulerCap,omitempty"`
+	// Set a default buffer size limit for multiline parsers. The value must be according to the Unit Size specification.
+	// +kubebuilder:validation:Pattern:="^\\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$"
+	MultilineBufferLimit string `json:"multilineBufferLimit,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -242,6 +245,9 @@ func (s *Service) Params() *params.KVs {
 	}
 	if s.SchedulerCap != nil {
 		m.Insert("scheduler.cap", fmt.Sprint(*s.SchedulerCap))
+	}
+	if s.MultilineBufferLimit != "" {
+		m.Insert("multiline_buffer_limit", s.MultilineBufferLimit)
 	}
 	return m
 }

--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types_test.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types_test.go
@@ -1184,6 +1184,47 @@ func TestRenderMainConfigK8sInYaml(t *testing.T) {
 	g.Expect(yamlConfig).To(Equal(expectedK8sYamlWithClusterFilterOutput))
 }
 
+func TestClusterFluentBitConfig_Service_MultilineBufferLimit(t *testing.T) {
+	g := NewGomegaWithT(t)
+	sl := plugins.NewSecretLoader(nil, "testnamespace")
+
+	cfbc := ClusterFluentBitConfig{
+		Spec: FluentBitConfigSpec{
+			Service: &Service{
+				Daemon:               utils.ToPtr(false),
+				FlushSeconds:         utils.ToPtr[float64](1),
+				MultilineBufferLimit: "5MB",
+			},
+		},
+	}
+
+	expectedClassic := `[Service]
+    Daemon    false
+    Flush    1
+    multiline_buffer_limit    5MB
+`
+	expectedYamlFmt := `service:
+  daemon: false
+  flush: 1
+  multiline_buffer_limit: 5MB
+pipeline:
+  inputs:
+  outputs:
+`
+
+	config, err := cfbc.RenderMainConfig(
+		sl, ClusterInputList{}, ClusterFilterList{}, ClusterOutputList{}, nil, nil, nil,
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(config).To(Equal(expectedClassic))
+
+	yamlConfig, err := cfbc.RenderMainConfigInYaml(
+		sl, ClusterInputList{}, ClusterFilterList{}, ClusterOutputList{}, nil, nil, nil,
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(yamlConfig).To(Equal(expectedYamlFmt))
+}
+
 func TestClusterFluentBitConfig_RenderMainConfig_WithParsersFiles(t *testing.T) {
 	g := NewGomegaWithT(t)
 	sl := plugins.NewSecretLoader(nil, "testnamespace")

--- a/charts/fluent-bit-crds/templates/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/charts/fluent-bit-crds/templates/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -372,6 +372,11 @@ spec:
                     - debug
                     - trace
                     type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
+                    type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)
                     type: string

--- a/charts/fluent-bit-crds/templates/fluentbit.fluent.io_fluentbitconfigs.yaml
+++ b/charts/fluent-bit-crds/templates/fluentbit.fluent.io_fluentbitconfigs.yaml
@@ -404,6 +404,11 @@ spec:
                     - debug
                     - trace
                     type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
+                    type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)
                     type: string

--- a/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusterfluentbitconfigs.yaml
@@ -369,6 +369,11 @@ spec:
                     - debug
                     - trace
                     type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
+                    type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)
                     type: string

--- a/config/crd/bases/fluentbit.fluent.io_fluentbitconfigs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_fluentbitconfigs.yaml
@@ -401,6 +401,11 @@ spec:
                     - debug
                     - trace
                     type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
+                    type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)
                     type: string

--- a/docs/fluentbit.md
+++ b/docs/fluentbit.md
@@ -646,6 +646,7 @@ ParserSpec defines the desired state of ClusterParser
 | hotReload | If true enable reloading via HTTP | *bool |
 | schedulerBase | Set a base for exponential backoff in the scheduler. Supported in Fluent Bit >= 1.8.7 | *int32 |
 | schedulerCap | Set a maximum retry time in seconds for the scheduler. Supported in Fluent Bit >= 1.8.7 | *int32 |
+| multilineBufferLimit | Set a default buffer size limit for multiline parsers. The value must be according to the Unit Size specification. | string |
 
 [Back to TOC](#table-of-contents)
 # Storage

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -1830,6 +1830,11 @@ spec:
                     - debug
                     - trace
                     type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
+                    type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)
                     type: string
@@ -17081,6 +17086,11 @@ spec:
                     - info
                     - debug
                     - trace
+                    type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -1830,6 +1830,11 @@ spec:
                     - debug
                     - trace
                     type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
+                    type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)
                     type: string
@@ -17081,6 +17086,11 @@ spec:
                     - info
                     - debug
                     - trace
+                    type: string
+                  multilineBufferLimit:
+                    description: Set a default buffer size limit for multiline parsers.
+                      The value must be according to the Unit Size specification.
+                    pattern: ^\d+(k|K|KB|kb|m|M|MB|mb|g|G|GB|gb)?$
                     type: string
                   parsersFile:
                     description: Optional 'parsers' config file (can be multiple)


### PR DESCRIPTION
… to FluentBitConfig and ClusterFluentBitConfig

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Adds support for the multiline_buffer_limit configuration field.

### Which issue(s) this PR fixes:
Fixes #1876

### Does this PR introduced a user-facing change?
```release-note
add support for multiline_buffer_limit configuration to FluentBitConfig and ClusterFluentBitConfig
```

### Additional documentation, usage docs, etc.:
```docs

```
