### PR TITLE
chore(sec): upgrade go to v1.26.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "docker.io/golang:1.23",
+  "image": "docker.io/golang:1.26.2",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/git:1": {}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.6.2
+          version: v2.11.4

--- a/apis/fluentbit/v1alpha2/clusterfilter_types.go
+++ b/apis/fluentbit/v1alpha2/clusterfilter_types.go
@@ -131,16 +131,16 @@ func (list ClusterFilterList) Load(sl plugins.SecretLoader) (string, error) {
 
 			buf.WriteString("[Filter]\n")
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("    Name    %s\n", p.Name()))
+				fmt.Fprintf(&buf, "    Name    %s\n", p.Name())
 			}
 			if item.Spec.LogLevel != "" {
-				buf.WriteString(fmt.Sprintf("    Log_Level    %s\n", item.Spec.LogLevel))
+				fmt.Fprintf(&buf, "    Log_Level    %s\n", item.Spec.LogLevel)
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("    Match    %s\n", item.Spec.Match))
+				fmt.Fprintf(&buf, "    Match    %s\n", item.Spec.Match)
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("    Match_Regex    %s\n", item.Spec.MatchRegex))
+				fmt.Fprintf(&buf, "    Match_Regex    %s\n", item.Spec.MatchRegex)
 			}
 			kvs, err := p.Params(sl)
 			if err != nil {
@@ -170,7 +170,7 @@ func (list ClusterFilterList) LoadAsYaml(sl plugins.SecretLoader, depth int) (st
 	if len(list.Items) == 0 {
 		return "", nil
 	}
-	buf.WriteString(fmt.Sprintf("%sfilters:\n", utils.YamlIndent(depth)))
+	fmt.Fprintf(&buf, "%sfilters:\n", utils.YamlIndent(depth))
 	padding := utils.YamlIndent(depth + 2)
 
 	for _, item := range list.Items {
@@ -180,16 +180,16 @@ func (list ClusterFilterList) LoadAsYaml(sl plugins.SecretLoader, depth int) (st
 			}
 
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("%s- name: %s\n", utils.YamlIndent(depth+1), p.Name()))
+				fmt.Fprintf(&buf, "%s- name: %s\n", utils.YamlIndent(depth+1), p.Name())
 			}
 			if item.Spec.LogLevel != "" {
-				buf.WriteString(fmt.Sprintf("%slog_level: %s\n", padding, item.Spec.LogLevel))
+				fmt.Fprintf(&buf, "%slog_level: %s\n", padding, item.Spec.LogLevel)
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("%smatch: \"%s\"\n", padding, item.Spec.Match))
+				fmt.Fprintf(&buf, "%smatch: \"%s\"\n", padding, item.Spec.Match)
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("%smatch_regex: %s\n", padding, item.Spec.MatchRegex))
+				fmt.Fprintf(&buf, "%smatch_regex: %s\n", padding, item.Spec.MatchRegex)
 			}
 			kvs, err := p.Params(sl)
 			if err != nil {

--- a/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
+++ b/apis/fluentbit/v1alpha2/clusterfluentbitconfig_types.go
@@ -337,7 +337,7 @@ func (cfg ClusterFluentBitConfig) RenderMainConfigInYaml(
 		buf.WriteString(rtc)
 	}
 	if filterSections == "" && nsFilterSections != nil {
-		buf.WriteString(fmt.Sprintf("%sfilters:\n", utils.YamlIndent(1)))
+		fmt.Fprintf(&buf, "%sfilters:\n", utils.YamlIndent(1))
 	} else {
 		// 1. filterSections == "" && nsFilterSections == nil
 		// 2. filterSections != "" && nsFilterSections != nil
@@ -348,7 +348,7 @@ func (cfg ClusterFluentBitConfig) RenderMainConfigInYaml(
 		buf.WriteString(filters)
 	}
 	if outputSections == "" && nsOutputSections != nil {
-		buf.WriteString(fmt.Sprintf("%soutputs:\n", utils.YamlIndent(1)))
+		fmt.Fprintf(&buf, "%soutputs:\n", utils.YamlIndent(1))
 	} else {
 		// 1. outputSections == "" && nsOutputSections == nil
 		// 2. outputSections != "" && nsOutputSections != nil

--- a/apis/fluentbit/v1alpha2/clusterinput_types.go
+++ b/apis/fluentbit/v1alpha2/clusterinput_types.go
@@ -126,13 +126,13 @@ func (list ClusterInputList) Load(sl plugins.SecretLoader) (string, error) {
 
 			buf.WriteString("[Input]\n")
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("    Name    %s\n", p.Name()))
+				fmt.Fprintf(&buf, "    Name    %s\n", p.Name())
 			}
 			if item.Spec.Alias != "" {
-				buf.WriteString(fmt.Sprintf("    Alias    %s\n", item.Spec.Alias))
+				fmt.Fprintf(&buf, "    Alias    %s\n", item.Spec.Alias)
 			}
 			if item.Spec.LogLevel != "" {
-				buf.WriteString(fmt.Sprintf("    Log_Level    %s\n", item.Spec.LogLevel))
+				fmt.Fprintf(&buf, "    Log_Level    %s\n", item.Spec.LogLevel)
 			}
 			kvs, err := p.Params(sl)
 			if err != nil {
@@ -157,7 +157,7 @@ func (list ClusterInputList) LoadAsYaml(sl plugins.SecretLoader, depth int) (str
 	var buf bytes.Buffer
 
 	sort.Sort(InputByName(list.Items))
-	buf.WriteString(fmt.Sprintf("%sinputs:\n", utils.YamlIndent(depth)))
+	fmt.Fprintf(&buf, "%sinputs:\n", utils.YamlIndent(depth))
 	padding := utils.YamlIndent(depth + 2)
 
 	for _, item := range list.Items {
@@ -167,16 +167,16 @@ func (list ClusterInputList) LoadAsYaml(sl plugins.SecretLoader, depth int) (str
 			}
 
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("%s- name: %s\n", utils.YamlIndent(depth+1), p.Name()))
+				fmt.Fprintf(&buf, "%s- name: %s\n", utils.YamlIndent(depth+1), p.Name())
 			}
 			if item.Spec.Alias != "" {
-				buf.WriteString(fmt.Sprintf("%salias: %s\n", padding, item.Spec.Alias))
+				fmt.Fprintf(&buf, "%salias: %s\n", padding, item.Spec.Alias)
 			}
 			if item.Spec.LogLevel != "" {
-				buf.WriteString(fmt.Sprintf("%slog_level: %s\n", padding, item.Spec.LogLevel))
+				fmt.Fprintf(&buf, "%slog_level: %s\n", padding, item.Spec.LogLevel)
 			}
 			if item.Spec.Processors != nil {
-				buf.WriteString(fmt.Sprintf("%sprocessors:\n", padding))
+				fmt.Fprintf(&buf, "%sprocessors:\n", padding)
 				processorYaml, err := yaml.Marshal(item.Spec.Processors)
 				if err != nil {
 					return fmt.Errorf("error marshalling processor: %w", err)

--- a/apis/fluentbit/v1alpha2/clusteroutput_types.go
+++ b/apis/fluentbit/v1alpha2/clusteroutput_types.go
@@ -154,22 +154,22 @@ func (list ClusterOutputList) Load(sl plugins.SecretLoader) (string, error) {
 
 			buf.WriteString("[Output]\n")
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("    Name    %s\n", p.Name()))
+				fmt.Fprintf(&buf, "    Name    %s\n", p.Name())
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("    Match    %s\n", item.Spec.Match))
+				fmt.Fprintf(&buf, "    Match    %s\n", item.Spec.Match)
 			}
 			if item.Spec.LogLevel != "" {
-				buf.WriteString(fmt.Sprintf("    Log_Level    %s\n", item.Spec.LogLevel))
+				fmt.Fprintf(&buf, "    Log_Level    %s\n", item.Spec.LogLevel)
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("    Match_Regex    %s\n", item.Spec.MatchRegex))
+				fmt.Fprintf(&buf, "    Match_Regex    %s\n", item.Spec.MatchRegex)
 			}
 			if item.Spec.Alias != "" {
-				buf.WriteString(fmt.Sprintf("    Alias    %s\n", item.Spec.Alias))
+				fmt.Fprintf(&buf, "    Alias    %s\n", item.Spec.Alias)
 			}
 			if item.Spec.RetryLimit != "" {
-				buf.WriteString(fmt.Sprintf("    Retry_Limit    %s\n", item.Spec.RetryLimit))
+				fmt.Fprintf(&buf, "    Retry_Limit    %s\n", item.Spec.RetryLimit)
 			}
 			kvs, err := p.Params(sl)
 			if err != nil {
@@ -194,7 +194,7 @@ func (list ClusterOutputList) LoadAsYaml(sl plugins.SecretLoader, depth int) (st
 	var buf bytes.Buffer
 
 	sort.Sort(OutputByName(list.Items))
-	buf.WriteString(fmt.Sprintf("%soutputs:\n", utils.YamlIndent(depth)))
+	fmt.Fprintf(&buf, "%soutputs:\n", utils.YamlIndent(depth))
 	padding := utils.YamlIndent(depth + 2)
 	for _, item := range list.Items {
 		merge := func(p plugins.Plugin) error {
@@ -203,25 +203,25 @@ func (list ClusterOutputList) LoadAsYaml(sl plugins.SecretLoader, depth int) (st
 			}
 
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("%s- name: %s\n", utils.YamlIndent(depth+1), p.Name()))
+				fmt.Fprintf(&buf, "%s- name: %s\n", utils.YamlIndent(depth+1), p.Name())
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("%smatch: \"%s\"\n", padding, item.Spec.Match))
+				fmt.Fprintf(&buf, "%smatch: \"%s\"\n", padding, item.Spec.Match)
 			}
 			if item.Spec.LogLevel != "" {
-				buf.WriteString(fmt.Sprintf("%slog_level: %s\n", padding, item.Spec.LogLevel))
+				fmt.Fprintf(&buf, "%slog_level: %s\n", padding, item.Spec.LogLevel)
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("%smatch_regex: %s\n", padding, item.Spec.MatchRegex))
+				fmt.Fprintf(&buf, "%smatch_regex: %s\n", padding, item.Spec.MatchRegex)
 			}
 			if item.Spec.Alias != "" {
-				buf.WriteString(fmt.Sprintf("%salias: %s\n", padding, item.Spec.Alias))
+				fmt.Fprintf(&buf, "%salias: %s\n", padding, item.Spec.Alias)
 			}
 			if item.Spec.RetryLimit != "" {
-				buf.WriteString(fmt.Sprintf("%sretry_limit: %s\n", padding, item.Spec.RetryLimit))
+				fmt.Fprintf(&buf, "%sretry_limit: %s\n", padding, item.Spec.RetryLimit)
 			}
 			if item.Spec.Processors != nil {
-				buf.WriteString(fmt.Sprintf("%sprocessors:\n", padding))
+				fmt.Fprintf(&buf, "%sprocessors:\n", padding)
 				processorYaml, err := yaml.Marshal(item.Spec.Processors)
 				if err != nil {
 					return fmt.Errorf("error marshalling processor: %w", err)

--- a/apis/fluentbit/v1alpha2/clusterparser_types.go
+++ b/apis/fluentbit/v1alpha2/clusterparser_types.go
@@ -103,8 +103,8 @@ func (list ClusterParserList) Load(sl plugins.SecretLoader, existingParsers map[
 			}
 
 			buf.WriteString("[PARSER]\n")
-			buf.WriteString(fmt.Sprintf("    Name    %s\n", item.Name))
-			buf.WriteString(fmt.Sprintf("    Format    %s\n", p.Name()))
+			fmt.Fprintf(&buf, "    Name    %s\n", item.Name)
+			fmt.Fprintf(&buf, "    Format    %s\n", p.Name())
 
 			kvs, err := p.Params(sl)
 			if err != nil {
@@ -114,10 +114,10 @@ func (list ClusterParserList) Load(sl plugins.SecretLoader, existingParsers map[
 
 			for _, decorder := range item.Spec.Decoders {
 				if decorder.DecodeField != "" {
-					buf.WriteString(fmt.Sprintf("    Decode_Field    %s\n", decorder.DecodeField))
+					fmt.Fprintf(&buf, "    Decode_Field    %s\n", decorder.DecodeField)
 				}
 				if decorder.DecodeFieldAs != "" {
-					buf.WriteString(fmt.Sprintf("    Decode_Field_As    %s\n", decorder.DecodeFieldAs))
+					fmt.Fprintf(&buf, "    Decode_Field_As    %s\n", decorder.DecodeFieldAs)
 				}
 			}
 			existingParsers[item.Name] = true

--- a/apis/fluentbit/v1alpha2/filter_types.go
+++ b/apis/fluentbit/v1alpha2/filter_types.go
@@ -78,13 +78,13 @@ func (list FilterList) Load(sl plugins.SecretLoader) (string, error) {
 
 			buf.WriteString("[Filter]\n")
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("    Name    %s\n", p.Name()))
+				fmt.Fprintf(&buf, "    Name    %s\n", p.Name())
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("    Match    %s\n", utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match)))
+				fmt.Fprintf(&buf, "    Match    %s\n", utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match))
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("    Match_Regex    %s\n", utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex)))
+				fmt.Fprintf(&buf, "    Match_Regex    %s\n", utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex))
 			}
 
 			var iface interface{} = p
@@ -125,13 +125,13 @@ func (list FilterList) LoadAsYaml(sl plugins.SecretLoader, depth int) (string, e
 			}
 
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("%s- name: %s\n", utils.YamlIndent(depth+1), p.Name()))
+				fmt.Fprintf(&buf, "%s- name: %s\n", utils.YamlIndent(depth+1), p.Name())
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("%smatch: \"%s\"\n", padding, utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match)))
+				fmt.Fprintf(&buf, "%smatch: \"%s\"\n", padding, utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match))
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("%smatch_regex: %s\n", padding, utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex)))
+				fmt.Fprintf(&buf, "%smatch_regex: %s\n", padding, utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex))
 			}
 
 			var iface interface{} = p

