### PR TITLE
fix: correct the fluent-operator deployment to match the setup.yaml with helm template

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -42,16 +42,13 @@ resources:
 # be able to communicate with the Webhook Server.
 #- ../network-policy
 
-patches:
-# [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
-# More info: https://book.kubebuilder.io/reference/metrics
-- path: manager_metrics_patch.yaml
-  target:
-    kind: Deployment
-
-# Uncomment the patches line if you enable Metrics and CertManager
-# [METRICS-WITH-CERTS] To enable metrics protected with certManager, uncomment the following line.
-# This patch will protect the metrics with certManager self-signed certs.
+# [METRICS-WITH-CERTS] To enable HTTPS metrics protected with certManager,
+# uncomment the patches below. These patches enable the endpoint and configure
+# it to use the certificate managed by certManager.
+#patches:
+#- path: manager_metrics_patch.yaml
+#  target:
+#    kind: Deployment
 #- path: cert_metrics_manager_patch.yaml
 #  target:
 #    kind: Deployment

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,6 +49,9 @@ resources:
 #- path: manager_metrics_patch.yaml
 #  target:
 #    kind: Deployment
+#- path: metrics_service_patch.yaml
+#  target:
+#    kind: Service
 #- path: cert_metrics_manager_patch.yaml
 #  target:
 #    kind: Deployment

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,4 +1,9 @@
-# This patch adds the args to allow exposing the metrics endpoint using HTTPS
-- op: add
-  path: /spec/template/spec/containers/0/args/-
-  value: --metrics-bind-address=:8443
+# This patch configures the manager to expose the metrics endpoint using HTTPS.
+- op: replace
+  path: /spec/template/spec/containers/0/args
+  value:
+    - --metrics-bind-address=:8443
+    - --metrics-secure=true
+- op: replace
+  path: /spec/template/spec/containers/0/ports/0/containerPort
+  value: 8443

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -7,10 +7,10 @@ metadata:
   name: fluent-operator-metrics
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: metrics
+    port: 8080
     protocol: TCP
-    targetPort: 8443
+    targetPort: 8080
   selector:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator

--- a/config/default/metrics_service_patch.yaml
+++ b/config/default/metrics_service_patch.yaml
@@ -1,0 +1,7 @@
+# This patch configures the metrics Service for the optional HTTPS endpoint.
+- op: replace
+  path: /spec/ports/0/port
+  value: 8443
+- op: replace
+  path: /spec/ports/0/targetPort
+  value: 8443

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,7 +49,9 @@ spec:
                 fieldPath: metadata.namespace
           - name: CONTAINER_LOG_PATH
             value: /var/log/containers
-        args: []
+        args:
+          - --metrics-bind-address=:8080
+          - --metrics-secure=false
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,57 +16,67 @@ spec:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: fluent-operator
     spec:
-      securityContext:
-        runAsNonRoot: true
+      volumes:
+      - name: env
+        configMap:
+          name: fluent-operator-env
       containers:
-      - command:
-        - /manager
-        args:
-        - --leader-elect
-        - --health-probe-bind-address=:8081
+      - name: fluent-operator
         image: controller:latest
-        name: manager
-        ports:
-        - containerPort: 8081
-          name: health
-          protocol: TCP
         securityContext:
-          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          limits:
+            cpu: 100m
+            memory: 60Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
         env:
           - name: NAMESPACE
             valueFrom:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
-        resources:
-          limits:
-            cpu: 200m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+          - name: CONTAINER_LOG_PATH
+            value: /var/log/containers
+        args: []
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
           - name: env
             mountPath: /fluent-operator
-      volumes:
-      - name: env
-        configMap:
-          name: fluent-operator-env
+        ports:
+          - containerPort: 8080
+            name: metrics
       serviceAccountName: fluent-operator
-      terminationGracePeriodSeconds: 10
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -22,5 +22,5 @@ spec:
           matchLabels:
             metrics: enabled  # Only from namespaces with this label
       ports:
-        - port: 8443
+        - port: metrics
           protocol: TCP

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -9,20 +9,8 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
-      scheme: https # Ensure this is the name of the port that exposes HTTPS metrics
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        # TODO(user): The option insecureSkipVerify: true is not recommended for production since it disables
-        # certificate verification. This poses a significant security risk by making the system vulnerable to
-        # man-in-the-middle attacks, where an attacker could intercept and manipulate the communication between
-        # Prometheus and the monitored services. This could lead to unauthorized access to sensitive metrics data,
-        # compromising the integrity and confidentiality of the information.
-        # Please use the following options for secure configurations:
-        # caFile: /etc/metrics-certs/ca.crt
-        # certFile: /etc/metrics-certs/tls.crt
-        # keyFile: /etc/metrics-certs/tls.key
-        insecureSkipVerify: true
+      port: metrics
+      scheme: http
   selector:
     matchLabels:
       app.kubernetes.io/component: operator

