### PR TITLE
feat(helm): add namespaceOverride support to FluentBit chart

### DIFF
--- a/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
+++ b/charts/fluent-operator/templates/fluentbit-fluentBit.yaml
@@ -4,7 +4,7 @@ apiVersion: fluentbit.fluent.io/v1alpha2
 kind: FluentBit
 metadata:
   name: fluent-bit
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ default .Release.Namespace .Values.fluentbit.namespaceOverride | quote }}
   labels:
     app.kubernetes.io/name: fluent-bit
 spec:

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -113,6 +113,8 @@ operator:
 fluentbit:
   # -- Enable Fluent Bit deployment
   enable: true
+  # -- Override the namespace for FluentBit resources; defaults to .Release.Namespace
+  namespaceOverride: ""
   serviceMonitor:
     # -- Enable Prometheus ServiceMonitor for Fluent Bit
     enable: false


### PR DESCRIPTION
## Summary
Adds `fluentbit.namespaceOverride` to allow deploying FluentBit resources into a configurable namespace, falling back to `.Release.Namespace` when unset.

## Changes
- `values.yaml`: added `fluentbit.namespaceOverride: ""`
- `templates/fluentbit-fluentBit.yaml`: namespace resolves via `default .Release.Namespace .Values.fluentbit.namespaceOverride`

Fixes #1918