--- a/apis/fluentbit/v1alpha2/multilineparser_types.go
+++ b/apis/fluentbit/v1alpha2/multilineparser_types.go
@@ -87,7 +87,7 @@ func load[T multilineParserInterface](items []T, sl plugins.SecretLoader) (strin
 			}
 
 			buf.WriteString("[MULTILINE_PARSER]\n")
-			buf.WriteString(fmt.Sprintf("    Name    %s\n", item.name()))
+			fmt.Fprintf(&buf, "    Name    %s\n", item.name())
 
 			kvs, err := p.Params(sl)
 			if err != nil {

--- a/apis/fluentbit/v1alpha2/output_types.go
+++ b/apis/fluentbit/v1alpha2/output_types.go
@@ -71,19 +71,19 @@ func (list OutputList) Load(sl plugins.SecretLoader) (string, error) {
 
 			buf.WriteString("[Output]\n")
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("    Name    %s\n", p.Name()))
+				fmt.Fprintf(&buf, "    Name    %s\n", p.Name())
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("    Match    %s\n", utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match)))
+				fmt.Fprintf(&buf, "    Match    %s\n", utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match))
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("    Match_Regex    %s\n", utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex)))
+				fmt.Fprintf(&buf, "    Match_Regex    %s\n", utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex))
 			}
 			if item.Spec.Alias != "" {
-				buf.WriteString(fmt.Sprintf("    Alias    %s\n", item.Spec.Alias))
+				fmt.Fprintf(&buf, "    Alias    %s\n", item.Spec.Alias)
 			}
 			if item.Spec.RetryLimit != "" {
-				buf.WriteString(fmt.Sprintf("    Retry_Limit    %s\n", item.Spec.RetryLimit))
+				fmt.Fprintf(&buf, "    Retry_Limit    %s\n", item.Spec.RetryLimit)
 			}
 			if item.Spec.CustomPlugin != nil && item.Spec.CustomPlugin.Config != "" {
 				item.Spec.CustomPlugin.Config = custom.MakeCustomConfigNamespaced(item.Spec.CustomPlugin.Config, item.Namespace)
@@ -125,19 +125,19 @@ func (list OutputList) LoadAsYaml(sl plugins.SecretLoader, depth int) (string, e
 			}
 
 			if p.Name() != "" {
-				buf.WriteString(fmt.Sprintf("%s- name: %s\n", utils.YamlIndent(depth+1), p.Name()))
+				fmt.Fprintf(&buf, "%s- name: %s\n", utils.YamlIndent(depth+1), p.Name())
 			}
 			if item.Spec.Match != "" {
-				buf.WriteString(fmt.Sprintf("%smatch: \"%s\"\n", padding, utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match)))
+				fmt.Fprintf(&buf, "%smatch: \"%s\"\n", padding, utils.GenerateNamespacedMatchExpr(item.Namespace, item.Spec.Match))
 			}
 			if item.Spec.MatchRegex != "" {
-				buf.WriteString(fmt.Sprintf("%smatch_regex: %s\n", padding, utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex)))
+				fmt.Fprintf(&buf, "%smatch_regex: %s\n", padding, utils.GenerateNamespacedMatchRegExpr(item.Namespace, item.Spec.MatchRegex))
 			}
 			if item.Spec.Alias != "" {
-				buf.WriteString(fmt.Sprintf("%salias: %s\n", padding, item.Spec.Alias))
+				fmt.Fprintf(&buf, "%salias: %s\n", padding, item.Spec.Alias)
 			}
 			if item.Spec.RetryLimit != "" {
-				buf.WriteString(fmt.Sprintf("%sretry_limit: %s\n", padding, item.Spec.RetryLimit))
+				fmt.Fprintf(&buf, "%sretry_limit: %s\n", padding, item.Spec.RetryLimit)
 			}
 			if item.Spec.CustomPlugin != nil && item.Spec.CustomPlugin.YamlConfig != nil {
 				item.Spec.CustomPlugin.MakeNamespaced(item.Namespace)

--- a/apis/fluentbit/v1alpha2/parser_types.go
+++ b/apis/fluentbit/v1alpha2/parser_types.go
@@ -69,8 +69,8 @@ func (list ParserList) Load(sl plugins.SecretLoader) (string, error) {
 			}
 
 			buf.WriteString("[PARSER]\n")
-			buf.WriteString(fmt.Sprintf("    Name    %s\n", fmt.Sprintf("%s-%x", item.Name, md5.Sum([]byte(item.Namespace)))))
-			buf.WriteString(fmt.Sprintf("    Format    %s\n", p.Name()))
+			fmt.Fprintf(&buf, "    Name    %s\n", fmt.Sprintf("%s-%x", item.Name, md5.Sum([]byte(item.Namespace))))
+			fmt.Fprintf(&buf, "    Format    %s\n", p.Name())
 
 			kvs, err := p.Params(sl)
 			if err != nil {
@@ -80,10 +80,10 @@ func (list ParserList) Load(sl plugins.SecretLoader) (string, error) {
 
 			for _, decorder := range item.Spec.Decoders {
 				if decorder.DecodeField != "" {
-					buf.WriteString(fmt.Sprintf("    Decode_Field    %s\n", decorder.DecodeField))
+					fmt.Fprintf(&buf, "    Decode_Field    %s\n", decorder.DecodeField)
 				}
 				if decorder.DecodeFieldAs != "" {
-					buf.WriteString(fmt.Sprintf("    Decode_Field_As    %s\n", decorder.DecodeFieldAs))
+					fmt.Fprintf(&buf, "    Decode_Field_As    %s\n", decorder.DecodeFieldAs)
 				}
 			}
 			return nil

--- a/apis/fluentbit/v1alpha2/plugins/custom/custom_plugin_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/custom/custom_plugin_types.go
@@ -61,7 +61,7 @@ func indentation(str string) string {
 	var buf bytes.Buffer
 	for s := range strings.SplitSeq(str, "\n") {
 		if s != "" {
-			buf.WriteString(fmt.Sprintf("    %s\n", strings.TrimSpace(s)))
+			fmt.Fprintf(&buf, "    %s\n", strings.TrimSpace(s))
 		}
 	}
 	return buf.String()
@@ -73,14 +73,14 @@ func MakeCustomConfigNamespaced(customConfig string, namespace string) string {
 		section = strings.TrimSpace(section)
 		idx := strings.LastIndex(section, " ")
 		if strings.HasPrefix(section, "Match_Regex") {
-			buf.WriteString(fmt.Sprintf("Match_Regex %s\n", utils.GenerateNamespacedMatchRegExpr(namespace, section[idx+1:])))
+			fmt.Fprintf(&buf, "Match_Regex %s\n", utils.GenerateNamespacedMatchRegExpr(namespace, section[idx+1:]))
 			continue
 		}
 		if strings.HasPrefix(section, "Match") {
-			buf.WriteString(fmt.Sprintf("Match %s\n", utils.GenerateNamespacedMatchExpr(namespace, section[idx+1:])))
+			fmt.Fprintf(&buf, "Match %s\n", utils.GenerateNamespacedMatchExpr(namespace, section[idx+1:]))
 			continue
 		}
-		buf.WriteString(fmt.Sprintf("%s\n", section))
+		fmt.Fprintf(&buf, "%s\n", section)
 	}
 	return buf.String()
 }

--- a/apis/fluentbit/v1alpha2/plugins/params/kvs.go
+++ b/apis/fluentbit/v1alpha2/plugins/params/kvs.go
@@ -65,7 +65,7 @@ func (kvs *KVs) String() string {
 
 	var buf bytes.Buffer
 	for i := 0; i < len(kvs.keys); i++ {
-		buf.WriteString(fmt.Sprintf("    %s    %s\n", kvs.keys[i], kvs.values[i]))
+		fmt.Fprintf(&buf, "    %s    %s\n", kvs.keys[i], kvs.values[i])
 	}
 	return buf.String()
 }
@@ -89,14 +89,14 @@ func (kvs *KVs) YamlString(depth int) string {
 	for _, key := range kvs.keys { // keep the order
 		values := keyValuesMap[key]
 		if len(values) == 1 {
-			buf.WriteString(fmt.Sprintf("%s%s: %s\n", utils.YamlIndent(depth), strings.ToLower(key), values[0]))
+			fmt.Fprintf(&buf, "%s%s: %s\n", utils.YamlIndent(depth), strings.ToLower(key), values[0])
 		} else {
 			if _, ok := keyFinishedMap[key]; ok { // avoid output multiple times
 				continue
 			}
-			buf.WriteString(fmt.Sprintf("%s%s:\n", utils.YamlIndent(depth), strings.ToLower(key)))
+			fmt.Fprintf(&buf, "%s%s:\n", utils.YamlIndent(depth), strings.ToLower(key))
 			for _, value := range values {
-				buf.WriteString(fmt.Sprintf("%s  - %s\n", utils.YamlIndent(depth), value))
+				fmt.Fprintf(&buf, "%s  - %s\n", utils.YamlIndent(depth), value)
 			}
 			keyFinishedMap[key] = true
 		}

--- a/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
+++ b/apis/fluentd/v1alpha1/plugins/common/buffer_types.go
@@ -174,8 +174,9 @@ func (b *Buffer) Params(_ plugins.SecretLoader) (*params.PluginStore, error) {
 		if strings.HasPrefix(*b.Path, "/buffers") {
 			ps.InsertPairs("path", *b.Path)
 		} else {
-			targetPaths := []string{"/buffers"}
 			paths := strings.Split(*b.Path, "/")
+			targetPaths := make([]string, 0, 1+len(paths))
+			targetPaths[0] = "/buffers"
 			targetPaths = append(targetPaths, paths...)
 			ps.InsertPairs("path", filepath.Join(targetPaths...))
 		}

--- a/apis/fluentd/v1alpha1/plugins/custom/custom_types.go
+++ b/apis/fluentd/v1alpha1/plugins/custom/custom_types.go
@@ -27,7 +27,7 @@ func indentation(config string) string {
 	var buf bytes.Buffer
 	for split := range strings.SplitSeq(config, "\n") {
 		if split != "" {
-			buf.WriteString(fmt.Sprintf("  %s\n", split))
+			fmt.Fprintf(&buf, "  %s\n", split)
 		}
 	}
 	return buf.String()

--- a/apis/fluentd/v1alpha1/plugins/output/types.go
+++ b/apis/fluentd/v1alpha1/plugins/output/types.go
@@ -76,7 +76,7 @@ func (o *Output) Name() string {
 
 func (o *Output) Params(loader plugins.SecretLoader) (*params.PluginStore, error) {
 	ps := params.NewPluginStore(o.Name())
-	childs := make([]*params.PluginStore, 0)
+	childs := make([]*params.PluginStore, 0, 3)
 
 	ps.InsertPairs("@id", fmt.Sprint(*o.Id))
 
@@ -184,11 +184,10 @@ func (o *Output) Params(loader plugins.SecretLoader) (*params.PluginStore, error
 	}
 
 	return o.customOutput(ps, loader), nil
-
 }
 
 func (o *Output) forwardPlugin(parent *params.PluginStore, loader plugins.SecretLoader) *params.PluginStore {
-	childs := make([]*params.PluginStore, 0)
+	childs := make([]*params.PluginStore, 0, 3)
 
 	if len(o.Forward.Servers) > 0 {
 		for _, s := range o.Forward.Servers {
@@ -402,7 +401,6 @@ func (o *Output) elasticsearchPluginCommon(cmn *ElasticsearchCommon, parent *par
 }
 
 func (o *Output) elasticsearchPlugin(parent *params.PluginStore, loader plugins.SecretLoader) (*params.PluginStore, error) {
-
 	parent, err := o.elasticsearchPluginCommon(&o.Elasticsearch.ElasticsearchCommon, parent, loader)
 	if err != nil {
 		return nil, err
@@ -424,7 +422,6 @@ func (o *Output) elasticsearchPlugin(parent *params.PluginStore, loader plugins.
 }
 
 func (o *Output) elasticsearchDataStreamPlugin(parent *params.PluginStore, loader plugins.SecretLoader) (*params.PluginStore, error) {
-
 	parent, err := o.elasticsearchPluginCommon(&o.ElasticsearchDataStream.ElasticsearchCommon, parent, loader)
 	if err != nil {
 		return nil, err
@@ -740,7 +737,7 @@ func (o *Output) lokiPlugin(parent *params.PluginStore, loader plugins.SecretLoa
 }
 
 func (o *Output) cloudWatchPlugin(parent *params.PluginStore, sl plugins.SecretLoader) *params.PluginStore {
-	childs := make([]*params.PluginStore, 0)
+	childs := make([]*params.PluginStore, 0, 3)
 
 	params.InsertPairs(parent, "auto_create_stream", o.CloudWatch.AutoCreateStream)
 	if o.CloudWatch.AwsKeyId != nil {

--- a/cmd/doc-gen/main.go
+++ b/cmd/doc-gen/main.go
@@ -89,7 +89,7 @@ func plugins(docsLocations []DocumentsLocation) {
 				return err
 			}
 			if strings.HasSuffix(path, ".go") {
-				var flag = true
+				flag := true
 				for _, keyword := range unincludedKeyWords {
 					flag = flag && !strings.Contains(path, keyword)
 				}
@@ -111,13 +111,13 @@ func plugins(docsLocations []DocumentsLocation) {
 			for _, t := range types {
 				strukt := t[0]
 				if len(t) > 1 {
-					buffer.WriteString(fmt.Sprintf("# %s\n\n%s\n\n\n", strukt.Name, strukt.Doc))
+					fmt.Fprintf(&buffer, "# %s\n\n%s\n\n\n", strukt.Name, strukt.Doc)
 
 					buffer.WriteString("| Field | Description | Scheme |\n")
 					buffer.WriteString("| ----- | ----------- | ------ |\n")
 					fields := t[1:]
 					for _, f := range fields {
-						buffer.WriteString(fmt.Sprintf("| %s | %s | %s |\n", f.Name, f.Doc, f.Type))
+						fmt.Fprintf(&buffer, "| %s | %s | %s |\n", f.Name, f.Doc, f.Type)
 					}
 					buffer.WriteString("")
 				}
@@ -163,7 +163,8 @@ func crds(docsLocations []DocumentsLocation) {
 		}
 
 		var buffer bytes.Buffer
-		var types []KubeTypes
+
+		types := make([]KubeTypes, 0, 10)
 		for _, src := range srcs {
 			types = append(types, ParseDocumentationFrom(src, dl.name, false)...)
 		}
@@ -177,13 +178,13 @@ func crds(docsLocations []DocumentsLocation) {
 		for _, t := range types {
 			strukt := t[0]
 			if len(t) > 1 {
-				buffer.WriteString(fmt.Sprintf("# %s\n\n%s\n\n\n", strukt.Name, strukt.Doc))
+				fmt.Fprintf(&buffer, "# %s\n\n%s\n\n\n", strukt.Name, strukt.Doc)
 
 				buffer.WriteString("| Field | Description | Scheme |\n")
 				buffer.WriteString("| ----- | ----------- | ------ |\n")
 				fields := t[1:]
 				for _, f := range fields {
-					buffer.WriteString(fmt.Sprintf("| %s | %s | %s |\n", f.Name, f.Doc, f.Type))
+					fmt.Fprintf(&buffer, "| %s | %s | %s |\n", f.Name, f.Doc, f.Type)
 				}
 				buffer.WriteString("\n")
 				buffer.WriteString("[Back to TOC](#table-of-contents)\n")
@@ -215,7 +216,7 @@ func printTOC(types []KubeTypes) bytes.Buffer {
 	for _, t := range types {
 		strukt := t[0]
 		if len(t) > 1 {
-			buffer.WriteString(fmt.Sprintf("* [%s](#%s)\n", strukt.Name, toSectionLink(strukt.Name)))
+			fmt.Fprintf(&buffer, "* [%s](#%s)\n", strukt.Name, toSectionLink(strukt.Name))
 		}
 	}
 	return buffer

--- a/cmd/fluent-manager/Dockerfile
+++ b/cmd/fluent-manager/Dockerfile
@@ -1,7 +1,7 @@
-ARG GO_VERSION=1.25.3
+ARG GO_VERSION=1.26.2
 
 # Build the manager binary \
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine3.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/cmd/fluent-watcher/fluentbit/Dockerfile
+++ b/cmd/fluent-watcher/fluentbit/Dockerfile
@@ -1,7 +1,7 @@
 ARG FLUENT_BIT_BASE_VERSION=3.2.4 \
-    GO_VERSION=1.25.3
+    GO_VERSION=1.26.2
 
-FROM golang:${GO_VERSION}-alpine3.21 AS buildergo
+FROM golang:${GO_VERSION}-alpine3.23 AS buildergo
 RUN mkdir -p /fluent-bit
 RUN mkdir -p /code
 COPY . /code/

--- a/cmd/fluent-watcher/fluentbit/Dockerfile.debug
+++ b/cmd/fluent-watcher/fluentbit/Dockerfile.debug
@@ -1,7 +1,7 @@
 ARG FLUENT_BIT_BASE_VERSION=3.2.4 \
-    GO_VERSION=1.25.3
+    GO_VERSION=1.26.2
 
-FROM golang:${GO_VERSION}-alpine3.21 AS buildergo
+FROM golang:${GO_VERSION}-alpine3.23 AS buildergo
 RUN mkdir -p /fluent-bit
 RUN mkdir -p /code
 COPY . /code/

--- a/cmd/fluent-watcher/fluentd/Dockerfile
+++ b/cmd/fluent-watcher/fluentd/Dockerfile
@@ -1,5 +1,5 @@
 ARG FLUENTD_BASE_VERSION \
-    GO_VERSION=1.25.3
+    GO_VERSION=1.26.2
 
 FROM golang:${GO_VERSION} AS builder
 

--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -384,26 +384,22 @@ func (r *FluentBitConfigReconciler) generateRewriteTagConfig(
 		return ""
 	}
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintln("[Filter]"))
-	buf.WriteString(fmt.Sprintln("    Name    rewrite_tag"))
-	buf.WriteString(fmt.Sprintf("    Match    %s\n", tag))
-	buf.WriteString(
-		fmt.Sprintf(
-			"    Rule    $kubernetes['namespace_name'] ^(%s)$ %x.$TAG false\n", cfg.Namespace,
-			md5.Sum([]byte(cfg.Namespace)),
-		),
-	)
+	fmt.Fprintln(&buf, "[Filter]")
+	fmt.Fprintln(&buf, "    Name    rewrite_tag")
+	fmt.Fprintf(&buf, "    Match    %s\n", tag)
+	fmt.Fprintf(&buf, "    Rule    $kubernetes['namespace_name'] ^(%s)$ %x.$TAG false\n", cfg.Namespace,
+		md5.Sum([]byte(cfg.Namespace)))
 	if cfg.Spec.Service != nil {
 		if cfg.Spec.Service.EmitterName != "" {
-			buf.WriteString(fmt.Sprintf("    Emitter_Name    %s\n", cfg.Spec.Service.EmitterName))
+			fmt.Fprintf(&buf, "    Emitter_Name    %s\n", cfg.Spec.Service.EmitterName)
 		} else {
-			buf.WriteString(fmt.Sprintf("    Emitter_Name    re_emitted_%x\n", md5.Sum([]byte(cfg.Namespace))))
+			fmt.Fprintf(&buf, "    Emitter_Name    re_emitted_%x\n", md5.Sum([]byte(cfg.Namespace)))
 		}
 		if cfg.Spec.Service.EmitterStorageType != "" {
-			buf.WriteString(fmt.Sprintf("    Emitter_Storage.type    %s\n", cfg.Spec.Service.EmitterStorageType))
+			fmt.Fprintf(&buf, "    Emitter_Storage.type    %s\n", cfg.Spec.Service.EmitterStorageType)
 		}
 		if cfg.Spec.Service.EmitterMemBufLimit != "" {
-			buf.WriteString(fmt.Sprintf("    Emitter_Mem_Buf_Limit    %s\n", cfg.Spec.Service.EmitterMemBufLimit))
+			fmt.Fprintf(&buf, "    Emitter_Mem_Buf_Limit    %s\n", cfg.Spec.Service.EmitterMemBufLimit)
 		}
 	}
 	return buf.String()

--- a/docs/best-practice/forwarding-logs-via-http/Dockerfile
+++ b/docs/best-practice/forwarding-logs-via-http/Dockerfile
@@ -1,4 +1,4 @@
-GO_VERSION=1.25.3
+GO_VERSION=1.26.2
 # Build the manager binary
 FROM golang:${GO_VERSION} AS builder
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluent/fluent-operator/v3
 
-go 1.25.3
+go 1.26.2
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
### What this PR does / why we need it:

Upgrades go versions across a few Docker images. Resolves a critical vulnerability in fluent-bit-watcher binary plus a few others.

Have tested all the docker builds still work.

### Which issue(s) this PR fixes:

Fixes #1922 

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs

```
