### PR TITLE
feat: set Alias on auto-generated namespace-routing rewrite_tag filters

### DIFF
--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -628,11 +628,13 @@ func (r *FluentBitConfigReconciler) generateRewriteTagConfig(
 	}
 
 	rewriteTag := &filter.RewriteTag{
+		CommonParams: plugins.CommonParams{
+			Alias: fmt.Sprintf("namespace-routing-%s", cfg.Namespace),
+		},
 		Rules: []string{
 			fmt.Sprintf("$kubernetes['namespace_name'] ^(%s)$ %x.$TAG false", cfg.Namespace, md5.Sum([]byte(cfg.Namespace))),
 		},
 	}
-	rewriteTag.Alias = fmt.Sprintf("namespace-routing-%s", cfg.Namespace)
 	if cfg.Spec.Service != nil {
 		if cfg.Spec.Service.EmitterName != "" {
 			rewriteTag.EmitterName = cfg.Spec.Service.EmitterName

--- a/controllers/fluentbitconfig_controller.go
+++ b/controllers/fluentbitconfig_controller.go
@@ -632,6 +632,7 @@ func (r *FluentBitConfigReconciler) generateRewriteTagConfig(
 			fmt.Sprintf("$kubernetes['namespace_name'] ^(%s)$ %x.$TAG false", cfg.Namespace, md5.Sum([]byte(cfg.Namespace))),
 		},
 	}
+	rewriteTag.Alias = fmt.Sprintf("namespace-routing-%s", cfg.Namespace)
 	if cfg.Spec.Service != nil {
 		if cfg.Spec.Service.EmitterName != "" {
 			rewriteTag.EmitterName = cfg.Spec.Service.EmitterName

--- a/controllers/fluentbitconfig_controller_test.go
+++ b/controllers/fluentbitconfig_controller_test.go
@@ -94,3 +94,44 @@ func TestGenerateRewriteTagConfigYaml(t *testing.T) {
 		t.Fatalf("expected classic TOML output, got:\n%s", classicOut)
 	}
 }
+
+// TestGenerateRewriteTagConfigAlias verifies that the auto-generated rewrite_tag
+// filter includes a meaningful Alias derived from the FluentBitConfig namespace,
+// in both classic and YAML output formats.
+func TestGenerateRewriteTagConfigAlias(t *testing.T) {
+	r := &FluentBitConfigReconciler{}
+	cfg := fluentbitv1alpha2.FluentBitConfig{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "my-app"},
+	}
+	inputs := fluentbitv1alpha2.ClusterInputList{
+		Items: []fluentbitv1alpha2.ClusterInput{
+			{
+				Spec: fluentbitv1alpha2.InputSpec{
+					Tail: &input.Tail{
+						Tag:  "kube.*",
+						Path: "/var/log/containers/*.log",
+					},
+				},
+			},
+		},
+	}
+
+	// Classic (INI) format must contain the alias.
+	classicOut, err := r.generateRewriteTagConfig(cfg, inputs, nil)
+	if err != nil {
+		t.Fatalf("generateRewriteTagConfig (classic) returned error: %v", err)
+	}
+	if !strings.Contains(classicOut, "Alias    namespace-routing-my-app") {
+		t.Fatalf("expected Alias in classic output, got:\n%s", classicOut)
+	}
+
+	// YAML format must contain the alias.
+	yamlFormat := configFileFormatYaml
+	yamlOut, err := r.generateRewriteTagConfig(cfg, inputs, &yamlFormat)
+	if err != nil {
+		t.Fatalf("generateRewriteTagConfig (yaml) returned error: %v", err)
+	}
+	if !strings.Contains(yamlOut, "alias: namespace-routing-my-app") {
+		t.Fatalf("expected alias in YAML output, got:\n%s", yamlOut)
+	}
+}

--- a/controllers/fluentbitconfig_controller_test.go
+++ b/controllers/fluentbitconfig_controller_test.go
@@ -85,6 +85,10 @@ func TestGenerateRewriteTagConfigYaml(t *testing.T) {
 		t.Fatalf("expected a rewrite_tag filter entry, got:\n%s", out)
 	}
 
+	if !strings.Contains(out, "alias: namespace-routing-foobar") {
+		t.Fatalf("expected alias for namespace foobar, got:\n%s", out)
+	}
+
 	// classic (default) format must remain unchanged (TOML).
 	classicOut, err := r.generateRewriteTagConfig(cfg, inputs, nil)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it:

Auto-generated namespace-routing `rewrite_tag` filters (created by `generateRewriteTagConfig`) produce metrics with opaque names like `rewrite_tag.0`, `rewrite_tag.1`. This makes it impossible to correlate filter pipeline metrics (`fluentbit_filter_records`, `fluentbit_filter_emit_records`) back to the namespace they route for.

This PR sets `Alias` on each auto-generated `rewrite_tag` filter using the pattern `namespace-routing-<namespace>`, so filter metrics become identifiable (e.g. `namespace-routing-kube-system` instead of `rewrite_tag.3`).

FluentBit core already uses `Alias` as the `name` label in Prometheus metrics (fluent/fluent-bit#4694). CRD-defined filters already support `Alias` (#356, #370). After #2019 refactored `generateRewriteTagConfig` to use a `filter.RewriteTag` struct, `CommonParams.AddCommonParams()` handles emission, so this is a one-field addition.

Alias uniqueness is guaranteed because Kubernetes namespace names are unique per cluster, so `namespace-routing-<ns>` cannot collide (fluent/fluent-bit#6076 does not apply).

### Which issue(s) this PR fixes:

Fixes #2051

### Does this PR introduced a user-facing change?

```release-note
Auto-generated namespace-routing rewrite_tag filters now set Alias to `namespace-routing-<namespace>`, making filter metrics identifiable by namespace.
```

### Additional documentation, usage docs, etc.:

```docs
None
```