--- a/config/prometheus/monitor_tls_patch.yaml
+++ b/config/prometheus/monitor_tls_patch.yaml
@@ -1,6 +1,11 @@
-# Patch for Prometheus ServiceMonitor to enable secure TLS configuration
-# using certificates managed by cert-manager
+# Patch the ServiceMonitor to use HTTPS and certificates managed by cert-manager.
 - op: replace
+  path: /spec/endpoints/0/scheme
+  value: https
+- op: add
+  path: /spec/endpoints/0/bearerTokenFile
+  value: /var/run/secrets/kubernetes.io/serviceaccount/token
+- op: add
   path: /spec/endpoints/0/tlsConfig
   value:
     # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -42984,10 +42984,10 @@ metadata:
   namespace: fluent
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: metrics
+    port: 8080
     protocol: TCP
-    targetPort: 8443
+    targetPort: 8080
   selector:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: fluent-operator
@@ -43012,56 +43012,65 @@ spec:
         app.kubernetes.io/name: fluent-operator
     spec:
       containers:
-      - args:
-        - --leader-elect
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=:8443
-        command:
-        - /manager
+      - args: []
         env:
         - name: NAMESPACE
           valueFrom:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        - name: CONTAINER_LOG_PATH
+          value: /var/log/containers
         image: ghcr.io/fluent/fluent-operator/fluent-operator:latest
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /healthz
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: manager
+          timeoutSeconds: 5
+        name: fluent-operator
         ports:
-        - containerPort: 8081
-          name: health
-          protocol: TCP
+        - containerPort: 8080
+          name: metrics
         readinessProbe:
+          failureThreshold: 3
           httpGet:
             path: /readyz
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
         resources:
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 100m
+            memory: 60Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 100m
+            memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /fluent-operator
           name: env
       securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
         runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: fluent-operator
-      terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
           name: fluent-operator-env

--- a/manifests/setup/setup.yaml
+++ b/manifests/setup/setup.yaml
@@ -43012,7 +43012,9 @@ spec:
         app.kubernetes.io/name: fluent-operator
     spec:
       containers:
-      - args: []
+      - args:
+        - --metrics-bind-address=:8080
+        - --metrics-secure=false
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
### What this PR does / why we need it

Fixes the YAML-based installation regression reported in #1995.

Since #1953, `manifests/setup/setup.yaml` has been generated from the Kustomize configuration. However, the manager Deployment in `config/manager/manager.yaml` was not aligned with the Helm chart defaults.

The generated Deployment explicitly enabled the secure metrics endpoint on port `8443` while using a read-only root filesystem. Without a provided certificate, controller-runtime attempts to generate certificates under `/tmp/k8s-metrics-server`, which can prevent the operator from starting.

This PR aligns the default Kustomize Deployment with the Deployment produced by Helm:

- Uses the image's `/manager` entrypoint instead of overriding `command`.
- Removes the default leader-election and secure-metrics arguments.
- Uses the `fluent-operator` container name.
- Adds the default `CONTAINER_LOG_PATH`.
- Aligns resource limits, probes, container security context, and pod security context.
- Aligns the declared metrics port with Helm's default port `8080`.
- Keeps HTTPS metrics configuration available as an optional Kustomize patch.

### Which issue(s) this PR fixes

Fixes #1995

### Files updated

- `config/manager/manager.yaml`
  - Aligns the Kustomize manager Deployment with the Helm defaults.

- `config/default/kustomization.yaml`
  - Stops enabling secure metrics by default.
  - Documents the optional patches required for HTTPS metrics with cert-manager.

- `config/default/metrics_service.yaml`
  - Changes the metrics Service from HTTPS port `8443` to the Helm default port `8080`.

- `manifests/setup/setup.yaml`
  - Regenerates the published YAML installation bundle from the updated Kustomize configuration.

### Validation

- Compared the generated Kustomize Deployment with the output of `helm template` using the default values.
- Ran `make test-e2e`: all 10 Fluentd e2e specs passed.
- Verified the operator Deployment becomes Ready in Kind with zero container restarts.
- Confirmed the operator uses the image entrypoint without explicit `command` or `args`.

### Does this PR introduce a user-facing change?

```release-note
Fix the YAML-based installation by aligning the generated operator Deployment with the Helm chart defaults.