### PR TITLE
fix(collector): render ClusterFluentBitConfig referenced by Collectors

### DIFF
--- a/controllers/collector_config_test.go
+++ b/controllers/collector_config_test.go
@@ -340,3 +340,77 @@ func TestFluentBitNamespacedConfigStillRendered(t *testing.T) {
 		}
 	}
 }
+
+// TestIsFluentBitConfigSecret guards the predicate that filters the Collector's
+// Secret watch. Unrelated Secrets must be dropped before collectorsForSecret
+// runs, while Secrets rendered by FluentBitConfigReconciler must pass.
+func TestIsFluentBitConfigSecret(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        bool
+	}{
+		{
+			name:        "config secret rendered by the operator",
+			annotations: map[string]string{fluentBitConfigHashAnnotation: "abc123"},
+			want:        true,
+		},
+		{
+			name:        "unrelated secret with no annotations",
+			annotations: nil,
+			want:        false,
+		},
+		{
+			name:        "unrelated secret with other annotations",
+			annotations: map[string]string{"helm.sh/release": "foo"},
+			want:        false,
+		},
+		{
+			// A Secret written before the config-hash annotation existed is
+			// filtered out, but FluentBitConfigReconciler treats a missing
+			// annotation as a change and rewrites it, so the next event passes.
+			name:        "legacy config secret without the annotation",
+			annotations: nil,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sec := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        testConfigName,
+					Namespace:   testCollectorNamespace,
+					Annotations: tt.annotations,
+				},
+			}
+			if got := isFluentBitConfigSecret(sec); got != tt.want {
+				t.Errorf("isFluentBitConfigSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConfigSecretCarriesHashAnnotation asserts the contract the predicate relies
+// on: every Secret rendered for a Collector is stamped with the annotation, so
+// the watch is never silently starved.
+func TestConfigSecretCarriesHashAnnotation(t *testing.T) {
+	s := newConfigTestScheme(t)
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(newCollectorTestObjects()...).Build()
+	r := &FluentBitConfigReconciler{Client: cl, Log: logf.Log, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var sec corev1.Secret
+	if err := cl.Get(context.Background(),
+		client.ObjectKey{Name: testConfigName, Namespace: testCollectorNamespace}, &sec); err != nil {
+		t.Fatalf("expected rendered secret: %v", err)
+	}
+
+	if !isFluentBitConfigSecret(&sec) {
+		t.Fatalf("rendered config secret lacks %s; the Collector Secret watch would ignore it",
+			fluentBitConfigHashAnnotation)
+	}
+}

--- a/controllers/collector_config_test.go
+++ b/controllers/collector_config_test.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2"
+	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/input"
+	"github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2/plugins/output"
+)
+
+const (
+	testCollectorNamespace = "logging"
+	testConfigName         = "collector-config"
+)
+
+func newConfigTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add client-go scheme: %v", err)
+	}
+	if err := fluentbitv1alpha2.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add fluentbit scheme: %v", err)
+	}
+	return s
+}
+
+// newCollectorTestObjects returns a ClusterFluentBitConfig selecting one cluster input
+// and one cluster output, plus a Collector referencing that config by name.
+func newCollectorTestObjects() []client.Object {
+	selector := metav1.LabelSelector{MatchLabels: map[string]string{"fluentbit.fluent.io/enabled": "true"}}
+
+	return []client.Object{
+		&fluentbitv1alpha2.ClusterFluentBitConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: testConfigName},
+			Spec: fluentbitv1alpha2.FluentBitConfigSpec{
+				InputSelector:  selector,
+				FilterSelector: selector,
+				OutputSelector: selector,
+			},
+		},
+		&fluentbitv1alpha2.ClusterInput{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "collector-forward",
+				Labels: map[string]string{"fluentbit.fluent.io/enabled": "true"},
+			},
+			Spec: fluentbitv1alpha2.InputSpec{
+				Forward: &input.Forward{Port: ptrInt32(24224)},
+			},
+		},
+		&fluentbitv1alpha2.ClusterOutput{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "collector-stdout",
+				Labels: map[string]string{"fluentbit.fluent.io/enabled": "true"},
+			},
+			Spec: fluentbitv1alpha2.OutputSpec{
+				Match:  "*",
+				Stdout: &output.Stdout{},
+			},
+		},
+		&fluentbitv1alpha2.Collector{
+			ObjectMeta: metav1.ObjectMeta{Name: "collector", Namespace: testCollectorNamespace},
+			Spec:       fluentbitv1alpha2.CollectorSpec{FluentBitConfigName: testConfigName},
+		},
+	}
+}
+
+func ptrInt32(i int32) *int32 { return &i }
+
+// TestCollectorClusterFluentBitConfigIsRendered reproduces
+// https://github.com/fluent/fluent-operator/issues/1436: a Collector referencing a
+// ClusterFluentBitConfig used to be ignored by the FluentBitConfig controller, which
+// only ever looked at FluentBit DaemonSets. As a result no Secret was ever rendered
+// and the Collector controller requeued forever without creating anything.
+func TestCollectorClusterFluentBitConfigIsRendered(t *testing.T) {
+	s := newConfigTestScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(newCollectorTestObjects()...).Build()
+
+	r := &FluentBitConfigReconciler{Client: cli, Log: logf.Log, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	var sec corev1.Secret
+	key := client.ObjectKey{Namespace: testCollectorNamespace, Name: testConfigName}
+	if err := cli.Get(context.Background(), key, &sec); err != nil {
+		t.Fatalf("expected the rendered configuration Secret %s, got: %v", key, err)
+	}
+
+	mainCfg := string(sec.Data["fluent-bit.conf"])
+	if !strings.Contains(mainCfg, "forward") {
+		t.Fatalf("expected the selected cluster input in the rendered config, got:\n%s", mainCfg)
+	}
+	if !strings.Contains(mainCfg, "stdout") {
+		t.Fatalf("expected the selected cluster output in the rendered config, got:\n%s", mainCfg)
+	}
+	if _, ok := sec.Data["parsers.conf"]; !ok {
+		t.Fatalf("expected parsers.conf in the rendered Secret, got keys %v", secretKeys(sec))
+	}
+
+	owners := sec.GetOwnerReferences()
+	if len(owners) != 1 || owners[0].Kind != "ClusterFluentBitConfig" || owners[0].Name != testConfigName {
+		t.Fatalf("expected the Secret to be owned by the ClusterFluentBitConfig, got %v", owners)
+	}
+}
+
+// TestCollectorConfigRenderedInYamlFormat verifies that spec.configFileFormat is
+// honoured on the Collector code path as well.
+func TestCollectorConfigRenderedInYamlFormat(t *testing.T) {
+	s := newConfigTestScheme(t)
+	objs := newCollectorTestObjects()
+	yamlFormat := configFileFormatYaml
+	objs[0].(*fluentbitv1alpha2.ClusterFluentBitConfig).Spec.ConfigFileFormat = &yamlFormat
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	r := &FluentBitConfigReconciler{Client: cli, Log: logf.Log, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	var sec corev1.Secret
+	key := client.ObjectKey{Namespace: testCollectorNamespace, Name: testConfigName}
+	if err := cli.Get(context.Background(), key, &sec); err != nil {
+		t.Fatalf("expected the rendered configuration Secret %s, got: %v", key, err)
+	}
+	if _, ok := sec.Data["fluent-bit.yaml"]; !ok {
+		t.Fatalf("expected fluent-bit.yaml in the rendered Secret, got keys %v", secretKeys(sec))
+	}
+}
+
+// TestCollectorConfigHonoursConfigNamespaceOverride checks that an explicit
+// spec.namespace on the ClusterFluentBitConfig still wins over the Collector's own
+// namespace, consistently with the FluentBit code path.
+func TestCollectorConfigHonoursConfigNamespaceOverride(t *testing.T) {
+	s := newConfigTestScheme(t)
+	objs := newCollectorTestObjects()
+	pinned := "fluent"
+	objs[0].(*fluentbitv1alpha2.ClusterFluentBitConfig).Spec.Namespace = &pinned
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	r := &FluentBitConfigReconciler{Client: cli, Log: logf.Log, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	var sec corev1.Secret
+	if err := cli.Get(
+		context.Background(), client.ObjectKey{Namespace: pinned, Name: testConfigName}, &sec,
+	); err != nil {
+		t.Fatalf("expected the Secret in the pinned namespace %q, got: %v", pinned, err)
+	}
+
+	err := cli.Get(
+		context.Background(),
+		client.ObjectKey{Namespace: testCollectorNamespace, Name: testConfigName},
+		&corev1.Secret{},
+	)
+	if err == nil {
+		t.Fatalf("did not expect a Secret in the Collector namespace when spec.namespace is pinned")
+	}
+}
+
+// TestCollectorDoesNotOverrideFluentBitConfig makes sure that a Collector sharing a
+// ClusterFluentBitConfig with a FluentBit DaemonSet cannot overwrite the Secret the
+// DaemonSet is already using, which would drop its namespaced (multi-tenant) plugins.
+func TestCollectorDoesNotOverrideFluentBitConfig(t *testing.T) {
+	s := newConfigTestScheme(t)
+	objs := newCollectorTestObjects()
+	// Pin the config so both code paths resolve to the very same namespace.
+	pinned := testCollectorNamespace
+	objs[0].(*fluentbitv1alpha2.ClusterFluentBitConfig).Spec.Namespace = &pinned
+	objs = append(objs, &fluentbitv1alpha2.FluentBit{
+		ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit", Namespace: testCollectorNamespace},
+		Spec: fluentbitv1alpha2.FluentBitSpec{
+			FluentBitConfigName: testConfigName,
+			NamespacedFluentBitCfgSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"never": "matches"},
+			},
+		},
+	})
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	r := &FluentBitConfigReconciler{Client: cli, Log: logf.Log, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	var sec corev1.Secret
+	key := client.ObjectKey{Namespace: testCollectorNamespace, Name: testConfigName}
+	if err := cli.Get(context.Background(), key, &sec); err != nil {
+		t.Fatalf("expected the rendered configuration Secret %s, got: %v", key, err)
+	}
+	if !strings.Contains(string(sec.Data["fluent-bit.conf"]), "forward") {
+		t.Fatalf("expected a rendered config, got:\n%s", sec.Data["fluent-bit.conf"])
+	}
+}
+
+// TestCollectorsForSecret verifies the Secret -> Collector mapping used to wake the
+// Collector controller up as soon as its configuration has been rendered.
+func TestCollectorsForSecret(t *testing.T) {
+	s := newConfigTestScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(
+		&fluentbitv1alpha2.Collector{
+			ObjectMeta: metav1.ObjectMeta{Name: "matching", Namespace: testCollectorNamespace},
+			Spec:       fluentbitv1alpha2.CollectorSpec{FluentBitConfigName: testConfigName},
+		},
+		&fluentbitv1alpha2.Collector{
+			ObjectMeta: metav1.ObjectMeta{Name: "other-config", Namespace: testCollectorNamespace},
+			Spec:       fluentbitv1alpha2.CollectorSpec{FluentBitConfigName: "something-else"},
+		},
+		&fluentbitv1alpha2.Collector{
+			ObjectMeta: metav1.ObjectMeta{Name: "other-namespace", Namespace: "elsewhere"},
+			Spec:       fluentbitv1alpha2.CollectorSpec{FluentBitConfigName: testConfigName},
+		},
+	).Build()
+
+	r := &CollectorReconciler{Client: cli, Log: logf.Log, Scheme: s}
+	reqs := r.collectorsForSecret(context.Background(), &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: testConfigName, Namespace: testCollectorNamespace},
+	})
+
+	if len(reqs) != 1 {
+		t.Fatalf("expected exactly one reconcile request, got %v", reqs)
+	}
+	if reqs[0].Name != "matching" || reqs[0].Namespace != testCollectorNamespace {
+		t.Fatalf("unexpected reconcile request: %v", reqs[0])
+	}
+}
+
+func secretKeys(sec corev1.Secret) []string {
+	keys := make([]string, 0, len(sec.Data))
+	for k := range sec.Data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// TestFluentBitNamespacedConfigStillRendered guards the refactoring that introduced
+// the Collector code path: the FluentBit DaemonSet path must keep rendering cluster
+// scoped plugins, namespace level plugins and the generated rewrite_tag filters into
+// the operator namespace.
+func TestFluentBitNamespacedConfigStillRendered(t *testing.T) {
+	t.Setenv("NAMESPACE", "fluent")
+	s := newConfigTestScheme(t)
+	selector := metav1.LabelSelector{MatchLabels: map[string]string{"fluentbit.fluent.io/enabled": "true"}}
+
+	objs := []client.Object{
+		&fluentbitv1alpha2.ClusterFluentBitConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: testConfigName},
+			Spec: fluentbitv1alpha2.FluentBitConfigSpec{
+				InputSelector:  selector,
+				FilterSelector: selector,
+				OutputSelector: selector,
+			},
+		},
+		&fluentbitv1alpha2.ClusterInput{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "tail",
+				Labels: map[string]string{"fluentbit.fluent.io/enabled": "true"},
+			},
+			Spec: fluentbitv1alpha2.InputSpec{
+				Tail: &input.Tail{Tag: "kube.*", Path: "/var/log/containers/*.log"},
+			},
+		},
+		&fluentbitv1alpha2.FluentBit{
+			ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit", Namespace: "fluent"},
+			Spec: fluentbitv1alpha2.FluentBitSpec{
+				FluentBitConfigName:            testConfigName,
+				NamespacedFluentBitCfgSelector: selector,
+			},
+		},
+		&fluentbitv1alpha2.FluentBitConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tenant",
+				Namespace: "tenant-a",
+				Labels:    map[string]string{"fluentbit.fluent.io/enabled": "true"},
+			},
+			Spec: fluentbitv1alpha2.NamespacedFluentBitCfgSpec{OutputSelector: selector},
+		},
+		&fluentbitv1alpha2.Output{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "tenant-stdout",
+				Namespace: "tenant-a",
+				Labels:    map[string]string{"fluentbit.fluent.io/enabled": "true"},
+			},
+			Spec: fluentbitv1alpha2.OutputSpec{Match: "*", Stdout: &output.Stdout{}},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	r := &FluentBitConfigReconciler{Client: cli, Log: logf.Log, Scheme: s}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	var sec corev1.Secret
+	if err := cli.Get(
+		context.Background(), client.ObjectKey{Namespace: "fluent", Name: testConfigName}, &sec,
+	); err != nil {
+		t.Fatalf("expected the rendered configuration Secret fluent/%s, got: %v", testConfigName, err)
+	}
+
+	mainCfg := string(sec.Data["fluent-bit.conf"])
+	t.Logf("rendered fluent-bit.conf:\n%s", mainCfg)
+	for _, want := range []string{"tail", "rewrite_tag", "stdout"} {
+		if !strings.Contains(mainCfg, want) {
+			t.Fatalf("expected %q in the rendered config, got:\n%s", want, mainCfg)
+		}
+	}
+}

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -29,9 +29,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2"
@@ -50,6 +52,25 @@ type CollectorReconciler struct {
 // controller up as soon as the configuration is rendered, this is only a
 // safety net against missed events.
 const collectorSecretRequeueInterval = 30 * time.Second
+
+// fluentBitConfigHashAnnotation is stamped by FluentBitConfigReconciler onto
+// every config Secret it renders. It identifies a Secret as belonging to the
+// Fluent Bit config pipeline.
+const fluentBitConfigHashAnnotation = "fluent.io/config-hash"
+
+// isFluentBitConfigSecret reports whether a Secret was rendered by
+// FluentBitConfigReconciler, which stamps every config Secret it writes with the
+// fluent.io/config-hash annotation. Used to keep unrelated Secret events out of
+// the Collector watch: without it collectorsForSecret runs for every Secret in
+// the cluster, allocating a CollectorList each time only to discard it.
+//
+// A Secret written before that annotation existed is filtered out here, but
+// FluentBitConfigReconciler treats a missing annotation as a change and rewrites
+// the Secret, so the subsequent event carries the annotation and passes.
+func isFluentBitConfigSecret(obj client.Object) bool {
+	_, ok := obj.GetAnnotations()[fluentBitConfigHashAnnotation]
+	return ok
+}
 
 // collectorsForSecret maps a Secret to the Collectors consuming it, so that the
 // configuration rendered by the FluentBitConfig controller is picked up
@@ -325,6 +346,7 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
-		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.collectorsForSecret)).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.collectorsForSecret),
+			builder.WithPredicates(predicate.NewPredicateFuncs(isFluentBitConfigSecret))).
 		Complete(r)
 }

