### PR TITLE
feat: adjust fluentbit `service` helm value to allow specifying all possible service fields

### DIFF
--- a/charts/fluent-operator/templates/_helpers.tpl
+++ b/charts/fluent-operator/templates/_helpers.tpl
@@ -94,3 +94,15 @@ Determine the container log path based on containerRuntime
 /var/log/containers
 {{- end -}}
 {{- end }}
+
+{{/*
+Render a ClusterFluentBitConfig `service` section, merging the caller-provided
+defaults with the `fluentbit.service` value (which takes precedence on conflicts).
+Expects a dict with:
+  defaults - dict of default service fields
+  root     - the root template context (e.g. `$`)
+*/}}
+{{- define "fluent-operator.fluentbitService" -}}
+{{- $merged := mergeOverwrite (deepCopy .defaults) (.root.Values.fluentbit.service | default dict) -}}
+{{- toYaml $merged -}}
+{{- end }}

--- a/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentBitConfig.yaml
@@ -12,21 +12,11 @@ spec:
   {{- end }}
   configFileFormat: {{ .Values.fluentbit.configFileFormat | default "classic" | quote }}
   service:
-    parsersFile: /fluent-bit/etc/parsers.conf
-    httpServer: true
+    {{- $defaults := dict "parsersFile" "/fluent-bit/etc/parsers.conf" "httpServer" true }}
     {{- with .Values.fluentbit.logLevel }}
-    logLevel: {{ . | quote }}
+    {{- $defaults = set $defaults "logLevel" . }}
     {{- end }}
-    {{- with .Values.fluentbit.service.storage }}
-    storage:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
-    {{- with .Values.fluentbit.service.schedulerBase }}
-    schedulerBase: {{ . }}
-    {{- end }}
-    {{- with .Values.fluentbit.service.schedulerCap }}
-    schedulerCap: {{ . }}
-    {{- end }}
+    {{- include "fluent-operator.fluentbitService" (dict "defaults" $defaults "root" $) | nindent 4 }}
   inputSelector:
     matchLabels:
       fluentbit.fluent.io/enabled: "true"

--- a/charts/fluent-operator/templates/fluentbitconfig-fluentbitconfig-edge.yaml
+++ b/charts/fluent-operator/templates/fluentbitconfig-fluentbitconfig-edge.yaml
@@ -8,13 +8,8 @@ metadata:
 spec:
   configFileFormat: {{ .Values.fluentbit.configFileFormat | default "classic" | quote }}
   service:
-    parsersFile: parsers.conf
-    {{- with .Values.fluentbit.service.schedulerBase }}
-    schedulerBase: {{ . }}
-    {{- end }}
-    {{- with .Values.fluentbit.service.schedulerCap }}
-    schedulerCap: {{ . }}
-    {{- end }}
+    {{- $defaults := dict "parsersFile" "parsers.conf" }}
+    {{- include "fluent-operator.fluentbitService" (dict "defaults" $defaults "root" $) | nindent 4 }}
   inputSelector:
     matchLabels:
       fluentbit.fluent.io/enabled: "true"

--- a/charts/fluent-operator/values.yaml
+++ b/charts/fluent-operator/values.yaml
@@ -530,16 +530,14 @@ fluentbit:
     # -- Scheduler cap for maximum retry time (seconds)
     # schedulerCap: 2000
     # -- Storage configuration for Fluent Bit buffering
-    storage: {}
-  # Remove the above storage section and uncomment below section if you want to configure file-system as storage for buffer
-  #    storage:
-  #      path: "/host/fluent-bit-buffer/"
-  #      backlogMemLimit: "50MB"
-  #      checksum: "off"
-  #      deleteIrrecoverableChunks: "on"
-  #      maxChunksUp: 128
-  #      metrics: "on"
-  #      sync: normal
+    # storage:
+    #   path: "/host/fluent-bit-buffer/"
+    #   backlogMemLimit: "50MB"
+    #   checksum: "off"
+    #   deleteIrrecoverableChunks: "on"
+    #   maxChunksUp: 128
+    #   metrics: "on"
+    #   sync: normal
 
   # Configure the default filters in FluentBit.
   # The `filter` will filter and parse the collected log information and output the logs into a uniform format. You can choose whether to turn this on or not.


### PR DESCRIPTION
…ossible service fields

<!--
PR titles must follow Conventional Commits format: https://www.conventionalcommits.org
Examples: feat: add X | fix: correct Y | chore: update Z | docs: improve W
-->

<!--
Thank you for contributing to Fluent Operator!
Your commits need to follow DCO: https://probot.github.io/apps/dco/
And please provide the following information to help us make the most of your pull request:
-->

### What this PR does / why we need it:

Allows users of the helm chart to specify any possible fluentbit `service` configuration, rather than only the fields that the chart explicitly exposes through values. This will reduce future maintenance of the helm chart by not requiring chart maintainers to add every possible `service` configuration value into the helm chart.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
