### PR TITLE
ci: add workflow_dispatch trigger to "build" workflow and dispatch from release-please

### DIFF
--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -85,11 +85,12 @@ jobs:
 
       - name: Set version env for workflow_dispatch
         if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          tag="${{ inputs.tag }}"
-          version="${tag#v}"
+          version="${INPUT_TAG#v}"
           {
-            echo "WD_TAG=${tag}"
+            echo "WD_TAG=${INPUT_TAG}"
             echo "WD_VERSION=${version}"
             echo "WD_MAJOR_MINOR=${version%.*}"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -25,6 +25,7 @@ on:
 env:
   GHCR_REPO: 'ghcr.io/${{ github.repository }}/fluent-operator'
   DOCKERHUB_REPO: 'kubesphere/fluent-operator'
+  HAS_DOCKERHUB: ${{ secrets.REGISTRY_USER != '' }}
 
 permissions:
   contents: read
@@ -121,7 +122,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        if: secrets.REGISTRY_USER != ''
+        if: env.HAS_DOCKERHUB == 'true'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
@@ -134,7 +135,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_REPO }}
-            ${{ secrets.REGISTRY_USER != '' && env.DOCKERHUB_REPO || '' }}
+            ${{ env.HAS_DOCKERHUB == 'true' && env.DOCKERHUB_REPO || '' }}
           flavor: |
             latest=false
           tags: |
@@ -157,7 +158,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             GO_VERSION=${{ steps.setup-go.outputs.go-version }}
-          outputs: type=image,"name=${{ env.GHCR_REPO }}${{ secrets.REGISTRY_USER != '' && format(',{0}', env.DOCKERHUB_REPO) || '' }}",push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,"name=${{ env.GHCR_REPO }}${{ env.HAS_DOCKERHUB == 'true' && format(',{0}', env.DOCKERHUB_REPO) || '' }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Output image digests
         id: output-digests
@@ -180,7 +181,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        if: secrets.REGISTRY_USER != ''
+        if: env.HAS_DOCKERHUB == 'true'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -135,6 +135,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag
             type=raw,value=${{ env.WD_TAG }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ env.WD_VERSION }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ env.WD_MAJOR_MINOR }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -10,35 +10,6 @@ on:
   push:
     branches:
       - "master"
-    tags:
-      - "v*"
-    paths:
-      - ".github/workflows/build-op-image.yaml"
-      - ".github/workflows/clone-docker-image-action.yaml"
-      - "apis/**"
-      - "cmd/fluent-manager/**"
-      - "controllers/**"
-      - "hack/**"
-      - "manifests/setup/setup.yaml"
-      - "pkg/fluentd/router/**"
-      - "pkg/fluentd/operator/**"
-      - "pkg/fluentd/utils/**"
-      - "Makefile"
-
-  pull_request:
-    branches:
-      - "master"
-    paths:
-      - ".github/workflows/build-op-image.yaml"
-      - ".github/workflows/clone-docker-image-action.yaml"
-      - "apis/**"
-      - "cmd/fluent-manager/**"
-      - "controllers/**"
-      - "hack/**"
-      - "manifests/setup/setup.yaml"
-      - "pkg/fluentd/router/**"
-      - "pkg/fluentd/operator/**"
-      - "pkg/fluentd/utils/**"
 
 env:
   GHCR_REPO: 'ghcr.io/${{ github.repository }}/fluent-operator'
@@ -49,8 +20,8 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -132,7 +103,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
@@ -140,7 +110,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
@@ -153,37 +122,17 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_REPO }}
-            ${{ github.event_name != 'pull_request' && env.DOCKERHUB_REPO || '' }}
+            ${{ env.DOCKERHUB_REPO }}
           flavor: |
             latest=false
           tags: |
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && env.WD_PRERELEASE == '') }}
-            type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && env.WD_PRERELEASE == '' }}
             type=raw,value=${{ env.WD_TAG }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ env.WD_VERSION }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ env.WD_MAJOR_MINOR }},enable=${{ github.event_name == 'workflow_dispatch' && env.WD_PRERELEASE == '' }}