--- a/controllers/collector_controller.go
+++ b/controllers/collector_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,6 +31,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	fluentbitv1alpha2 "github.com/fluent/fluent-operator/v3/apis/fluentbit/v1alpha2"
 	"github.com/fluent/fluent-operator/v3/pkg/operator"
@@ -42,6 +45,32 @@ type CollectorReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+// collectorSecretRequeueInterval is how long to wait before re-checking for the
+// configuration Secret of a Collector. A Secret watch normally wakes the
+// controller up as soon as the configuration is rendered, this is only a
+// safety net against missed events.
+const collectorSecretRequeueInterval = 30 * time.Second
+
+// collectorsForSecret maps a Secret to the Collectors consuming it, so that the
+// configuration rendered by the FluentBitConfig controller is picked up
+// immediately.
+func (r *CollectorReconciler) collectorsForSecret(ctx context.Context, obj client.Object) []reconcile.Request {
+	var collectors fluentbitv1alpha2.CollectorList
+	if err := r.List(ctx, &collectors, client.InNamespace(obj.GetNamespace())); err != nil {
+		r.Log.Error(err, "failed to list collectors for secret", "secret", client.ObjectKeyFromObject(obj))
+		return nil
+	}
+
+	reqs := make([]reconcile.Request, 0, len(collectors.Items))
+	for _, co := range collectors.Items {
+		if co.Spec.FluentBitConfigName != obj.GetName() {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&co)})
+	}
+	return reqs
+}
+
 // +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=collectors,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=collectors/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;patch;delete
