### PR TITLE
feat(rbac): complete namespaced mode to reduce cluster-wide permissions

### DIFF
--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - --disable-component-controllers={{ . }}
           {{- end }}
           {{- with .Values.operator.watchNamespaces }}
-          - --watch-namespaces={{ . }}
+          - {{ printf "--watch-namespaces=%s" . | quote }}
           {{- end }}
         {{- with .Values.operator.livenessProbe }}
         livenessProbe:

--- a/charts/fluent-operator/templates/fluent-operator-deployment.yaml
+++ b/charts/fluent-operator/templates/fluent-operator-deployment.yaml
@@ -55,6 +55,9 @@ spec:
           {{- with .Values.operator.disableComponentControllers }}
           - --disable-component-controllers={{ . }}
           {{- end }}
+          {{- with .Values.operator.watchNamespaces }}
+          - --watch-namespaces={{ . }}
+          {{- end }}
         {{- with .Values.operator.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -103,6 +103,10 @@ operator:
   #  myExampleLabel: someValue
   # -- Disable specific component controllers. Value can be "fluent-bit" or "fluentd" to disable that controller
   disableComponentControllers: ""
+  # -- Comma separated list of namespaces the operator should watch and manage resources in. When set, the
+  # operator scopes its cache and creates namespaced Roles/RoleBindings (instead of cluster-wide) for the
+  # agents it manages, allowing the operator's own RBAC to be reduced. Defaults to cluster scope when empty.
+  watchNamespaces: ""
   # -- Extra arguments for the Fluent Operator controller
   extraArgs:
     []

--- a/cmd/fluent-manager/main.go
+++ b/cmd/fluent-manager/main.go
@@ -232,9 +232,10 @@ func main() {
 		}
 
 		if err = (&controllers.CollectorReconciler{
-			Client: mgr.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName("Collector"),
-			Scheme: mgr.GetScheme(),
+			Client:     mgr.GetClient(),
+			Log:        ctrl.Log.WithName("controllers").WithName("Collector"),
+			Scheme:     mgr.GetScheme(),
+			Namespaced: namespacedController,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Collector")
 			os.Exit(1)
@@ -266,9 +267,10 @@ func main() {
 		}
 
 		if err = (&controllers.FluentdReconciler{
-			Client: mgr.GetClient(),
-			Log:    ctrl.Log.WithName("controllers").WithName("Fluentd"),
-			Scheme: mgr.GetScheme(),
+			Client:     mgr.GetClient(),
+			Log:        ctrl.Log.WithName("controllers").WithName("Fluentd"),
+			Scheme:     mgr.GetScheme(),
+			Namespaced: namespacedController,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Fluentd")
 			os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -123,6 +123,7 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - roles
   verbs:
   - create
   - get
@@ -133,7 +134,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  - roles
   verbs:
   - create
   - delete

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -50,7 +50,7 @@ type CollectorReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;watch;patch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;delete;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;delete;get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -98,34 +98,21 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// Install RBAC resources for the filter plugin kubernetes
-	var role, sa, binding client.Object
-	if r.Namespaced {
-		role, sa, binding = operator.MakeScopedRBACObjects(
-			co.Name,
-			co.Namespace,
-			"collector",
-			co.Spec.RBACRules,
-			co.Spec.ServiceAccountAnnotations,
-		)
-	} else {
-		role, sa, binding = operator.MakeRBACObjects(
-			co.Name,
-			co.Namespace,
-			"collector",
-			co.Spec.RBACRules,
-			co.Spec.ServiceAccountAnnotations,
-		)
-	}
-	// Deploy Fluent Bit Collector (Cluster)Role
+	// Reconcile the RBAC the agent needs, scoped to a namespace or the cluster.
+	role, sa, binding := operator.MakeRBACObjectsForScope(
+		r.Namespaced,
+		co.Name,
+		co.Namespace,
+		"collector",
+		co.Spec.RBACRules,
+		co.Spec.ServiceAccountAnnotations,
+	)
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluent Bit Collector (Cluster)RoleBinding
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, binding, r.mutate(binding, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluent Bit Collector ServiceAccount
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, sa, r.mutate(sa, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -259,29 +246,8 @@ func (r *CollectorReconciler) delete(ctx context.Context, co *fluentbitv1alpha2.
 		return err
 	}
 
-	// Only the per-instance (Cluster)RoleBinding is removed here; the (Cluster)Role
-	// is shared across all Collector instances and must not be deleted.
-	if r.Namespaced {
-		_, _, rbName := operator.MakeScopedRBACNames(co.Name, "collector")
-		rolebinding := rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rbName,
-				Namespace: co.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else {
-		_, _, crbName := operator.MakeRBACNames(co.Name, "collector")
-		crb := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crbName,
-			},
-		}
-		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, co.Name, co.Namespace, "collector"); err != nil {
+		return err
 	}
 
 	sts := appsv1.StatefulSet{

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -38,8 +38,9 @@ import (
 // CollectorReconciler reconciles a FluentBit object
 type CollectorReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log        logr.Logger
+	Scheme     *runtime.Scheme
+	Namespaced bool
 }
 
 // +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=collectors,verbs=get;list;watch;update
@@ -49,6 +50,8 @@ type CollectorReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;delete;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;delete;get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -96,19 +99,30 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Install RBAC resources for the filter plugin kubernetes
-	cr, sa, crb := operator.MakeRBACObjects(
-		co.Name,
-		co.Namespace,
-		"collector",
-		co.Spec.RBACRules,
-		co.Spec.ServiceAccountAnnotations,
-	)
-	// Deploy Fluent Bit Collector ClusterRole
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, cr, r.mutate(cr, &co)); err != nil {
+	var role, sa, binding client.Object
+	if r.Namespaced {
+		role, sa, binding = operator.MakeScopedRBACObjects(
+			co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+	} else {
+		role, sa, binding = operator.MakeRBACObjects(
+			co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+	}
+	// Deploy Fluent Bit Collector (Cluster)Role
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluent Bit Collector ClusterRoleBinding
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, crb, r.mutate(crb, &co)); err != nil {
+	// Deploy Fluent Bit Collector (Cluster)RoleBinding
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, binding, r.mutate(binding, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
 	// Deploy Fluent Bit Collector ServiceAccount
@@ -175,6 +189,36 @@ func (r *CollectorReconciler) mutate(obj client.Object, co *fluentbitv1alpha2.Co
 			o.Subjects = expected.Subjects
 			return nil
 		}
+	case *rbacv1.Role:
+		// The Role is shared across all Collector instances in the namespace, so
+		// no per-instance controller reference is set on it.
+		expected, _, _ := operator.MakeScopedRBACObjects(co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+
+		return func() error {
+			o.Rules = expected.Rules
+			return nil
+		}
+	case *rbacv1.RoleBinding:
+		_, _, expected := operator.MakeScopedRBACObjects(co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+
+		return func() error {
+			o.RoleRef = expected.RoleRef
+			o.Subjects = expected.Subjects
+			if err := ctrl.SetControllerReference(co, o, r.Scheme); err != nil {
+				return err
+			}
+			return nil
+		}
 	case *appsv1.StatefulSet:
 		expected := operator.MakefbStatefulset(*co)
 
@@ -214,7 +258,31 @@ func (r *CollectorReconciler) delete(ctx context.Context, co *fluentbitv1alpha2.
 	if err := r.Delete(ctx, &sa); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	// TODO: clusterrole, clusterrolebinding
+
+	// Only the per-instance (Cluster)RoleBinding is removed here; the (Cluster)Role
+	// is shared across all Collector instances and must not be deleted.
+	if r.Namespaced {
+		_, _, rbName := operator.MakeScopedRBACNames(co.Name, "collector")
+		rolebinding := rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rbName,
+				Namespace: co.Namespace,
+			},
+		}
+		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		_, _, crbName := operator.MakeRBACNames(co.Name, "collector")
+		crb := rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crbName,
+			},
+		}
+		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
 
 	sts := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -246,7 +246,9 @@ func (r *CollectorReconciler) delete(ctx context.Context, co *fluentbitv1alpha2.
 		return err
 	}
 
-	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, co.Name, co.Namespace, "collector"); err != nil {
+	if err := operator.DeletePerInstanceBinding(
+		ctx, r.Client, r.Namespaced, co.Name, co.Namespace, "collector",
+	); err != nil {
 		return err
 	}
 

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -100,7 +100,7 @@ func (r *CollectorReconciler) collectorsForSecret(ctx context.Context, obj clien
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;watch;patch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;delete;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;delete;get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -43,8 +43,9 @@ import (
 // CollectorReconciler reconciles a FluentBit object
 type CollectorReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log        logr.Logger
+	Scheme     *runtime.Scheme
+	Namespaced bool
 }
 
 // collectorSecretRequeueInterval is how long to wait before re-checking for the
@@ -99,6 +100,8 @@ func (r *CollectorReconciler) collectorsForSecret(ctx context.Context, obj clien
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;delete;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;delete;get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
@@ -156,19 +159,30 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Install RBAC resources for the filter plugin kubernetes
-	cr, sa, crb := operator.MakeRBACObjects(
-		co.Name,
-		co.Namespace,
-		"collector",
-		co.Spec.RBACRules,
-		co.Spec.ServiceAccountAnnotations,
-	)
-	// Deploy Fluent Bit Collector ClusterRole
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, cr, r.mutate(cr, &co)); err != nil {
+	var role, sa, binding client.Object
+	if r.Namespaced {
+		role, sa, binding = operator.MakeScopedRBACObjects(
+			co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+	} else {
+		role, sa, binding = operator.MakeRBACObjects(
+			co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+	}
+	// Deploy Fluent Bit Collector (Cluster)Role
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluent Bit Collector ClusterRoleBinding
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, crb, r.mutate(crb, &co)); err != nil {
+	// Deploy Fluent Bit Collector (Cluster)RoleBinding
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, binding, r.mutate(binding, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
 	// Deploy Fluent Bit Collector ServiceAccount
@@ -235,6 +249,36 @@ func (r *CollectorReconciler) mutate(obj client.Object, co *fluentbitv1alpha2.Co
 			o.Subjects = expected.Subjects
 			return nil
 		}
+	case *rbacv1.Role:
+		// The Role is shared across all Collector instances in the namespace, so
+		// no per-instance controller reference is set on it.
+		expected, _, _ := operator.MakeScopedRBACObjects(co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+
+		return func() error {
+			o.Rules = expected.Rules
+			return nil
+		}
+	case *rbacv1.RoleBinding:
+		_, _, expected := operator.MakeScopedRBACObjects(co.Name,
+			co.Namespace,
+			"collector",
+			co.Spec.RBACRules,
+			co.Spec.ServiceAccountAnnotations,
+		)
+
+		return func() error {
+			o.RoleRef = expected.RoleRef
+			o.Subjects = expected.Subjects
+			if err := ctrl.SetControllerReference(co, o, r.Scheme); err != nil {
+				return err
+			}
+			return nil
+		}
 	case *appsv1.StatefulSet:
 		expected := operator.MakefbStatefulset(*co)
 
@@ -274,7 +318,31 @@ func (r *CollectorReconciler) delete(ctx context.Context, co *fluentbitv1alpha2.
 	if err := r.Delete(ctx, &sa); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	// TODO: clusterrole, clusterrolebinding
+
+	// Only the per-instance (Cluster)RoleBinding is removed here; the (Cluster)Role
+	// is shared across all Collector instances and must not be deleted.
+	if r.Namespaced {
+		_, _, rbName := operator.MakeScopedRBACNames(co.Name, "collector")
+		rolebinding := rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rbName,
+				Namespace: co.Namespace,
+			},
+		}
+		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		_, _, crbName := operator.MakeRBACNames(co.Name, "collector")
+		crb := rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crbName,
+			},
+		}
+		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
 
 	sts := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -306,7 +306,9 @@ func (r *CollectorReconciler) delete(ctx context.Context, co *fluentbitv1alpha2.
 		return err
 	}
 
-	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, co.Name, co.Namespace, "collector"); err != nil {
+	if err := operator.DeletePerInstanceBinding(
+		ctx, r.Client, r.Namespaced, co.Name, co.Namespace, "collector",
+	); err != nil {
 		return err
 	}
 

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -158,34 +158,21 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// Install RBAC resources for the filter plugin kubernetes
-	var role, sa, binding client.Object
-	if r.Namespaced {
-		role, sa, binding = operator.MakeScopedRBACObjects(
-			co.Name,
-			co.Namespace,
-			"collector",
-			co.Spec.RBACRules,
-			co.Spec.ServiceAccountAnnotations,
-		)
-	} else {
-		role, sa, binding = operator.MakeRBACObjects(
-			co.Name,
-			co.Namespace,
-			"collector",
-			co.Spec.RBACRules,
-			co.Spec.ServiceAccountAnnotations,
-		)
-	}
-	// Deploy Fluent Bit Collector (Cluster)Role
+	// Reconcile the RBAC the agent needs, scoped to a namespace or the cluster.
+	role, sa, binding := operator.MakeRBACObjectsForScope(
+		r.Namespaced,
+		co.Name,
+		co.Namespace,
+		"collector",
+		co.Spec.RBACRules,
+		co.Spec.ServiceAccountAnnotations,
+	)
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluent Bit Collector (Cluster)RoleBinding
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, binding, r.mutate(binding, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluent Bit Collector ServiceAccount
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, sa, r.mutate(sa, &co)); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -319,29 +306,8 @@ func (r *CollectorReconciler) delete(ctx context.Context, co *fluentbitv1alpha2.
 		return err
 	}
 
-	// Only the per-instance (Cluster)RoleBinding is removed here; the (Cluster)Role
-	// is shared across all Collector instances and must not be deleted.
-	if r.Namespaced {
-		_, _, rbName := operator.MakeScopedRBACNames(co.Name, "collector")
-		rolebinding := rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rbName,
-				Namespace: co.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else {
-		_, _, crbName := operator.MakeRBACNames(co.Name, "collector")
-		crb := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crbName,
-			},
-		}
-		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, co.Name, co.Namespace, "collector"); err != nil {
+		return err
 	}
 
 	sts := appsv1.StatefulSet{

--- a/controllers/fluent_controller_finalizer.go
+++ b/controllers/fluent_controller_finalizer.go
@@ -77,7 +77,9 @@ func (r *FluentdReconciler) delete(ctx context.Context, fd *fluentdv1alpha1.Flue
 		return err
 	}
 
-	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, fd.Name, fd.Namespace, "fluentd"); err != nil {
+	if err := operator.DeletePerInstanceBinding(
+		ctx, r.Client, r.Namespaced, fd.Name, fd.Namespace, "fluentd",
+	); err != nil {
 		return err
 	}
 

--- a/controllers/fluent_controller_finalizer.go
+++ b/controllers/fluent_controller_finalizer.go
@@ -76,7 +76,31 @@ func (r *FluentdReconciler) delete(ctx context.Context, fd *fluentdv1alpha1.Flue
 	if err := r.Delete(ctx, &sa); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-	// TODO: clusterrole, clusterrolebinding
+
+	// Only the per-instance (Cluster)RoleBinding is removed here; the (Cluster)Role
+	// is shared across all Fluentd instances and must not be deleted.
+	if r.Namespaced {
+		_, _, rbName := operator.MakeScopedRBACNames(fd.Name, "fluentd")
+		rolebinding := rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rbName,
+				Namespace: fd.Namespace,
+			},
+		}
+		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		_, _, crbName := operator.MakeRBACNames(fd.Name, "fluentd")
+		crb := rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crbName,
+			},
+		}
+		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
 
 	sts := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -155,6 +179,38 @@ func (r *FluentdReconciler) mutate(obj client.Object, fd *fluentdv1alpha1.Fluent
 		return func() error {
 			o.RoleRef = expected.RoleRef
 			o.Subjects = expected.Subjects
+			return nil
+		}
+	case *rbacv1.Role:
+		// The Role is shared across all Fluentd instances in the namespace, so
+		// no per-instance controller reference is set on it.
+		expected, _, _ := operator.MakeScopedRBACObjects(
+			fd.Name,
+			fd.Namespace,
+			"fluentd",
+			fd.Spec.RBACRules,
+			fd.Spec.ServiceAccountAnnotations,
+		)
+
+		return func() error {
+			o.Rules = expected.Rules
+			return nil
+		}
+	case *rbacv1.RoleBinding:
+		_, _, expected := operator.MakeScopedRBACObjects(
+			fd.Name,
+			fd.Namespace,
+			"fluentd",
+			fd.Spec.RBACRules,
+			fd.Spec.ServiceAccountAnnotations,
+		)
+
+		return func() error {
+			o.RoleRef = expected.RoleRef
+			o.Subjects = expected.Subjects
+			if err := ctrl.SetControllerReference(fd, o, r.Scheme); err != nil {
+				return err
+			}
 			return nil
 		}
 	case *appsv1.StatefulSet:

--- a/controllers/fluent_controller_finalizer.go
+++ b/controllers/fluent_controller_finalizer.go
@@ -77,29 +77,8 @@ func (r *FluentdReconciler) delete(ctx context.Context, fd *fluentdv1alpha1.Flue
 		return err
 	}
 
-	// Only the per-instance (Cluster)RoleBinding is removed here; the (Cluster)Role
-	// is shared across all Fluentd instances and must not be deleted.
-	if r.Namespaced {
-		_, _, rbName := operator.MakeScopedRBACNames(fd.Name, "fluentd")
-		rolebinding := rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rbName,
-				Namespace: fd.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else {
-		_, _, crbName := operator.MakeRBACNames(fd.Name, "fluentd")
-		crb := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crbName,
-			},
-		}
-		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, fd.Name, fd.Namespace, "fluentd"); err != nil {
+		return err
 	}
 
 	sts := appsv1.StatefulSet{

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -53,7 +53,7 @@ type FluentBitReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;watch;patch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;delete;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;delete;get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
 

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -100,25 +100,15 @@ func (r *FluentBitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// Install RBAC resources for the filter plugin kubernetes
-	var role, sa, binding client.Object
-	if r.Namespaced {
-		role, sa, binding = operator.MakeScopedRBACObjects(
-			fb.Name,
-			fb.Namespace,
-			"fluent-bit",
-			fb.Spec.RBACRules,
-			fb.Spec.ServiceAccountAnnotations,
-		)
-	} else {
-		role, sa, binding = operator.MakeRBACObjects(
-			fb.Name,
-			fb.Namespace,
-			"fluent-bit",
-			fb.Spec.RBACRules,
-			fb.Spec.ServiceAccountAnnotations,
-		)
-	}
+	// Reconcile the RBAC the agent needs, scoped to a namespace or the cluster.
+	role, sa, binding := operator.MakeRBACObjectsForScope(
+		r.Namespaced,
+		fb.Name,
+		fb.Namespace,
+		"fluent-bit",
+		fb.Spec.RBACRules,
+		fb.Spec.ServiceAccountAnnotations,
+	)
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &fb)); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -269,31 +259,8 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 		return err
 	}
 
-	if r.Namespaced {
-		_, _, roleBindingName := operator.MakeScopedRBACNames(fb.Name, "fluent-bit")
-		// Only the RoleBinding is per-instance; the Role is shared across all
-		// FluentBit instances in the namespace, so it must not be deleted here.
-		rolebinding := rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      roleBindingName,
-				Namespace: fb.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else {
-		_, _, crbName := operator.MakeRBACNames(fb.Name, "fluent-bit")
-		// Only the ClusterRoleBinding is per-instance; the ClusterRole is shared
-		// across all FluentBit instances, so it must not be deleted here.
-		crb := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crbName,
-			},
-		}
-		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, fb.Name, fb.Namespace, "fluent-bit"); err != nil {
+		return err
 	}
 
 	ds := appsv1.DaemonSet{

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -189,6 +189,8 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.Role:
+		// The Role is shared across all FluentBit instances in the namespace, so
+		// no per-instance controller reference is set on it.
 		expected, _, _ := operator.MakeScopedRBACObjects(
 			fb.Name,
 			fb.Namespace,
@@ -199,9 +201,6 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 
 		return func() error {
 			o.Rules = expected.Rules
-			if err := ctrl.SetControllerReference(fb, o, r.Scheme); err != nil {
-				return err
-			}
 			return nil
 		}
 	case *rbacv1.ClusterRole:

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -189,7 +189,13 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.Role:
-		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
+		expected, _, _ := operator.MakeScopedRBACObjects(
+			fb.Name,
+			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
+			fb.Spec.ServiceAccountAnnotations,
+		)
 
 		return func() error {
 			o.Rules = expected.Rules
@@ -210,7 +216,13 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *corev1.ServiceAccount:
-		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
+		_, expected, _ := operator.MakeScopedRBACObjects(
+			fb.Name,
+			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
+			fb.Spec.ServiceAccountAnnotations,
+		)
 
 		return func() error {
 			o.Annotations = expected.Annotations
@@ -220,7 +232,13 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.RoleBinding:
-		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
+		_, _, expected := operator.MakeScopedRBACObjects(
+			fb.Name,
+			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
+			fb.Spec.ServiceAccountAnnotations,
+		)
 		return func() error {
 			o.Subjects = expected.Subjects
 			o.RoleRef = expected.RoleRef
@@ -259,7 +277,9 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 		return err
 	}
 
-	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, fb.Name, fb.Namespace, "fluent-bit"); err != nil {
+	if err := operator.DeletePerInstanceBinding(
+		ctx, r.Client, r.Namespaced, fb.Name, fb.Namespace, "fluent-bit",
+	); err != nil {
 		return err
 	}
 

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -106,6 +106,8 @@ func (r *FluentBitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		role, sa, binding = operator.MakeScopedRBACObjects(
 			fb.Name,
 			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
 			fb.Spec.ServiceAccountAnnotations,
 		)
 	} else {
@@ -197,7 +199,7 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.Role:
-		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
+		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 
 		return func() error {
 			o.Rules = expected.Rules
@@ -218,7 +220,7 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *corev1.ServiceAccount:
-		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
+		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 
 		return func() error {
 			o.Annotations = expected.Annotations
@@ -228,7 +230,7 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.RoleBinding:
-		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
+		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 		return func() error {
 			o.Subjects = expected.Subjects
 			o.RoleRef = expected.RoleRef
@@ -268,17 +270,9 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 	}
 
 	if r.Namespaced {
-		roleName, _, roleBindingName := operator.MakeScopedRBACNames(fb.Name)
-		role := rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      roleName,
-				Namespace: fb.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, &role); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-
+		_, _, roleBindingName := operator.MakeScopedRBACNames(fb.Name, "fluent-bit")
+		// Only the RoleBinding is per-instance; the Role is shared across all
+		// FluentBit instances in the namespace, so it must not be deleted here.
 		rolebinding := rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      roleBindingName,
@@ -288,8 +282,19 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+	} else {
+		_, _, crbName := operator.MakeRBACNames(fb.Name, "fluent-bit")
+		// Only the ClusterRoleBinding is per-instance; the ClusterRole is shared
+		// across all FluentBit instances, so it must not be deleted here.
+		crb := rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crbName,
+			},
+		}
+		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
 	}
-	// TODO: clusterrole, clusterrolebinding
 
 	ds := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -210,7 +210,13 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.Role:
-		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
+		expected, _, _ := operator.MakeScopedRBACObjects(
+			fb.Name,
+			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
+			fb.Spec.ServiceAccountAnnotations,
+		)
 
 		return func() error {
 			o.Rules = expected.Rules
@@ -231,7 +237,13 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *corev1.ServiceAccount:
-		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
+		_, expected, _ := operator.MakeScopedRBACObjects(
+			fb.Name,
+			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
+			fb.Spec.ServiceAccountAnnotations,
+		)
 
 		return func() error {
 			o.Annotations = expected.Annotations
@@ -241,7 +253,13 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.RoleBinding:
-		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
+		_, _, expected := operator.MakeScopedRBACObjects(
+			fb.Name,
+			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
+			fb.Spec.ServiceAccountAnnotations,
+		)
 		return func() error {
 			o.Subjects = expected.Subjects
 			o.RoleRef = expected.RoleRef
@@ -280,7 +298,9 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 		return err
 	}
 
-	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, fb.Name, fb.Namespace, "fluent-bit"); err != nil {
+	if err := operator.DeletePerInstanceBinding(
+		ctx, r.Client, r.Namespaced, fb.Name, fb.Namespace, "fluent-bit",
+	); err != nil {
 		return err
 	}
 

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -100,25 +100,15 @@ func (r *FluentBitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	// Install RBAC resources for the filter plugin kubernetes
-	var role, sa, binding client.Object
-	if r.Namespaced {
-		role, sa, binding = operator.MakeScopedRBACObjects(
-			fb.Name,
-			fb.Namespace,
-			"fluent-bit",
-			fb.Spec.RBACRules,
-			fb.Spec.ServiceAccountAnnotations,
-		)
-	} else {
-		role, sa, binding = operator.MakeRBACObjects(
-			fb.Name,
-			fb.Namespace,
-			"fluent-bit",
-			fb.Spec.RBACRules,
-			fb.Spec.ServiceAccountAnnotations,
-		)
-	}
+	// Reconcile the RBAC the agent needs, scoped to a namespace or the cluster.
+	role, sa, binding := operator.MakeRBACObjectsForScope(
+		r.Namespaced,
+		fb.Name,
+		fb.Namespace,
+		"fluent-bit",
+		fb.Spec.RBACRules,
+		fb.Spec.ServiceAccountAnnotations,
+	)
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &fb)); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -290,31 +280,8 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 		return err
 	}
 
-	if r.Namespaced {
-		_, _, roleBindingName := operator.MakeScopedRBACNames(fb.Name, "fluent-bit")
-		// Only the RoleBinding is per-instance; the Role is shared across all
-		// FluentBit instances in the namespace, so it must not be deleted here.
-		rolebinding := rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      roleBindingName,
-				Namespace: fb.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-	} else {
-		_, _, crbName := operator.MakeRBACNames(fb.Name, "fluent-bit")
-		// Only the ClusterRoleBinding is per-instance; the ClusterRole is shared
-		// across all FluentBit instances, so it must not be deleted here.
-		crb := rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: crbName,
-			},
-		}
-		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
+	if err := operator.DeletePerInstanceBinding(ctx, r.Client, r.Namespaced, fb.Name, fb.Namespace, "fluent-bit"); err != nil {
+		return err
 	}
 
 	ds := appsv1.DaemonSet{

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -210,6 +210,8 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.Role:
+		// The Role is shared across all FluentBit instances in the namespace, so
+		// no per-instance controller reference is set on it.
 		expected, _, _ := operator.MakeScopedRBACObjects(
 			fb.Name,
 			fb.Namespace,
@@ -220,9 +222,6 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 
 		return func() error {
 			o.Rules = expected.Rules
-			if err := ctrl.SetControllerReference(fb, o, r.Scheme); err != nil {
-				return err
-			}
 			return nil
 		}
 	case *rbacv1.ClusterRole:

--- a/controllers/fluentbit_controller.go
+++ b/controllers/fluentbit_controller.go
@@ -106,6 +106,8 @@ func (r *FluentBitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		role, sa, binding = operator.MakeScopedRBACObjects(
 			fb.Name,
 			fb.Namespace,
+			"fluent-bit",
+			fb.Spec.RBACRules,
 			fb.Spec.ServiceAccountAnnotations,
 		)
 	} else {
@@ -218,7 +220,7 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.Role:
-		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
+		expected, _, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 
 		return func() error {
 			o.Rules = expected.Rules
@@ -239,7 +241,7 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *corev1.ServiceAccount:
-		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
+		_, expected, _ := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 
 		return func() error {
 			o.Annotations = expected.Annotations
@@ -249,7 +251,7 @@ func (r *FluentBitReconciler) mutate(obj client.Object, fb *fluentbitv1alpha2.Fl
 			return nil
 		}
 	case *rbacv1.RoleBinding:
-		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, fb.Spec.ServiceAccountAnnotations)
+		_, _, expected := operator.MakeScopedRBACObjects(fb.Name, fb.Namespace, "fluent-bit", fb.Spec.RBACRules, fb.Spec.ServiceAccountAnnotations)
 		return func() error {
 			o.Subjects = expected.Subjects
 			o.RoleRef = expected.RoleRef
@@ -289,17 +291,9 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 	}
 
 	if r.Namespaced {
-		roleName, _, roleBindingName := operator.MakeScopedRBACNames(fb.Name)
-		role := rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      roleName,
-				Namespace: fb.Namespace,
-			},
-		}
-		if err := r.Delete(ctx, &role); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-
+		_, _, roleBindingName := operator.MakeScopedRBACNames(fb.Name, "fluent-bit")
+		// Only the RoleBinding is per-instance; the Role is shared across all
+		// FluentBit instances in the namespace, so it must not be deleted here.
 		rolebinding := rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      roleBindingName,
@@ -309,8 +303,19 @@ func (r *FluentBitReconciler) delete(ctx context.Context, fb *fluentbitv1alpha2.
 		if err := r.Delete(ctx, &rolebinding); err != nil && !errors.IsNotFound(err) {
 			return err
 		}
+	} else {
+		_, _, crbName := operator.MakeRBACNames(fb.Name, "fluent-bit")
+		// Only the ClusterRoleBinding is per-instance; the ClusterRole is shared
+		// across all FluentBit instances, so it must not be deleted here.
+		crb := rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: crbName,
+			},
+		}
+		if err := r.Delete(ctx, &crb); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
 	}
-	// TODO: clusterrole, clusterrolebinding
 
 	ds := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/fluentd_controller.go
+++ b/controllers/fluentd_controller.go
@@ -43,8 +43,9 @@ const (
 // FluentdReconciler reconciles a Fluentd object
 type FluentdReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	Log        logr.Logger
+	Scheme     *runtime.Scheme
+	Namespaced bool
 }
 
 // +kubebuilder:rbac:groups=fluentd.fluent.io,resources=fluentds,verbs=get;list;watch;update
@@ -54,6 +55,7 @@ type FluentdReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts;services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=create;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;delete;get;list;watch;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -100,19 +102,30 @@ func (r *FluentdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// Install RBAC resources for the filter plugin kubernetes
-	cr, sa, crb := operator.MakeRBACObjects(
-		fd.Name,
-		fd.Namespace,
-		fluentdLowercase,
-		fd.Spec.RBACRules,
-		fd.Spec.ServiceAccountAnnotations,
-	)
-	// Deploy Fluentd ClusterRole
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, cr, r.mutate(cr, &fd)); err != nil {
+	var role, sa, binding client.Object
+	if r.Namespaced {
+		role, sa, binding = operator.MakeScopedRBACObjects(
+			fd.Name,
+			fd.Namespace,
+			fluentdLowercase,
+			fd.Spec.RBACRules,
+			fd.Spec.ServiceAccountAnnotations,
+		)
+	} else {
+		role, sa, binding = operator.MakeRBACObjects(
+			fd.Name,
+			fd.Namespace,
+			fluentdLowercase,
+			fd.Spec.RBACRules,
+			fd.Spec.ServiceAccountAnnotations,
+		)
+	}
+	// Deploy Fluentd (Cluster)Role
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &fd)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluentd ClusterRoleBinding
-	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, crb, r.mutate(crb, &fd)); err != nil {
+	// Deploy Fluentd (Cluster)RoleBinding
+	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, binding, r.mutate(binding, &fd)); err != nil {
 		return ctrl.Result{}, err
 	}
 	// Deploy Fluentd ServiceAccount

--- a/controllers/fluentd_controller.go
+++ b/controllers/fluentd_controller.go
@@ -55,7 +55,8 @@ type FluentdReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts;services,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=create;get;list;watch;patch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;delete;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=create;get;list;watch;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=create;delete;get;list;watch;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/fluentd_controller.go
+++ b/controllers/fluentd_controller.go
@@ -101,34 +101,21 @@ func (r *FluentdReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	// Install RBAC resources for the filter plugin kubernetes
-	var role, sa, binding client.Object
-	if r.Namespaced {
-		role, sa, binding = operator.MakeScopedRBACObjects(
-			fd.Name,
-			fd.Namespace,
-			fluentdLowercase,
-			fd.Spec.RBACRules,
-			fd.Spec.ServiceAccountAnnotations,
-		)
-	} else {
-		role, sa, binding = operator.MakeRBACObjects(
-			fd.Name,
-			fd.Namespace,
-			fluentdLowercase,
-			fd.Spec.RBACRules,
-			fd.Spec.ServiceAccountAnnotations,
-		)
-	}
-	// Deploy Fluentd (Cluster)Role
+	// Reconcile the RBAC the agent needs, scoped to a namespace or the cluster.
+	role, sa, binding := operator.MakeRBACObjectsForScope(
+		r.Namespaced,
+		fd.Name,
+		fd.Namespace,
+		fluentdLowercase,
+		fd.Spec.RBACRules,
+		fd.Spec.ServiceAccountAnnotations,
+	)
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, role, r.mutate(role, &fd)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluentd (Cluster)RoleBinding
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, binding, r.mutate(binding, &fd)); err != nil {
 		return ctrl.Result{}, err
 	}
-	// Deploy Fluentd ServiceAccount
 	if _, err := controllerutil.CreateOrPatch(ctx, r.Client, sa, r.mutate(sa, &fd)); err != nil {
 		return ctrl.Result{}, err
 	}

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -42828,6 +42828,7 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - roles
   verbs:
   - create
   - get
@@ -42838,7 +42839,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  - roles
   verbs:
   - create
   - delete

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -43662,6 +43662,7 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - roles
   verbs:
   - create
   - get
@@ -43672,7 +43673,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  - roles
   verbs:
   - create
   - delete

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -62,10 +62,12 @@ func MakeRBACObjects(
 
 func MakeScopedRBACObjects(
 	name,
-	namespace string,
+	namespace,
+	component string,
+	additionalRules []rbacv1.PolicyRule,
 	saAnnotations map[string]string,
 ) (*rbacv1.Role, *corev1.ServiceAccount, *rbacv1.RoleBinding) {
-	rName, saName, rbName := MakeScopedRBACNames(name)
+	rName, saName, rbName := MakeScopedRBACNames(name, component)
 	r := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rName,
@@ -78,6 +80,10 @@ func MakeScopedRBACObjects(
 				Resources: []string{"pods"},
 			},
 		},
+	}
+
+	if additionalRules != nil {
+		r.Rules = append(r.Rules, additionalRules...)
 	}
 
 	sa := corev1.ServiceAccount{
@@ -116,8 +122,8 @@ func MakeRBACNames(name, component string) (string, string, string) {
 	return cr, name, crb
 }
 
-func MakeScopedRBACNames(name string) (string, string, string) {
-	r := "fluent:fluent-operator"
-	rb := fmt.Sprintf("fluent-operator-fluent-bit-%s", name)
+func MakeScopedRBACNames(name, component string) (string, string, string) {
+	r := fmt.Sprintf("fluent-operator-%s", component)
+	rb := fmt.Sprintf("fluent-operator-%s-%s", component, name)
 	return r, name, rb
 }

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -146,28 +146,25 @@ func MakeRBACObjectsForScope(
 	return cr, s, crb
 }
 
-// DeletePerInstanceBinding removes the per-instance RoleBinding (namespaced) or
-// ClusterRoleBinding (cluster-scoped) created for an agent. The (Cluster)Role is
-// shared across all instances of a component and is intentionally left in place.
+// DeletePerInstanceBinding removes the per-instance RoleBinding created for an
+// agent when running in namespaced mode. In cluster-scoped mode nothing is
+// deleted: the per-instance ClusterRoleBinding references a shared ClusterRole,
+// and the operator is intentionally not granted delete on cluster-scoped RBAC
+// (keeping its footprint minimal), so the binding is left in place.
 func DeletePerInstanceBinding(
 	ctx context.Context,
 	c client.Client,
 	namespaced bool,
 	name, namespace, component string,
 ) error {
-	var binding client.Object
-	if namespaced {
-		_, _, rbName := MakeScopedRBACNames(name, component)
-		binding = &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: namespace},
-		}
-	} else {
-		_, _, crbName := MakeRBACNames(name, component)
-		binding = &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{Name: crbName},
-		}
+	if !namespaced {
+		return nil
 	}
-	if err := c.Delete(ctx, binding); err != nil && !apierrors.IsNotFound(err) {
+	_, _, rbName := MakeScopedRBACNames(name, component)
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: namespace},
+	}
+	if err := c.Delete(ctx, rb); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/pkg/operator/rbac.go
+++ b/pkg/operator/rbac.go
@@ -1,11 +1,14 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func MakeRBACObjects(
@@ -82,9 +85,7 @@ func MakeScopedRBACObjects(
 		},
 	}
 
-	if additionalRules != nil {
-		r.Rules = append(r.Rules, additionalRules...)
-	}
+	r.Rules = append(r.Rules, additionalRules...)
 
 	sa := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -122,8 +123,52 @@ func MakeRBACNames(name, component string) (string, string, string) {
 	return cr, name, crb
 }
 
+// MakeScopedRBACNames returns the namespaced Role/ServiceAccount/RoleBinding
+// names. They follow the same convention as the cluster-scoped names.
 func MakeScopedRBACNames(name, component string) (string, string, string) {
-	r := fmt.Sprintf("fluent-operator-%s", component)
-	rb := fmt.Sprintf("fluent-operator-%s-%s", component, name)
-	return r, name, rb
+	return MakeRBACNames(name, component)
+}
+
+// MakeRBACObjectsForScope builds the RBAC objects an agent needs, returning the
+// namespaced (Role/RoleBinding) variants when namespaced is true and the
+// cluster-scoped (ClusterRole/ClusterRoleBinding) variants otherwise.
+func MakeRBACObjectsForScope(
+	namespaced bool,
+	name, namespace, component string,
+	additionalRules []rbacv1.PolicyRule,
+	saAnnotations map[string]string,
+) (role, sa, binding client.Object) {
+	if namespaced {
+		r, s, rb := MakeScopedRBACObjects(name, namespace, component, additionalRules, saAnnotations)
+		return r, s, rb
+	}
+	cr, s, crb := MakeRBACObjects(name, namespace, component, additionalRules, saAnnotations)
+	return cr, s, crb
+}
+
+// DeletePerInstanceBinding removes the per-instance RoleBinding (namespaced) or
+// ClusterRoleBinding (cluster-scoped) created for an agent. The (Cluster)Role is
+// shared across all instances of a component and is intentionally left in place.
+func DeletePerInstanceBinding(
+	ctx context.Context,
+	c client.Client,
+	namespaced bool,
+	name, namespace, component string,
+) error {
+	var binding client.Object
+	if namespaced {
+		_, _, rbName := MakeScopedRBACNames(name, component)
+		binding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: namespace},
+		}
+	} else {
+		_, _, crbName := MakeRBACNames(name, component)
+		binding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: crbName},
+		}
+	}
+	if err := c.Delete(ctx, binding); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Addresses #1281 by completing the operator's namespaced mode so it can run without cluster-wide RBAC on the resources it manages.

The operator already had a `--watch-namespaces` flag that scopes the controller-runtime cache (eliminating the `... is forbidden ... at the cluster scope` list/watch errors) and a `Namespaced` mode for the FluentBit controller that creates namespaced `Role`/`RoleBinding` instead of `ClusterRole`/`ClusterRoleBinding`. This PR extends that to the rest of the operator and makes it easy to enable.

This is **opt-in**; cluster scope remains the default, so existing installs are unaffected.

## Changes

- **Generalize the scoped RBAC builder** (`pkg/operator/rbac.go`): `MakeScopedRBACObjects`/`MakeScopedRBACNames` now take a `component` argument and apply `additionalRules`, so any agent can get namespaced RBAC. Scoped names follow the same `fluent-operator-<component>` convention as the cluster-scoped objects. A small `MakeRBACObjectsForScope` helper centralizes the namespaced-vs-cluster selection used by all three controllers.
- **Collector & Fluentd controllers**: add a `Namespaced` flag (wired to `--watch-namespaces`) so they create `Role`/`RoleBinding` instead of `ClusterRole`/`ClusterRoleBinding`. Previously only FluentBit honored namespaced mode.
- **Deletion cleanup**: in namespaced mode the per-instance `RoleBinding` is now removed when an agent CR is deleted (via the shared `DeletePerInstanceBinding` helper). In cluster mode the per-instance `ClusterRoleBinding` is left in place (unchanged from prior behavior): the operator is intentionally **not** granted `delete` on cluster-scoped RBAC, keeping its footprint minimal. The shared `(Cluster)Role` is always preserved, since deleting it would break sibling instances.
- **Tighten the operator's own RBAC** (`config/rbac/role.yaml`, `manifests/setup/setup.yaml`): since the operator only deletes the per-instance `RoleBinding` and never the shared `Role`, the kubebuilder markers now grant `roles` only `create;get;list;watch;patch` (no `delete`), keeping `delete` on `rolebindings`.
- **Helm chart**: expose `operator.watchNamespaces` as a first-class value that renders `--watch-namespaces=...` (defaults to empty / cluster scope).

## Notes / follow-ups (not in this PR)

- The operator's own static `ClusterRole` in the Helm chart is unchanged; a namespaced operator `Role` option is a sensible follow-up. (The chart already grants neither `roles:delete` nor `rolebindings:delete`; note that without `rolebindings:delete` a Helm-deployed operator can't clean up per-instance `RoleBinding`s in namespaced mode.)
- Cleaning up the per-instance `ClusterRoleBinding` in cluster mode would require granting the operator `delete` on `clusterrolebindings`; deferred here to keep this PR focused on reducing (not expanding) cluster-scoped permissions.
- Trade-offs to document separately: in namespaced mode the fluent-bit kubernetes metadata filter can only enrich pods in watched namespaces, and cluster-scoped CRDs (`ClusterInput`/`ClusterOutput`/etc.) still require cluster-scoped watches.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` on changed packages
- [x] `go test ./pkg/operator/... ./controllers/...`
- [x] `helm template --set operator.watchNamespaces=logging` renders `--watch-namespaces=logging`; default omits it
- [x] Regenerated `config/rbac/role.yaml` and `manifests/setup/setup.yaml` from the updated kubebuilder markers (`make manifests`); the only change is `roles` dropping the `delete` verb
- [x] CI `e2e tests` and `helm e2e tests` pass (cluster-mode lifecycle, incl. finalizer cleanup)
- [ ] Manual e2e: deploy with `--watch-namespaces` and confirm namespaced `Role`/`RoleBinding` are created for fluent-bit/collector/fluentd and no cluster-scope list/watch errors appear

Made with [Cursor](https://cursor.com)