-            type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
             type=sha,format=long,prefix=,priority=1000,enable=${{ github.event_name != 'workflow_dispatch' }}
 
-      - name: Build image (pull request)
-        if: github.event_name == 'pull_request'
-        id: build-pr
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          file: cmd/fluent-manager/Dockerfile
-          platforms: ${{ matrix.platform }}
-          labels: ${{ steps.image-metadata.outputs.labels }}
-          provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            GO_VERSION=${{ steps.setup-go.outputs.go-version }}
-          push: false
-
       - name: Build and push image
-        if: github.event_name != 'pull_request'
         id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -199,7 +148,6 @@ jobs:
           outputs: type=image,"name=${{ env.GHCR_REPO }},${{ env.DOCKERHUB_REPO }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Output image digests
-        if: github.event_name != 'pull_request'
         id: output-digests
         run: |
           platform="${{ matrix.platform }}"
@@ -209,7 +157,6 @@ jobs:
 
   manifest:
     name: Publish image manifest
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -10,6 +10,17 @@ on:
   push:
     branches:
       - "master"
+    paths:
+      - ".github/workflows/build-op-image.yaml"
+      - "apis/**"
+      - "cmd/fluent-manager/**"
+      - "controllers/**"
+      - "hack/**"
+      - "manifests/setup/setup.yaml"
+      - "pkg/fluentd/router/**"
+      - "pkg/fluentd/operator/**"
+      - "pkg/fluentd/utils/**"
+      - "Makefile"
 
 env:
   GHCR_REPO: 'ghcr.io/${{ github.repository }}/fluent-operator'

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -2,6 +2,11 @@ name: Build/Push Fluent Operator image
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build (e.g. v3.8.0)'
+        required: true
+        type: string
   release:
     types: [published]
   push:
@@ -75,7 +80,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
+
+      - name: Set version env for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          tag="${{ inputs.tag }}"
+          version="${tag#v}"
+          echo "WD_TAG=${tag}" >> "$GITHUB_ENV"
+          echo "WD_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "WD_MAJOR_MINOR=${version%.*}" >> "$GITHUB_ENV"
 
       - name: Install Go
         id: setup-go
@@ -115,8 +130,10 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
             type=ref,event=tag
+            type=raw,value=${{ env.WD_TAG }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ env.WD_MAJOR_MINOR }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
             type=sha,format=long,prefix=,priority=1000

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -32,7 +32,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -7,8 +7,6 @@ on:
         description: 'Git tag to build (e.g. v3.8.0 or v3.8.0-rc1)'
         required: true
         type: string
-  release:
-    types: [published]
   push:
     branches:
       - "master"

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -88,9 +88,28 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          version="${INPUT_TAG#v}"
+          tag="${INPUT_TAG}"
+
+          if [ -z "${tag}" ]; then
+            echo "workflow_dispatch input 'tag' must not be empty" >&2
+            exit 1
+          fi
+
+          case "${tag}" in
+            *$'\n'*|*$'\r'*)
+              echo "workflow_dispatch input 'tag' must not contain carriage returns or newlines" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "workflow_dispatch input 'tag' must match format v<major>.<minor>.<patch> (for example: v3.8.0)" >&2
+            exit 1
+          fi
+
+          version="${tag#v}"
           {
-            echo "WD_TAG=${INPUT_TAG}"
+            echo "WD_TAG=${tag}"
             echo "WD_VERSION=${version}"
             echo "WD_MAJOR_MINOR=${version%.*}"
           } >> "$GITHUB_ENV"

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -1,6 +1,9 @@
 name: Build/Push Fluent Operator image
 
 on:
+  workflow_dispatch:
+  release:
+    types: [published]
   push:
     branches:
       - "master"

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -88,9 +88,11 @@ jobs:
         run: |
           tag="${{ inputs.tag }}"
           version="${tag#v}"
-          echo "WD_TAG=${tag}" >> "$GITHUB_ENV"
-          echo "WD_VERSION=${version}" >> "$GITHUB_ENV"
-          echo "WD_MAJOR_MINOR=${version%.*}" >> "$GITHUB_ENV"
+          {
+            echo "WD_TAG=${tag}"
+            echo "WD_VERSION=${version}"
+            echo "WD_MAJOR_MINOR=${version%.*}"
+          } >> "$GITHUB_ENV"
 
       - name: Install Go
         id: setup-go

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -166,7 +166,7 @@ jobs:
             type=raw,value=${{ env.WD_MAJOR_MINOR }},enable=${{ github.event_name == 'workflow_dispatch' && env.WD_PRERELEASE == '' }}
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
-            type=sha,format=long,prefix=,priority=1000
+            type=sha,format=long,prefix=,priority=1000,enable=${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Build image (pull request)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -32,7 +32,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ inputs.tag || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Git tag to build (e.g. v3.8.0)'
+        description: 'Git tag to build (e.g. v3.8.0 or v3.8.0-rc1)'
         required: true
         type: string
   release:
@@ -102,16 +102,23 @@ jobs:
               ;;
           esac
 
-          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "workflow_dispatch input 'tag' must match format v<major>.<minor>.<patch> (for example: v3.8.0)" >&2
+          if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9][a-zA-Z0-9.-]*)?$ ]]; then
+            echo "workflow_dispatch input 'tag' must match format v<major>.<minor>.<patch> or v<major>.<minor>.<patch>-<pre-release> (for example: v3.8.0 or v3.8.0-rc1)" >&2
             exit 1
           fi
 
           version="${tag#v}"
+          base_version="${version%%-*}"  # strip pre-release suffix (e.g. 3.8.0-rc1 -> 3.8.0)
+          major_minor="${base_version%.*}"  # e.g. 3.8.0 -> 3.8
+          prerelease=""
+          if [[ "${version}" != "${base_version}" ]]; then
+            prerelease="true"
+          fi
           {
             echo "WD_TAG=${tag}"
             echo "WD_VERSION=${version}"
-            echo "WD_MAJOR_MINOR=${version%.*}"
+            echo "WD_MAJOR_MINOR=${major_minor}"
+            echo "WD_PRERELEASE=${prerelease}"
           } >> "$GITHUB_ENV"
 
       - name: Install Go
