### PR TITLE
feat: add storage.total_limit_size support to splunk output

### DIFF
--- a/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/splunk_types.go
@@ -61,6 +61,8 @@ type Splunk struct {
 	*plugins.TLS `json:"tls,omitempty"`
 	// Include fluentbit networking options for this output-plugin
 	*plugins.Networking `json:"networking,omitempty"`
+	// Limit the maximum number of Chunks in the filesystem for the current output logical destination.
+	TotalLimitSize string `json:"totalLimitSize,omitempty"`
 }
 
 // Name implement Section() method
@@ -118,6 +120,8 @@ func (o *Splunk) Params(sl plugins.SecretLoader) (*params.KVs, error) {
 			kvs.Insert("event_field", v)
 		}
 	}
+
+	plugins.InsertKVString(kvs, "storage.total_limit_size", o.TotalLimitSize)
 
 	return kvs, nil
 }

--- a/apis/fluentbit/v1alpha2/plugins/output/splunk_types_test.go
+++ b/apis/fluentbit/v1alpha2/plugins/output/splunk_types_test.go
@@ -1,0 +1,42 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins"
+	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/params"
+	"github.com/fluent/fluent-operator/v3/pkg/utils"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSplunk_Params(t *testing.T) {
+	g := NewGomegaWithT(t)
+	fcb := fake.ClientBuilder{}
+	fc := fcb.WithObjects(&v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "test_namespace", Name: "splunk_secret"},
+		Data: map[string][]byte{
+			"splunk_token": []byte("expected_splunk_token"),
+		},
+	}).Build()
+
+	sl := plugins.NewSecretLoader(fc, "test_namespace")
+	s := Splunk{
+		Host:           "splunk.example.com",
+		Port:           utils.ToPtr[int32](8088),
+		SplunkToken:    &plugins.Secret{ValueFrom: plugins.ValueSource{SecretKeyRef: v1.SecretKeySelector{LocalObjectReference: v1.LocalObjectReference{Name: "splunk_secret"}, Key: "splunk_token"}}},
+		TotalLimitSize: "512M",
+	}
+
+	expected := params.NewKVs()
+	expected.Insert("splunk_token", "expected_splunk_token")
+	expected.Insert("host", "splunk.example.com")
+	expected.Insert("port", "8088")
+	expected.Insert("storage.total_limit_size", "512M")
+
+	kvs, err := s.Params(sl)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(kvs).To(Equal(expected))
+}

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_clusteroutputs.yaml
@@ -4386,6 +4386,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration

--- a/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator-fluent-bit-crds/templates/fluentbit.fluent.io_outputs.yaml
@@ -4386,6 +4386,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_clusteroutputs.yaml
@@ -4384,6 +4384,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration

--- a/charts/fluent-operator/crds/fluentbit.fluent.io_outputs.yaml
+++ b/charts/fluent-operator/crds/fluentbit.fluent.io_outputs.yaml
@@ -4384,6 +4384,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration

--- a/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_clusteroutputs.yaml
@@ -4385,6 +4385,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration

--- a/config/crd/bases/fluentbit.fluent.io_outputs.yaml
+++ b/config/crd/bases/fluentbit.fluent.io_outputs.yaml
@@ -4385,6 +4385,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration

--- a/docs/plugins/fluentbit/output/splunk.md
+++ b/docs/plugins/fluentbit/output/splunk.md
@@ -26,3 +26,4 @@ Splunk output plugin allows to ingest your records into a Splunk Enterprise serv
 | Workers | Enables dedicated thread(s) for this output. Default value `2` is set since version 1.8.13. For previous versions is 0. | *int32 |
 | tls |  | *[plugins.TLS](../tls.md) |
 | networking | Include fluentbit networking options for this output-plugin | *[plugins.Networking](../net.md) |
+| totalLimitSize | Limit the maximum number of Chunks in the filesystem for the current output logical destination. | string |

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -8585,6 +8585,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration
@@ -39257,6 +39261,10 @@ spec:
                         description: Hostname to be used for TLS SNI extension
                         type: string
                     type: object
+                  totalLimitSize:
+                    description: Limit the maximum number of Chunks in the filesystem
+                      for the current output logical destination.
+                    type: string
                 type: object
               stackdriver:
                 description: Stackdriver defines Stackdriver Output Configuration


### PR DESCRIPTION
  ### What this PR does / why we need it:

  Adds `storage.total_limit_size` support to the Splunk output plugin, enabling
  operators to limit the maximum on-disk chunk buffer size per Splunk output.

  Follows the exact same pattern already implemented in 7 other output plugins
  (Elasticsearch, OpenTelemetry, Syslog, Loki, Kafka, OpenSearch and HTTP).

  ### Which issue(s) this PR fixes:
None

  ### Does this PR introduced a user-facing change?

  ```release-note
  The Splunk output plugin now supports `totalLimitSize` to limit the maximum
  number of filesystem chunks via `storage.total_limit_size`.

  Additional documentation, usage docs, etc.:

  - [Usage]: https://docs.fluentbit.io/manual/administration/buffering-and-storage#output-section-configuration