@@ -50,6 +79,7 @@ type CollectorReconciler struct {
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;list;watch;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -61,7 +91,7 @@ type CollectorReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = r.Log.WithValues("collector", req.NamespacedName)
+	logger := r.Log.WithValues("collector", req.NamespacedName)
 
 	var co fluentbitv1alpha2.Collector
 	if err := r.Get(ctx, req.NamespacedName, &co); err != nil {
@@ -90,7 +120,16 @@ func (r *CollectorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	objKey := client.ObjectKey{Namespace: co.Namespace, Name: co.Spec.FluentBitConfigName}
 	if err := r.Get(ctx, objKey, &sec); err != nil {
 		if errors.IsNotFound(err) {
-			return ctrl.Result{Requeue: true}, nil
+			// The FluentBitConfig controller renders the ClusterFluentBitConfig
+			// referenced by spec.fluentBitConfigName into this Secret. Until it shows
+			// up there is nothing to mount, so report why and try again later instead
+			// of failing silently.
+			logger.Info(
+				"Waiting for the Fluent Bit configuration secret to be created, "+
+					"check that spec.fluentBitConfigName refers to an existing ClusterFluentBitConfig",
+				"secret", objKey.Name, "namespace", objKey.Namespace,
+			)
+			return ctrl.Result{RequeueAfter: collectorSecretRequeueInterval}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -286,5 +325,6 @@ func (r *CollectorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.collectorsForSecret)).
 		Complete(r)
 }

--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -112,7 +112,7 @@ func (r *FluentBitConfigReconciler) updateSecretIfNeeded(
 			return err
 		}
 	} else {
-		existingHash, ok := existingSecret.Annotations["fluent.io/config-hash"]
+		existingHash, ok := existingSecret.Annotations[fluentBitConfigHashAnnotation]
 		if !ok || existingHash != newConfigHash {
 			needsUpdate = true
 		}
@@ -124,7 +124,7 @@ func (r *FluentBitConfigReconciler) updateSecretIfNeeded(
 				if sec.Annotations == nil {
 					sec.Annotations = make(map[string]string)
 				}
-				sec.Annotations["fluent.io/config-hash"] = newConfigHash
+				sec.Annotations[fluentBitConfigHashAnnotation] = newConfigHash
 
 				sec.Data = map[string][]byte{
 					configFileName:           []byte(mainAppCfg),

--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -169,6 +169,7 @@ func (r *FluentBitConfigReconciler) updateSecretIfNeeded(
 
 // +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=clusterfluentbitconfigs,verbs=list;watch
 // +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=fluentbitconfigs,verbs=list;watch
+// +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=collectors,verbs=list;watch
 // +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=clusterinputs;clusterfilters;clusteroutputs;clusterparsers;clustermultilineparsers,verbs=list;watch
 // +kubebuilder:rbac:groups=fluentbit.fluent.io,resources=filters;outputs;parsers;multilineparsers,verbs=list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get
@@ -190,63 +191,65 @@ func (r *FluentBitConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// we will repopulate namespaces that have a FluentBitConfig CR
 	storeNamespaces = make(map[string]bool)
 
-	var fbs fluentbitv1alpha2.FluentBitList
-	if err := r.List(ctx, &fbs); err != nil {
+	var cfgs fluentbitv1alpha2.ClusterFluentBitConfigList
+	if err := r.List(ctx, &cfgs); err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
 
-	for _, fb := range fbs.Items {
-		var cfgs fluentbitv1alpha2.ClusterFluentBitConfigList
-		if err := r.List(ctx, &cfgs); err != nil {
-			if errors.IsNotFound(err) {
-				return ctrl.Result{}, nil
-			}
-			return ctrl.Result{}, err
-		}
+	// Secrets rendered during this loop, keyed by "<namespace>/<name>". A
+	// ClusterFluentBitConfig referenced by a FluentBit always wins, so that
+	// adding a Collector can never change the configuration a DaemonSet is
+	// already using.
+	rendered := make(map[string]bool)
 
+	if err := r.reconcileFluentBits(ctx, cfgs, rendered); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileCollectors(ctx, cfgs, rendered); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// reconcileFluentBits renders the ClusterFluentBitConfigs referenced by the FluentBit
+// DaemonSets, including the namespace level (multi-tenant) plugins they select.
+func (r *FluentBitConfigReconciler) reconcileFluentBits(
+	ctx context.Context, cfgs fluentbitv1alpha2.ClusterFluentBitConfigList, rendered map[string]bool,
+) error {
+	var fbs fluentbitv1alpha2.FluentBitList
+	if err := r.List(ctx, &fbs); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, fb := range fbs.Items {
 		for _, cfg := range cfgs.Items {
 			// List all inputs matching the label selector.
 			if cfg.Name != fb.Spec.FluentBitConfigName {
 				continue
 			}
 
-			var inputs fluentbitv1alpha2.ClusterInputList
-			if err := listClusterResources(ctx, r.Client, &cfg.Spec.InputSelector, &inputs); err != nil {
-				return ctrl.Result{}, err
-			}
-
-			var filters fluentbitv1alpha2.ClusterFilterList
-			if err := listClusterResources(ctx, r.Client, &cfg.Spec.FilterSelector, &filters); err != nil {
-				return ctrl.Result{}, err
-			}
-
-			var outputs fluentbitv1alpha2.ClusterOutputList
-			if err := listClusterResources(ctx, r.Client, &cfg.Spec.OutputSelector, &outputs); err != nil {
-				return ctrl.Result{}, err
-			}
-
-			var parsers fluentbitv1alpha2.ClusterParserList
-			if err := listClusterResources(ctx, r.Client, &cfg.Spec.ParserSelector, &parsers); err != nil {
-				return ctrl.Result{}, err
-			}
-
-			var multilineParsers fluentbitv1alpha2.ClusterMultilineParserList
-			if err := listClusterResources(ctx, r.Client, &cfg.Spec.MultilineParserSelector, &multilineParsers); err != nil {
-				return ctrl.Result{}, err
+			clusterPlugins, err := r.listClusterPlugins(ctx, &cfg)
+			if err != nil {
+				return err
 			}
 
 			// List all the namespace level resources if they exist and generate configs to mutate tags
 			nsFilterLists, nsOutputLists, nsParserLists,
 				nsClusterParserLists, nsMultilineParserLists, nsClusterMultilineParserLists,
 				rewriteTagConfigs, err := r.processNamespacedFluentBitCfgs(
-				ctx, fb, inputs, cfg.Spec.ConfigFileFormat,
+				ctx, fb, clusterPlugins.inputs, cfg.Spec.ConfigFileFormat,
 			)
 
 			if err != nil {
-				return ctrl.Result{}, err
+				return err
 			}
 
 			var ns string
@@ -255,55 +258,190 @@ func (r *FluentBitConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			} else {
 				ns = os.Getenv("NAMESPACE")
 			}
-			cl := plugins.NewConfigMapLoader(r.Client, ns)
-			// load scripts for namespaced filters
-			nsScripts, err := cfg.RenderNamespacedLuaScript(cl, nsFilterLists)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			// load scripts for cluster filters
-			scripts, err := cfg.RenderLuaScript(cl, filters, ns)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			scripts = append(scripts, nsScripts...)
 
-			// Inject config data into Secret
-			sl := plugins.NewSecretLoader(r.Client, ns)
-			mainAppCfg, err := cfg.RenderMainConfigWithTargetFormat(
-				sl, inputs, filters, outputs, nsFilterLists, nsOutputLists, rewriteTagConfigs, cfg.Spec.ConfigFileFormat,
-			)
-			if err != nil {
-				return ctrl.Result{}, err
+			if err := r.renderAndStoreConfig(ctx, &cfg, ns, clusterPlugins, namespacedPlugins{
+				filters:                 nsFilterLists,
+				outputs:                 nsOutputLists,
+				parsers:                 nsParserLists,
+				clusterParsers:          nsClusterParserLists,
+				multilineParsers:        nsMultilineParserLists,
+				clusterMultilineParsers: nsClusterMultilineParserLists,
+				rewriteTagConfigs:       rewriteTagConfigs,
+			}); err != nil {
+				return err
 			}
-			parserCfg, err := cfg.RenderParserConfig(sl, parsers, nsParserLists, nsClusterParserLists)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			multilineParserCfg, err := cfg.RenderMultilineParserConfig(
-				sl, multilineParsers, nsMultilineParserLists, nsClusterMultilineParserLists,
-			)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-
-			configFileName := "fluent-bit.conf"
-			if cfg.Spec.ConfigFileFormat != nil && *cfg.Spec.ConfigFileFormat == configFileFormatYaml {
-				configFileName = "fluent-bit.yaml"
-			}
-
-			if err := r.updateSecretIfNeeded(
-				ctx, cfg.Name, ns, configFileName, mainAppCfg, parserCfg, multilineParserCfg, scripts,
-				func(sec *corev1.Secret) error {
-					return ctrl.SetControllerReference(&cfg, sec, r.Scheme)
-				},
-			); err != nil {
-				return ctrl.Result{}, err
-			}
+			rendered[fmt.Sprintf("%s/%s", ns, cfg.Name)] = true
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return nil
+}
+
+// reconcileCollectors renders the ClusterFluentBitConfigs referenced by the Collector
+// StatefulSets. The Collector controller blocks until a Secret named after
+// spec.fluentBitConfigName shows up in the Collector's own namespace, so without this
+// nothing is ever created for a Collector, see
+// https://github.com/fluent/fluent-operator/issues/1436.
+//
+// Collectors have no namespaced FluentBitConfig selector, hence only cluster scoped
+// plugins are rendered for them.
+func (r *FluentBitConfigReconciler) reconcileCollectors(
+	ctx context.Context, cfgs fluentbitv1alpha2.ClusterFluentBitConfigList, rendered map[string]bool,
+) error {
+	var collectors fluentbitv1alpha2.CollectorList
+	if err := r.List(ctx, &collectors); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	for _, co := range collectors.Items {
+		for _, cfg := range cfgs.Items {
+			if cfg.Name != co.Spec.FluentBitConfigName {
+				continue
+			}
+
+			// The Collector expects its configuration next to itself. An explicit
+			// spec.namespace on the ClusterFluentBitConfig still wins, to stay
+			// consistent with the FluentBit code path.
+			ns := co.Namespace
+			if cfg.Spec.Namespace != nil {
+				ns = fmt.Sprint(*cfg.Spec.Namespace)
+				if ns != co.Namespace {
+					r.Log.Info(
+						"ClusterFluentBitConfig pins its Secret to a namespace other than the Collector's, "+
+							"the Collector will keep waiting for its configuration",
+						"clusterfluentbitconfig", cfg.Name, "logging-control-plane", ns,
+						"collector", co.Name, "collector-namespace", co.Namespace,
+					)
+				}
+			}
+
+			if rendered[fmt.Sprintf("%s/%s", ns, cfg.Name)] {
+				r.Log.V(1).Info(
+					"Fluent Bit configuration already rendered in this reconcile, skipping",
+					"logging-control-plane", ns, "fluentbitconfig", cfg.Name, "collector", co.Name,
+				)
+				continue
+			}
+
+			clusterPlugins, err := r.listClusterPlugins(ctx, &cfg)
+			if err != nil {
+				return err
+			}
+
+			if err := r.renderAndStoreConfig(ctx, &cfg, ns, clusterPlugins, namespacedPlugins{}); err != nil {
+				return err
+			}
+			rendered[fmt.Sprintf("%s/%s", ns, cfg.Name)] = true
+		}
+	}
+
+	return nil
+}
+
+// clusterPlugins holds the cluster scoped plugins selected by a ClusterFluentBitConfig.
+type clusterPlugins struct {
+	inputs           fluentbitv1alpha2.ClusterInputList
+	filters          fluentbitv1alpha2.ClusterFilterList
+	outputs          fluentbitv1alpha2.ClusterOutputList
+	parsers          fluentbitv1alpha2.ClusterParserList
+	multilineParsers fluentbitv1alpha2.ClusterMultilineParserList
+}
+
+// namespacedPlugins holds the namespace level (multi-tenant) plugins that are merged
+// into the rendered configuration together with the cluster scoped ones. It is empty
+// for Collectors.
+type namespacedPlugins struct {
+	filters                 []fluentbitv1alpha2.FilterList
+	outputs                 []fluentbitv1alpha2.OutputList
+	parsers                 []fluentbitv1alpha2.ParserList
+	clusterParsers          []fluentbitv1alpha2.ClusterParserList
+	multilineParsers        []fluentbitv1alpha2.MultilineParserList
+	clusterMultilineParsers []fluentbitv1alpha2.ClusterMultilineParserList
+	rewriteTagConfigs       []string
+}
+
+// listClusterPlugins lists every cluster scoped plugin matching the label selectors of
+// the given ClusterFluentBitConfig.
+func (r *FluentBitConfigReconciler) listClusterPlugins(
+	ctx context.Context, cfg *fluentbitv1alpha2.ClusterFluentBitConfig,
+) (clusterPlugins, error) {
+	var cp clusterPlugins
+
+	if err := listClusterResources(ctx, r.Client, &cfg.Spec.InputSelector, &cp.inputs); err != nil {
+		return cp, err
+	}
+	if err := listClusterResources(ctx, r.Client, &cfg.Spec.FilterSelector, &cp.filters); err != nil {
+		return cp, err
+	}
+	if err := listClusterResources(ctx, r.Client, &cfg.Spec.OutputSelector, &cp.outputs); err != nil {
+		return cp, err
+	}
+	if err := listClusterResources(ctx, r.Client, &cfg.Spec.ParserSelector, &cp.parsers); err != nil {
+		return cp, err
+	}
+	if err := listClusterResources(
+		ctx, r.Client, &cfg.Spec.MultilineParserSelector, &cp.multilineParsers,
+	); err != nil {
+		return cp, err
+	}
+
+	return cp, nil
+}
+
+// renderAndStoreConfig renders the main, parser and multiline parser configurations
+// plus the Lua scripts, and stores them in a Secret named after the
+// ClusterFluentBitConfig in the given namespace.
+func (r *FluentBitConfigReconciler) renderAndStoreConfig(
+	ctx context.Context, cfg *fluentbitv1alpha2.ClusterFluentBitConfig, ns string,
+	cluster clusterPlugins, namespaced namespacedPlugins,
+) error {
+	cl := plugins.NewConfigMapLoader(r.Client, ns)
+	// load scripts for namespaced filters
+	nsScripts, err := cfg.RenderNamespacedLuaScript(cl, namespaced.filters)
+	if err != nil {
+		return err
+	}
+	// load scripts for cluster filters
+	scripts, err := cfg.RenderLuaScript(cl, cluster.filters, ns)
+	if err != nil {
+		return err
+	}
+	scripts = append(scripts, nsScripts...)
+
+	// Inject config data into Secret
+	sl := plugins.NewSecretLoader(r.Client, ns)
+	mainAppCfg, err := cfg.RenderMainConfigWithTargetFormat(
+		sl, cluster.inputs, cluster.filters, cluster.outputs, namespaced.filters, namespaced.outputs,
+		namespaced.rewriteTagConfigs, cfg.Spec.ConfigFileFormat,
+	)
+	if err != nil {
+		return err
+	}
+	parserCfg, err := cfg.RenderParserConfig(sl, cluster.parsers, namespaced.parsers, namespaced.clusterParsers)
+	if err != nil {
+		return err
+	}
+	multilineParserCfg, err := cfg.RenderMultilineParserConfig(
+		sl, cluster.multilineParsers, namespaced.multilineParsers, namespaced.clusterMultilineParsers,
+	)
+	if err != nil {
+		return err
+	}
+
+	configFileName := "fluent-bit.conf"
+	if cfg.Spec.ConfigFileFormat != nil && *cfg.Spec.ConfigFileFormat == configFileFormatYaml {
+		configFileName = "fluent-bit.yaml"
+	}
+
+	return r.updateSecretIfNeeded(
+		ctx, cfg.Name, ns, configFileName, mainAppCfg, parserCfg, multilineParserCfg, scripts,
+		func(sec *corev1.Secret) error {
+			return ctrl.SetControllerReference(cfg, sec, r.Scheme)
+		},
+	)
 }
 
 func (r *FluentBitConfigReconciler) processNamespacedFluentBitCfgs(
@@ -556,6 +694,7 @@ func (r *FluentBitConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Watches(&fluentbitv1alpha2.ClusterFluentBitConfig{}, &handler.EnqueueRequestForObject{}).
 		Watches(&fluentbitv1alpha2.FluentBitConfig{}, &handler.EnqueueRequestForObject{}).
+		Watches(&fluentbitv1alpha2.Collector{}, &handler.EnqueueRequestForObject{}).
 		Watches(&fluentbitv1alpha2.ClusterInput{}, &handler.EnqueueRequestForObject{}).
 		Watches(&fluentbitv1alpha2.ClusterFilter{}, &handler.EnqueueRequestForObject{}).
 		Watches(&fluentbitv1alpha2.ClusterOutput{}, &handler.EnqueueRequestForObject{}).


### PR DESCRIPTION
Fixes #1436

## Problem

Create a `Collector` referencing a `ClusterFluentBitConfig` via `spec.fluentBitConfigName` and the operator creates **nothing** — no StatefulSet, Service, ServiceAccount or Secret — and logs **no error**. `.status` stays `{}`.

Two interacting sites cause it:

**`collector_controller.go`** requires a Secret named `spec.fluentBitConfigName` and silently requeues when it is absent:

```go
if err := r.Get(ctx, objKey, &sec); err != nil {
    if errors.IsNotFound(err) {
        return ctrl.Result{Requeue: true}, nil   // no log, no event, no status
    }
```

**`fluentbitconfig_controller.go`** is the only thing that renders that Secret, and it only iterates `FluentBitList`:

```go
for _, fb := range fbs.Items {
    for _, cfg := range cfgs.Items {
        if cfg.Name != fb.Spec.FluentBitConfigName {
            continue    // a Collector-referenced config dies here
        }
```

`grep -c CollectorList controllers/*.go` returns 0 on both `v3.9.0` and `master`, so no released version can render configuration for a Collector.

## Fix

`Reconcile` now lists `ClusterFluentBitConfigList` once (previously re-listed per FluentBit) and drives two paths:

- `reconcileFluentBits` — existing behaviour, unchanged
- `reconcileCollectors` — renders configs referenced by `Collector` CRs into the **Collector's namespace**, which is where `collector_controller.go` looks

Rendering is shared, not duplicated (`listClusterPlugins` + `renderAndStoreConfig`). Adds `Watches(&Collector{})` so creating a Collector triggers a reconcile, plus the matching RBAC marker (`make manifests generate` produced no diff).

Also replaces the silent requeue in `collector_controller.go` with a logged, bounded one and a Secret watch — that silence is what made this hard to diagnose.

## Precedence and edge cases

- **FluentBit wins** if a FluentBit and a Collector reference the same config. Otherwise the Collector (which has no `NamespacedFluentBitCfgSelector`) would strip the DaemonSet's multi-tenant filters and the two loops would fight, flipping the config hash. Covered by a test.
- Two Collectors, one config: rendered once per namespace. No conflict.
- `cfg.Spec.Namespace` is honoured for consistency with the FluentBit path, but if it pins a namespace other than the Collector's the Collector still waits — that case now logs a warning. **A maintainer may prefer the Collector namespace to always win; happy to change it.**
- Collectors get cluster-scoped plugins only, since `CollectorSpec` has no `NamespacedFluentBitCfgSelector`. Existing CRD limitation, not introduced here.

## Testing

Six new tests in `controllers/collector_config_test.go`. Reverting only `fluentbitconfig_controller.go` to master reproduces the bug:

```
--- FAIL: TestCollectorClusterFluentBitConfigIsRendered
    expected the rendered configuration Secret logging/collector-config,
    got: secrets "collector-config" not found
```

`TestFluentBitNamespacedConfigStillRendered` guards the refactor: the rendered `fluent-bit.conf` (tail input, generated `rewrite_tag`, namespaced tenant output) is byte-identical before and after.

```
go build ./...   OK      make lint   0 issues
go vet ./...     OK      make test   ok  .../controllers
go test ./...    no change in pass/fail set vs master
```

The only failure, on master and this branch alike, is `tests/e2e/fluentd`, which needs a live cluster and is excluded from `make test`.

### Verified on real clusters

**minikube**, same manifests, only the operator image swapped:

| | stock `3.9.0` | patched |
|---|---|---|
| config Secret | missing | created |
| StatefulSet | none | 2/2 |
| PVCs | none | bound |

Config stays operator-managed: adding a `ClusterFilter` afterwards re-rendered the Secret (`config-hash` changed) and the running pods picked it up with **zero restarts**.

**A 27-node cluster**, 3-replica Collector: the config Secret rendered (impossible on stock 3.9.0), the StatefulSet reached 3/3 with three PVCs bound, and it has been ingesting steadily since.

One deployment note for users, not a code issue: the operator creates the Collector's ClusterRole, so `spec.rbacRules` must be a **subset of what the operator's ServiceAccount already holds** — otherwise Kubernetes privilege-escalation prevention rejects it (`attempting to grant RBAC permissions not currently held`) and the StatefulSet is never created.