@@ -152,11 +159,11 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && env.WD_PRERELEASE == '') }}
             type=ref,event=tag
             type=raw,value=${{ env.WD_TAG }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=raw,value=${{ env.WD_VERSION }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=raw,value=${{ env.WD_MAJOR_MINOR }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=${{ env.WD_MAJOR_MINOR }},enable=${{ github.event_name == 'workflow_dispatch' && env.WD_PRERELEASE == '' }}
             type=semver,pattern={{version}},enable=${{ github.ref_type == 'tag' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' }}
             type=sha,format=long,prefix=,priority=1000

--- a/.github/workflows/build-op-image.yaml
+++ b/.github/workflows/build-op-image.yaml
@@ -121,6 +121,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
+        if: secrets.REGISTRY_USER != ''
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io
@@ -133,7 +134,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_REPO }}
-            ${{ env.DOCKERHUB_REPO }}
+            ${{ secrets.REGISTRY_USER != '' && env.DOCKERHUB_REPO || '' }}
           flavor: |
             latest=false
           tags: |
@@ -156,7 +157,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             GO_VERSION=${{ steps.setup-go.outputs.go-version }}
-          outputs: type=image,"name=${{ env.GHCR_REPO }},${{ env.DOCKERHUB_REPO }}",push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,"name=${{ env.GHCR_REPO }}${{ secrets.REGISTRY_USER != '' && format(',{0}', env.DOCKERHUB_REPO) || '' }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Output image digests
         id: output-digests
@@ -179,6 +180,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
+        if: secrets.REGISTRY_USER != ''
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: docker.io

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           gh workflow run build-op-image.yaml \
             --repo "${{ github.repository }}" \
+            --ref "${{ steps.release.outputs.tag_name }}" \
             --field tag="${{ steps.release.outputs.tag_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -43,5 +44,14 @@ jobs:
       - name: Upload setup.yaml to release
         if: ${{ steps.release.outputs.release_created }}
         run: gh release upload "${{ steps.release.outputs.tag_name }}" manifests/setup/setup.yaml --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger operator image build
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          gh workflow run build-op-image.yaml \
+            --repo "${{ github.repository }}" \
+            --field tag="${{ steps.release.outputs.tag_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Root cause

The `paths` filter in `on.push` applies to **all** push events including tag pushes. The release-please merge commit only touches changelog/version files — none of which are in the paths list — so the workflow was silently skipped for every release.

Additionally, `release: types: [published]` does not fire when the release is created by `GITHUB_TOKEN` (GitHub suppresses downstream workflow runs from token-authenticated events), so that trigger is not a viable fix.

## Changes

### `build-op-image.yaml`

- **Remove** `push: tags: v*` trigger (superseded by explicit dispatch from `release-please.yaml`)
- **Remove** `pull_request` trigger and the no-push build step — images are only built on merge to master (when source paths change) or on versioned dispatch
- **Add** `workflow_dispatch` trigger with a required `tag` input (e.g. `v3.8.0` or `v3.8.0-rc1`) for manual backfills and release-triggered builds
- **Add** `HAS_DOCKERHUB` env flag (derived from `secrets.REGISTRY_USER`) to gracefully skip Docker Hub when credentials are not present
- **Add** input validation: tag must match `v<major>.<minor>.<patch>[-<pre-release>]`
- **Add** version env derivation (`WD_TAG`, `WD_VERSION`, `WD_MAJOR_MINOR`, `WD_PRERELEASE`) to drive image tags correctly on dispatch
- Pre-release tags (e.g. `v3.8.0-rc1`) get `v3.8.0-rc1` and `3.8.0-rc1` only — `latest` and `3.8` are suppressed
- Stable tags (e.g. `v3.8.0`) get `v3.8.0`, `3.8.0`, `3.8`, and `latest`
- Fix concurrency group to include `github.event_name` so push and dispatch runs don't cancel each other

### `release-please.yaml`

- **Add** `actions: write` permission
- **Add** "Trigger operator image build" step: after `release_created`, calls `gh workflow run build-op-image.yaml --field tag=<tag>` using `GITHUB_TOKEN` — this works because `workflow_dispatch` API calls are not subject to the token-triggered workflow suppression that blocks push/release events

## Tested

Full end-to-end test in [`joshuabaird/fluent-operator`](https://github.com/joshuabaird/fluent-operator) fork:

1. Merged a release-please 3.9.0 PR into fork master
2. `release-please.yaml` ran, created tag `v3.9.0` and GitHub release, then dispatched `build-op-image.yaml`
3. Both amd64 and arm64 builds completed, manifest published to GHCR with all expected tags:
   - `ghcr.io/joshuabaird/fluent-operator/fluent-operator:v3.9.0`
   - `ghcr.io/joshuabaird/fluent-operator/fluent-operator:3.9.0`
   - `ghcr.io/joshuabaird/fluent-operator/fluent-operator:3.9`
   - `ghcr.io/joshuabaird/fluent-operator/fluent-operator:latest`

## Backfill for v3.8.0

Once this merges, run:

```
gh workflow run build-op-image.yaml \
  --repo fluent/fluent-operator \
  --field tag=v3.8.0
```