### PR TITLE
Add log_response_payload support to HTTP Output plugin

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/http_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/http_types.go
@@ -38,6 +38,8 @@ type HTTP struct {
 	// Specify if duplicated headers are allowed.
 	// If a duplicated header is found, the latest key/value set is preserved.
 	AllowDuplicatedHeaders *bool `json:"allowDuplicatedHeaders,omitempty"`
+	// Specify if the response paylod should be logged or not.
+	LogResponsePayload *bool `json:"logResponsePayload,omitempty"`
 	// Specify an optional HTTP header field for the original message tag.
 	HeaderTag string `json:"headerTag,omitempty"`
 	// Add a HTTP header key/value pair. Multiple headers can be set.
@@ -105,6 +107,7 @@ func (h *HTTP) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 	plugins.InsertKVString(kvs, "gelf_full_message_key", h.GelfFullMessageKey)
 	plugins.InsertKVString(kvs, "gelf_level_key", h.GelfLevelKey)
 	plugins.InsertKVField(kvs, "allow_duplicated_headers", h.AllowDuplicatedHeaders)
+	plugins.InsertKVField(kvs, "log_response_payload", h.LogResponsePayload)
 
 	if h.TLS != nil {
 		tls, err := h.TLS.Params(sl)

--- a/apis/fluentbit/v1alpha2/plugins/output/http_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/http_types_test.go
@@ -25,16 +25,17 @@ func TestHTTP_Params(t *testing.T) {
 
 	sl := plugins.NewSecretLoader(fc, "test_namespace")
 	h := HTTP{
-		Host:           "example.com",
-		Port:           utils.ToPtr[int32](443),
-		HTTPUser:       &plugins.Secret{ValueFrom: plugins.ValueSource{SecretKeyRef: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "http_secret"}, Key: "http_user"}}},
-		HTTPPasswd:     &plugins.Secret{ValueFrom: plugins.ValueSource{SecretKeyRef: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "http_secret"}, Key: "http_passwd"}}},
-		Uri:            "/logs",
-		Format:         "json",
-		Headers:        map[string]string{"X-Custom": "value"},
-		TLS:            &plugins.TLS{Verify: utils.ToPtr(false)},
-		Networking:     &plugins.Networking{SourceAddress: utils.ToPtr("expected_source_address")},
-		TotalLimitSize: "512M",
+		Host:               "example.com",
+		Port:               utils.ToPtr[int32](443),
+		HTTPUser:           &plugins.Secret{ValueFrom: plugins.ValueSource{SecretKeyRef: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "http_secret"}, Key: "http_user"}}},
+		HTTPPasswd:         &plugins.Secret{ValueFrom: plugins.ValueSource{SecretKeyRef: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "http_secret"}, Key: "http_passwd"}}},
+		Uri:                "/logs",
+		Format:             "json",
+		LogResponsePayload: utils.ToPtr(false),
+		Headers:            map[string]string{"X-Custom": "value"},
+		TLS:                &plugins.TLS{Verify: utils.ToPtr(false)},
+		Networking:         &plugins.Networking{SourceAddress: utils.ToPtr("expected_source_address")},
+		TotalLimitSize:     "512M",
 	}
 
 	expected := params.NewKVs()
@@ -45,6 +46,7 @@ func TestHTTP_Params(t *testing.T) {
 	expected.Insert("uri", "/logs")
 	expected.Insert("format", "json")
 	expected.Insert("header", " X-Custom    value")
+	expected.Insert("log_response_payload", "false")
 	expected.Insert("tls", "On")
 	expected.Insert("tls.verify", "false")
 	expected.Insert("net.source_address", "expected_source_address")

--- a/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/zz_generated.deepcopy.go
@@ -432,6 +432,11 @@ func (in *HTTP) DeepCopyInto(out *HTTP) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.LogResponsePayload != nil {
+		in, out := &in.LogResponsePayload, &out.LogResponsePayload
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Headers != nil {
 		in, out := &in.Headers, &out.Headers
 		*out = make(map[string]string, len(*in))

--- a/charts/fluent-bit-crds/templates/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-bit-crds/templates/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1585,6 +1585,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:

--- a/charts/fluent-bit-crds/templates/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-bit-crds/templates/fluentbit.fluent.io_outputs.yaml
@@ -1585,6 +1585,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -1582,6 +1582,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -1582,6 +1582,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:

--- a/docs/plugins/fluentbit/output/http.md
+++ b/docs/plugins/fluentbit/output/http.md
@@ -14,6 +14,7 @@ The http output plugin allows to flush your records into a HTTP endpoint. <br />
 | compress | Set payload compression mechanism. Option available is 'gzip' | string |
 | format | Specify the data format to be used in the HTTP request body, by default it uses msgpack. Other supported formats are json, json_stream and json_lines and gelf. | string |
 | allowDuplicatedHeaders | Specify if duplicated headers are allowed. If a duplicated header is found, the latest key/value set is preserved. | *bool |
+| logResponsePayload | Specify if the response paylod should be logged or not. | *bool |
 | headerTag | Specify an optional HTTP header field for the original message tag. | string |
 | headers | Add a HTTP header key/value pair. Multiple headers can be set. | map[string]string |
 | jsonDateKey | Specify the name of the time key in the output record. To disable the time key just set the value to false. | string |

--- a/manifests/setup/fluent-operator-crd.yaml
+++ b/manifests/setup/fluent-operator-crd.yaml
@@ -5728,6 +5728,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:
@@ -35770,6 +35774,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -5728,6 +5728,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:
@@ -35770,6 +35774,10 @@ spec:
                       Specify the name of the time key in the output record.
                       To disable the time key just set the value to false.
                     type: string
+                  logResponsePayload:
+                    description: Specify if the response paylod should be logged or
+                      not.
+                    type: boolean
                   networking:
                     description: Include fluentbit networking options for this output-plugin
                     properties:


### PR DESCRIPTION
Added the LogResponsePayload field to the HTTP output plugin struct and its rendering in the Params() method.

### What this PR does / why we need it:

Add `log_response_payload` support to HTTP Output plugin.

`log_response_payload` defaults to `On` whereas it would be useful to set it to `Off`.

### Which issue(s) this PR fixes:

Fixes #1896

### Does this PR introduced a user-facing change?

```release-note
Add log_response_payload support to HTTP Output plugin
```